### PR TITLE
docs: add comprehensive documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# GitHub Copilot Instructions — Eventyay Interpretation Portal
+
+Canonical project policy is in [`../agents.md`](../agents.md). Read that first.
+
+## Copilot-Specific Defaults
+
+- Match the existing code style in the file you are editing.
+- For Python: follow the patterns in `app.py` and `portal/`. Keep `from __future__ import annotations` at the top of every Python file.
+- For JavaScript/Vue: follow the Composition API patterns in `src/composables/` and `src/services/`. No Options API, no jQuery, no inline scripts.
+- Prefer minimal, local edits. Do not refactor code that is not directly related to the current task.
+- If you are unsure whether a change is safe, leave a comment rather than guessing.
+
+## What this repo is
+
+A browser-first interpretation booth console for Eventyay live events. Interpreters monitor the floor session via a Jitsi iframe and broadcast their audio via WebRTC → aiortc ingest → FFmpeg HLS.
+
+**Current phase:** Interpreter Console MVP — mic tests, preflight checklist, ingest wiring. The ingest server infrastructure is a future phase.
+
+## Non-negotiable rules
+
+1. No OBS/RTMP/external encoder requirements.
+2. Jitsi is monitoring only — not the ingest transport.
+3. Exactly one active interpreter publishes per language channel.
+4. Never route interpreter mic audio to `AudioContext.destination`.
+5. No jQuery, no inline `<script>` blocks.
+6. Do not change `uv.lock` unless you run `uv sync --python 3.13 --dev` and all tests pass.
+
+Do not duplicate or override project rules in this file. Use `agents.md` as the single source of truth.

--- a/README.md
+++ b/README.md
@@ -1,103 +1,201 @@
 # Eventyay Interpretation Portal
 
-Eventyay Interpretation Portal is a lightweight collaborative interpretation booth for multilingual live events.
+The Eventyay Interpretation Portal is a browser-based, interpreter-centric console that lets human interpreters broadcast simultaneous interpretation at live events — no OBS, no hardware encoder, no RTMP knowledge required.
 
-It is designed to feel like an Eventyay-first subsystem, not a standalone demo:
+It is built as an Eventyay-native subsystem. The portal feeds the Eventyay viewer playback surface with language-specific audio; it does not replace it.
 
-- **Jitsi** for monitoring and booth coordination
-- **WebRTC** for interpreter microphone ingest
-- **FFmpeg + HLS** for scalable viewer delivery
-- **Collaborative booth controls** for coordinators, active interpreters, and standby interpreters
+---
 
-The development environment is managed with `uv` and pinned to a working Python/media stack for Apple Silicon. See [`docs/development.md`](./docs/development.md) for the full bootstrap and troubleshooting guide.
+## What this repository is
 
-## System goals
+This repository contains:
 
-1. Run the interpreter workflow in one browser tab (no OBS/RTMP/external encoder).
-2. Keep monitoring and ingest separated (Jitsi is not the ingest transport).
-3. Enforce one active publisher per language channel.
-4. Support collaborative booth operations (participant state, handoff, internal chat).
-5. Stay visually and structurally aligned with Eventyay video UI patterns.
+- **The interpreter console** — a single-tab Vue 3 application where an interpreter monitors the floor session (via an embedded Jitsi frame) and broadcasts their spoken translation (via browser WebRTC mic capture → ingest API).
+- **The booth coordination layer** — a Flask + Socket.IO server that tracks participant roles (active interpreter, backup, coordinator, listener), enforces single-publisher-per-channel rules, handles handoffs, and runs internal booth chat.
+- **The ingest bridge** — an `aiortc`-powered endpoint that accepts WebRTC SDP offers from the interpreter's browser, terminates the audio connection server-side, and hands audio to FFmpeg for HLS segmentation.
 
-## Architecture summary
+The viewer-side playback (YouTube video clock + drift-corrected HLS audio) lives in the upstream Eventyay video module and is not part of this repository.
 
-- **Interpreter monitor path:** Jitsi iframe, receive-focused by default.
-- **Interpreter ingest path:** browser mic `getUserMedia` -> `RTCPeerConnection` offer/answer -> ingest endpoint.
-- **Distribution path:** ingest server -> FFmpeg transcode/segment -> HLS playlist -> viewer player.
-- **Coordination path:** Flask-SocketIO booth participant state and internal chat.
+---
 
-See [`ARCHITECTURE.md`](./ARCHITECTURE.md) for full diagrams and flow details.
+## What interpreter booths are
 
-## Interpreter workflow
+An **interpreter booth** is the virtual equivalent of a soundproofed glass booth at a UN-style conference. Each booth is scoped to one language channel (e.g., `hall-a-fr` for French interpretation of hall A).
 
-1. Join monitor room from a Jitsi URL.
-2. Join the booth as interpreter, coordinator, or listener.
-3. Confirm active/standby ownership in the participant list.
-4. Become active interpreter or receive coordinator assignment.
-5. Start interpretation stream to the ingest endpoint.
-6. Use booth chat and pass relay during handoff.
+Inside a booth:
 
-## Coordinator workflow
+| Role | What they do |
+|---|---|
+| **Active Interpreter** | The only person currently broadcasting live audio to viewers. |
+| **Backup Interpreter** | Ready to take over; can request or receive a handoff. |
+| **Coordinator** | Supervises the booth, can reassign the active role at any time. |
+| **Listener** | Observes the booth; no publishing rights. |
 
-1. Monitor participant states and speaking activity.
-2. Switch active interpreter when handoff is required.
-3. Use booth chat for terminology/rotation/technical coordination.
-4. Confirm only one live publisher per channel.
+The organizer generates a private, tokenized URL per language per session and shares it with the booth team. The interpreter opens the URL, goes through a preflight checklist (headset check, mic test, level meter), and clicks **Go Live** when ready. No other configuration is needed.
 
-## Viewer workflow (upstream Eventyay surface)
+---
 
-1. Viewer selects language on stage/video page.
-2. Viewer video clock (YouTube) remains master.
-3. Hidden audio (HLS) is synchronized via drift correction loop.
-4. Fallback to original audio remains available.
+## System architecture at a glance
 
-## Constraints and assumptions
+```
+Speaker/Presenter
+       │
+       ▼
+  Jitsi meeting ──────────────────────────────────────────────┐
+       │                                                       │
+       │  (interpreter monitors floor audio via Jitsi iframe) │
+       ▼                                                       ▼
+Interpreter Console (this repo)                     Eventyay Viewer
+  ┌─────────────────────────────┐                  ┌──────────────────────────┐
+  │  Jitsi iframe (receive-only)│                  │  YouTube video (master   │
+  │  Mic capture (WebRTC)       │                  │  clock)                  │
+  │  Booth chat / participant   │                  │  HLS language audio      │
+  │  grid / health panel        │                  │  (drift-corrected)       │
+  └────────────┬────────────────┘                  └──────────────────────────┘
+               │ WebRTC SDP offer/answer
+               ▼
+         Ingest API  (app.py / portal/ingest.py)
+               │ aiortc terminates RTP
+               ▼
+           FFmpeg  →  HLS segments  →  hls-output/
+```
 
-- Jitsi monitor should start with mic/camera muted (receive-first behavior).
-- Ingest audio must never be locally looped back.
-- DSP flags are enabled for mic capture:
-  - `echoCancellation: true`
-  - `noiseSuppression: true`
-  - `autoGainControl: true`
-- Ingest negotiation endpoint contract:
-  - `POST /api/interpreter/connect/{channel}`
-- One active interpreter publishes per language channel.
-- Initial collaboration state is in memory; production deploys should add PostgreSQL persistence and Redis-backed Socket.IO when multiple workers are used.
-- Local setup is pinned to Python `3.13.x`, `aiortc 1.14.0`, and `av 16.1.0`.
-- The repo no longer relies on building `av` against the system FFmpeg installation during normal development setup.
+Full diagrams: [docs/architecture/system-overview.md](docs/architecture/system-overview.md)
 
-## Scaling assumptions
+---
 
-- Initial target: medium event scale (hundreds of concurrent viewers per language through HLS distribution).
-- FFmpeg and HLS packaging are external infrastructure concerns.
-- CDN is optional for initial rollout; can be introduced as traffic profile grows.
+## Quick start
 
-## Local setup
+### Prerequisites
+
+- Python 3.13 (managed by `uv`)
+- Node.js 18+ and npm (for the Vue frontend build)
+- `uv` — the Python package manager ([install guide](https://docs.astral.sh/uv/getting-started/installation/))
+
+### Backend
 
 ```bash
+cd eventyay-interpretation-portal
+cp .env.example .env          # review and adjust if needed
 uv sync --python 3.13 --dev
 uv run python app.py
 ```
 
-Open:
+Server starts at `http://127.0.0.1:5000`.
+
+### Frontend (development mode)
+
+```bash
+npm install
+npm run dev
+```
+
+Vite dev server starts at `http://localhost:5173`.
+
+### Open an interpreter booth
 
 ```text
 http://127.0.0.1:5000/interpreter/hall-a-fr?token=dev-token&language=French
 ```
 
-If `BOOTH_ACCESS_TOKEN` is empty, the `token` query parameter is optional. If a token is configured, every booth URL and API call must use the matching temporary token.
+If `BOOTH_ACCESS_TOKEN` is empty in `.env`, the `token` parameter is optional. When a token is set, every booth URL and API call must include the matching token.
 
-## Local environment
+---
 
-Copy `.env.example` to `.env` and configure:
+## Environment variables
 
-- `HOST` - bind address for local development. Defaults to `127.0.0.1`.
-- `PORT` - Flask/Socket.IO server port.
-- `FLASK_DEBUG` - `1` to enable debug mode locally.
-- `SECRET_KEY` - Flask session secret.
-- `BOOTH_ACCESS_TOKEN` - optional temporary booth invite token.
-- `BOOTH_WS_CORS_ORIGINS` - allowed Socket.IO origins.
-- `DEFAULT_JITSI_ROOM` - monitoring room prefill.
+Copy `.env.example` to `.env`. All variables have safe development defaults.
+
+| Variable | Default | Description |
+|---|---|---|
+| `HOST` | `127.0.0.1` | Bind address. Use `0.0.0.0` only for LAN testing. |
+| `PORT` | `5000` | Flask/Socket.IO port. |
+| `FLASK_DEBUG` | `1` | Enable Flask debug mode locally. |
+| `SECRET_KEY` | `change-me` | Flask session secret. Change in production. |
+| `BOOTH_ACCESS_TOKEN` | _(empty)_ | Optional invite token for booth URLs. |
+| `BOOTH_WS_CORS_ORIGINS` | `*` | Allowed Socket.IO origins (comma-separated or `*`). |
+| `DEFAULT_JITSI_ROOM` | `https://meet.jit.si/eventyay-stage-room` | Pre-filled Jitsi monitoring URL. |
+| `JITSI_DOMAIN` | `meet.jit.si` | Jitsi server domain used for embed URL validation. |
+| `INGEST_HLS_ROOT` | `./hls-output` | Directory where FFmpeg writes HLS playlists and segments. |
+| `HLS_SEGMENT_SECONDS` | `2` | Target segment duration in seconds. |
+| `HLS_PLAYLIST_LENGTH` | `8` | Number of segments retained in the live playlist. |
+
+---
+
+## Workflows
+
+### Interpreter
+
+1. Open the tokenized booth URL.
+2. Complete the preflight checklist (headphones, mic test, level meter).
+3. Monitor the floor session via the embedded Jitsi frame.
+4. When assigned as active interpreter, click **Go Live**.
+5. Speak. Your audio is captured, sent via WebRTC, and segmented into HLS.
+6. Use booth chat for coordination, terminology, or handoff signalling.
+7. Click **Stop** or accept a coordinator handoff to yield the active role.
+
+### Coordinator
+
+1. Open the same booth URL with `role=coordinator`.
+2. Watch the participant grid for active/standby/connection status.
+3. Assign a different interpreter active via the participant grid.
+4. Use booth chat for rotation planning and terminology.
+
+### Viewer (upstream Eventyay surface)
+
+1. Open an Eventyay event stage page.
+2. Select a language from the audio track picker.
+3. The page loads HLS language audio alongside the YouTube video clock.
+4. A drift-correction loop keeps the language audio in sync with video.
+
+---
+
+## Running tests
+
+```bash
+uv run pytest
+```
+
+Tests cover booth state, participant role enforcement, ingest API boundaries, and Socket.IO event handlers. See [docs/testing/e2e-testing.md](docs/testing/e2e-testing.md).
+
+---
+
+## Documentation index
+
+| Document | Purpose |
+|---|---|
+| [docs/context/project-context.md](docs/context/project-context.md) | Product background and design intent |
+| [docs/architecture/system-overview.md](docs/architecture/system-overview.md) | Full system diagram and component map |
+| [docs/architecture/interpreter-flow.md](docs/architecture/interpreter-flow.md) | End-to-end interpreter audio pipeline |
+| [docs/architecture/jitsi-integration.md](docs/architecture/jitsi-integration.md) | How Jitsi is used for monitoring |
+| [docs/architecture/webrtc-ingest.md](docs/architecture/webrtc-ingest.md) | WebRTC ingest design and SDP flow |
+| [docs/frontend/frontend-architecture.md](docs/frontend/frontend-architecture.md) | Vue 3 component and service layer |
+| [docs/backend/backend-architecture.md](docs/backend/backend-architecture.md) | Flask routes, booth state, and ingest service |
+| [docs/specifications/interpreter-portal-spec.md](docs/specifications/interpreter-portal-spec.md) | Interpreter console feature specification |
+| [docs/specifications/booth-collaboration-spec.md](docs/specifications/booth-collaboration-spec.md) | Booth roles, handoff, and chat rules |
+| [docs/specifications/jitsi-room-management-spec.md](docs/specifications/jitsi-room-management-spec.md) | Jitsi room and embed policy |
+| [docs/setup/local-development.md](docs/setup/local-development.md) | Detailed local setup and troubleshooting |
+| [docs/testing/e2e-testing.md](docs/testing/e2e-testing.md) | Test suite overview and manual scenarios |
+| [docs/phases/implementation-roadmap.md](docs/phases/implementation-roadmap.md) | Current phase and future roadmap |
+
+---
+
+## Key constraints
+
+- Jitsi iframe starts muted (receive-only). Interpreters must use headphones to prevent echo.
+- Ingest audio is never looped back to the interpreter's local speakers.
+- Browser mic capture enables `echoCancellation`, `noiseSuppression`, and `autoGainControl`.
+- Exactly one active interpreter publishes per language channel at any time.
+- Booth state is currently in-memory. Production deployments require PostgreSQL and Redis.
+- Python runtime is pinned to `3.13.x`; `aiortc 1.14.0` and `av 16.1.0` are the validated media stack.
+
+---
+
+## Contributing
+
+See [AGENTS.md](AGENTS.md) for implementation guardrails and agent-specific instructions.
+See [docs/setup/local-development.md](docs/setup/local-development.md) for the full environment setup.
+
 - `JITSI_DOMAIN` - allowed Jitsi hostname for iframe validation.
 - `INGEST_HLS_ROOT` - local HLS output directory.
 - `HLS_SEGMENT_SECONDS` - FFmpeg HLS segment length.

--- a/agents.md
+++ b/agents.md
@@ -1,103 +1,166 @@
-# Eventyay Interpretation Portal — Contributor/Agent Guide
+# Eventyay Interpretation Portal — Agent Guide
 
 This file defines implementation guardrails for contributors and coding agents working inside `eventyay-interpretation-portal/`.
+
+Read this file in full before making changes. The constraints here are non-negotiable.
+
+---
 
 ## Product intent
 
 Build a production-oriented interpretation subsystem that is:
 
-- Eventyay-native in UI and architecture
-- browser-first for interpreter operations
-- collaborative for booth teams
-- extensible for future multilingual/relay workflows
+- **Eventyay-native** in UI and architecture
+- **Browser-first** for interpreter operations — no OBS, no RTMP, no external encoder
+- **Collaborative** for booth teams (active interpreter, backup, coordinator, listener)
+- **Extensible** for future multilingual, relay, and sign-language workflows
+
+The current phase is the **Interpreter Console MVP**: mic tests, preflight checklist, and WebRTC ingest wiring. The ingest server infrastructure (aiortc endpoint, FFmpeg HLS segmenter) is being developed in parallel and will be connected in a future phase. Agents should not assume the ingest server is production-ready.
+
+---
 
 ## Core design constraints
 
 1. **Single-tab workflow:** no OBS/RTMP/external encoder requirements.
 2. **Separation of concerns:**
-   - Jitsi = monitoring/coordination
-   - WebRTC ingest = interpreter audio uplink
-   - HLS = viewer distribution
-3. **One active publisher per language channel.**
-4. **No local audio loopback from ingest stream path.**
-5. **UI consistency:** match Eventyay video/streaming visual language.
+   - Jitsi = monitoring and booth coordination context only
+   - WebRTC ingest = interpreter audio uplink to the ingest API
+   - HLS = viewer distribution (outside this repo)
+3. **One active publisher per language channel at all times.**
+4. **No local audio loopback from ingest stream path.** The `MicStreamingManager` intentionally never connects its analyser to `AudioContext.destination`.
+5. **UI consistency:** match Eventyay video/streaming visual language (CSS variables, card-based layout).
+
+---
 
 ## Role model
 
 Supported booth roles:
 
-- Active Interpreter
-- Backup Interpreter
-- Coordinator
-- Listener
+| Role | Publishing rights | Assignment authority |
+|---|---|---|
+| Active Interpreter | Yes — only one per channel | Coordinator or self-assign on join |
+| Backup Interpreter | No — standby only | Coordinator or current active |
+| Coordinator | No — supervisory role | Fixed on join |
+| Listener | No | Fixed on join |
 
-Expected behavior:
+Enforcement rules:
 
-- only one active interpreter publishes at a time per channel
-- coordinator can override and reassign active role
-- booth chat remains internal/private to booth participants
+- Only the active interpreter may call `POST /api/interpreter/connect/{channel}`.
+- Coordinator or active interpreter may call `booth:set-active` via Socket.IO.
+- Non-interpreter roles cannot be promoted to active.
 
-## Runtime architecture expectations
+---
 
-- `app.py` owns Flask routes, Socket.IO events, and ingest endpoint boundaries.
-- `portal/booth_state.py` owns in-memory booth state, participant roles, handoff policy, and chat history.
-- `portal/ingest.py` owns aiortc peer negotiation and FFmpeg/HLS recorder setup.
-- `templates/` owns server-rendered HTML.
-- `static/js/interpreter-booth.js` owns browser behavior for joining, chat, Jitsi iframe setup, mic capture, and WebRTC offer creation.
-- `static/css/interpreter.css` owns lightweight Eventyay-aligned styling.
+## Module ownership
 
-Keep the browser layer small. Do not reintroduce a SPA, client-side router, frontend state store, or custom component system unless the Eventyay app integration requires it.
+| File / directory | Owns |
+|---|---|
+| `app.py` | Flask routes, Socket.IO event handlers, access token checks, ingest API boundaries |
+| `portal/booth_state.py` | In-memory booth registry, participant roles, handoff policy, chat history |
+| `portal/ingest.py` | aiortc peer negotiation, FFmpeg/HLS recorder setup, async runtime |
+| `portal/config.py` | Settings loaded from environment variables |
+| `templates/` | Server-rendered HTML (base shell + booth page) |
+| `src/` | Vue 3 SPA (bundled by Vite, served by Flask in production) |
+| `src/composables/useInterpreterBooth.js` | Central booth state machine, event wiring |
+| `src/services/ingestClient.js` | WebRTC SDP negotiation with the ingest API |
+| `src/services/micStreamingManager.js` | getUserMedia, level meter, peer connection lifecycle |
+| `src/services/jitsiEmbed.js` | Jitsi URL parsing and embed URL construction |
+| `src/services/boothRealtime.js` | Socket.IO + BroadcastChannel realtime transport |
 
-## Flow summary for implementation decisions
+---
 
-- **Interpreter flow:** Jitsi monitor join -> pre-flight -> mic test -> active assignment -> ingest start.
-- **Coordinator flow:** monitor participant states -> reassign active interpreter -> supervise booth health.
-- **Viewer flow (outside this module):** YouTube video clock + HLS language audio with drift-correction sync loop.
+## Flow summary
+
+### Interpreter flow
+
+```
+Open booth URL → preflight checklist → mic test → active assignment → Go Live
+     │                                                    │
+     ▼                                                    ▼
+Jitsi iframe loads (receive-only)            WebRTC offer → ingest API
+Monitoring floor audio/video                 aiortc terminates RTP
+                                             FFmpeg → HLS segments → hls-output/
+```
+
+### Coordinator flow
+
+```
+Open booth URL → monitor participant grid → assign active interpreter
+```
+
+### Viewer flow (outside this repo)
+
+```
+Eventyay stage page → select language → HLS audio loads
+YouTube video clock (master) + HLS drift-correction loop
+```
+
+---
 
 ## Media pipeline responsibilities
 
-- **Jitsi role:** monitoring and booth communication context.
-- **WebRTC role:** low-latency microphone ingest to Eventyay ingest backend.
-- **FFmpeg role:** transcode/segment interpreter audio to HLS assets.
-- **HLS role:** scalable viewer delivery path for selected language channels.
+| Component | Responsibility |
+|---|---|
+| Jitsi | Monitor floor audio/video; booth communication context |
+| Browser `getUserMedia` | Capture interpreter microphone with echoCancellation, noiseSuppression, autoGainControl |
+| `RTCPeerConnection` | Send audio track as Opus/RTP to the ingest endpoint |
+| `portal/ingest.py` + aiortc | Terminate the WebRTC connection server-side; receive audio tracks |
+| FFmpeg | Transcode/segment interpreter audio to HLS assets |
+| HLS | Scalable viewer delivery; served from `hls-output/` |
 
-## Realtime transport strategy
+---
 
-Current default:
+## Realtime transport
+
+Current (development):
 
 - Flask-SocketIO with in-memory booth state
-- booth invite URLs with optional temporary token query parameter
+- `BroadcastChannel` for cross-tab coordination in the same browser
+- Optional WebSocket URL for multi-machine setups
 
-Production path:
+Production requirements:
 
-- PostgreSQL for persistent booth/session records
-- Redis or another Socket.IO message queue when multiple app workers are deployed
-- keep viewer playback and ingest/HLS infrastructure outside the booth template layer
+- PostgreSQL for persistent booth and session records
+- Redis-backed Socket.IO adapter when multiple Flask workers are deployed
+- Keep viewer playback and ingest/HLS infrastructure outside this module
 
-## Scaling and deployment assumptions
+---
 
-- medium initial event scale (hundreds of concurrent viewers per language path)
-- ingest and FFmpeg/HLS services are deployed outside this frontend module
-- websocket sync is deployment-dependent; local fallback keeps development usable
+## What agents must not do
 
-## Validation expectations
+- Do not introduce jQuery or inline `<script>` blocks.
+- Do not add a second client-side router or a new state management store.
+- Do not replace `uv` with `pip` or `requirements.txt`.
+- Do not import `pretix.*`, `pretalx.*`, or `venueless.*` namespaces.
+- Do not modify `uv.lock` without re-running `uv sync --python 3.13 --dev` and confirming tests pass.
+- Do not add any code that routes interpreter microphone audio back to `AudioContext.destination`.
 
-At minimum per change:
+---
 
-- `uv sync --python 3.13 --dev`
-- `uv run pytest`
-- manual browser check with two interpreter tabs and one coordinator tab
+## Validation before submitting changes
 
-Dependency invariants:
+```bash
+uv sync --python 3.13 --dev
+uv run pytest
+```
 
-- use the `uv` lockfile as the source of truth
-- keep local development on Python `3.13.x` unless the media stack is revalidated
-- avoid reintroducing `requirements.txt` as the primary bootstrap path
-- do not require building `av` from source for normal contributor setup
+Manual browser check:
 
-For integrated environments:
+1. Open two interpreter tabs (active + backup).
+2. Open one coordinator tab.
+3. Confirm only one tab shows the active publisher state.
+4. Confirm mic test and level meter work on the active tab.
+5. Confirm coordinator can reassign active role.
 
-- execute the multi-user and media-path scenario in `README.md`
+---
+
+## Dependency invariants
+
+- Python runtime: `3.13.x` — do not change without revalidating the `aiortc`/`av` media stack.
+- `aiortc 1.14.0` and `av 16.1.0` are the validated ingest dependency versions.
+- `uv.lock` is the source of truth for all Python dependencies.
+- Do not require building `av` from source for normal contributor setup.
+
 - verify reconnect and handoff edge cases
 
 ## Documentation requirements

--- a/docs/architecture/interpreter-flow.md
+++ b/docs/architecture/interpreter-flow.md
@@ -1,0 +1,194 @@
+# Interpreter Audio Flow
+
+This document traces the complete audio path from the interpreter's microphone to the viewer's HLS player.
+
+---
+
+## End-to-end flow diagram
+
+```
+Interpreter microphone (physical headset mic)
+│
+▼
+navigator.mediaDevices.getUserMedia({
+  audio: {
+    echoCancellation: true,
+    noiseSuppression: true,
+    autoGainControl: true,
+    deviceId: { exact: selectedDeviceId }   ← user-selected in preflight
+  }
+})
+│
+▼
+MediaStream (audio-only; never connected to AudioContext.destination)
+│
+├──► AudioContext analyser node  ← level meter (visualisation only; no output)
+│
+└──► RTCPeerConnection.addTrack(audioTrack, stream)
+       │
+       ▼
+       peerConnection.createOffer({ offerToReceiveAudio: false, offerToReceiveVideo: false })
+       │
+       ▼
+       peerConnection.setLocalDescription(offer)
+       │
+       ▼
+       ICE gathering (3 s timeout)
+       │
+       ▼
+       POST /api/interpreter/connect/{channel_id}
+       Body: { type, sdp, booth_id, participant_id, token, language }
+       │
+       ▼  (server-side: portal/ingest.py)
+       aiortc RTCPeerConnection.setRemoteDescription(offer)
+       │
+       ▼
+       aiortc RTCPeerConnection.createAnswer()
+       │
+       ▼
+       ICE gathering (server-side)
+       │
+       ▼
+       JSON response: { type: "answer", sdp: "..." }
+       │
+       ▼  (back in browser)
+       peerConnection.setRemoteDescription(answer)
+       │
+       ▼
+       ICE candidate exchange (embedded in SDP / trickle ICE)
+       │
+       ▼
+       RTP stream (Opus codec) → server-side aiortc peer connection
+       │
+       ▼
+       aiortc @peer_connection.on('track')
+         → recorder.addTrack(track)
+         → recorder.start()
+       │
+       ▼
+       MediaRecorder → FFmpeg pipe or HLS file recorder
+       │
+       ▼
+       hls-output/{channel_id}/playlist.m3u8
+       hls-output/{channel_id}/segment-XXXX.ts
+       │
+       ▼
+       HLS origin / CDN
+       │
+       ▼
+       Eventyay viewer: Hidden HLS audio player (drift-corrected against YouTube clock)
+```
+
+---
+
+## Browser-side steps in detail
+
+### Step 1 — Device selection (preflight)
+
+`MicStreamingManager.listInputDevices()` calls `navigator.mediaDevices.enumerateDevices()` and filters for `audioinput` devices. The user selects their headset microphone from a dropdown in the `MicIngestPanel`.
+
+### Step 2 — Mic test
+
+`MicStreamingManager.startMicrophone(deviceId, onLevel)`:
+
+1. Calls `getUserMedia` with the selected device and DSP flags.
+2. Creates an `AudioContext` with an `AnalyserNode`.
+3. Connects the `MediaStreamSource` to the `AnalyserNode` only — never to `destination`. This prevents loopback.
+4. Runs a `requestAnimationFrame` loop computing RMS level from the time-domain data and calling `onLevel(level)`.
+5. The `MicIngestPanel` renders the level as a visual meter bar.
+
+The mic test completes when the interpreter confirms they can see the level responding to their voice. The `preflight.micTestComplete` flag is set.
+
+### Step 3 — Ingest connection (Go Live)
+
+`MicStreamingManager.createIngestConnection(onConnectionStateChange)`:
+
+1. Creates a new `RTCPeerConnection` with configured STUN servers.
+2. Adds all audio tracks from the active `MediaStream`.
+3. Creates an offer with `offerToReceiveAudio: false, offerToReceiveVideo: false` (send-only).
+4. Sets the local description and waits for ICE gathering to complete (max 3 s).
+5. Returns the local description (offer).
+
+`IngestClient.negotiate(channelId, localDescription)`:
+
+1. POSTs the SDP offer to `POST /api/interpreter/connect/{channel_id}`.
+2. Expects a JSON response with `type` and `sdp` fields (or a Janus-style `jsep` wrapper).
+3. Returns the answer SDP.
+
+Back in `MicStreamingManager`: calls `peerConnection.setRemoteDescription(answer)` to complete the connection.
+
+### Step 4 — Live streaming
+
+Once the peer connection state transitions to `connected`, the audio track flows as an Opus RTP stream to the server. The `BoothHealthPanel` shows live status.
+
+The `statsTimer` polls `RTCPeerConnection.getStats()` every 2 s to compute an approximate bitrate in kbps, which is surfaced in the health panel.
+
+### Step 5 — Stop / handoff
+
+`MicStreamingManager.stopPeerConnection()` closes the peer connection and removes event listeners.
+
+`IngestClient` calls `POST /api/interpreter/disconnect/{channel_id}` to signal the server.
+
+The server calls `ingest.disconnect(channel_id)` which closes the aiortc peer connection and stops the recorder.
+
+---
+
+## Server-side ingest in detail (`portal/ingest.py`)
+
+The `IngestService` manages a dedicated asyncio event loop on a background thread (`AsyncRuntime`). All aiortc operations run on this loop to avoid blocking Flask's threading model.
+
+### Connection sequence
+
+```python
+await peer_connection.setRemoteDescription(offer)
+answer = await peer_connection.createAnswer()
+await peer_connection.setLocalDescription(answer)
+await _wait_for_ice_completion(peer_connection)    # polls gatheringstate
+```
+
+The `@peer_connection.on('track')` handler:
+
+```python
+async def on_track(track):
+    if track.kind != 'audio':
+        return
+    recorder.addTrack(track)
+    await recorder.start()
+```
+
+The recorder is an `aiortc.contrib.media.MediaRecorder` pointed at the HLS output path. It transcodes the incoming Opus track with FFmpeg and segments it into `.ts` files with a `.m3u8` playlist.
+
+### Connection state monitoring
+
+```python
+@peer_connection.on('connectionstatechange')
+async def on_connectionstatechange():
+    session.connection_state = peer_connection.connectionState
+    if peer_connection.connectionState in {'failed', 'closed'}:
+        await _disconnect(channel_id)
+```
+
+When the browser disconnects or the peer connection fails, the server cleans up the session automatically.
+
+---
+
+## Echo prevention
+
+The primary echo prevention mechanism is **operational**: interpreters must use headphones. The portal enforces this via the preflight checklist (`headphonesConnected` item must be checked before Go Live is enabled).
+
+The secondary mechanism is **technical**: browser mic capture enables `echoCancellation: true`. The browser's built-in AEC (Acoustic Echo Cancellation) will suppress any residual floor audio leaking from speakers, but headphones are required to make AEC reliable.
+
+The tertiary guarantee: the analyser node used for the level meter is **never connected to `AudioContext.destination`**, so there is no programmatic loopback path in the browser code.
+
+---
+
+## Failure and reconnect behaviour
+
+| Failure | Browser behaviour | Server behaviour |
+|---|---|---|
+| ICE negotiation timeout | Show warning; retry up to `MAX_RECONNECT_ATTEMPTS` | N/A — server waits for new offer |
+| WebRTC `connectionState === 'failed'` | Show warning; auto-retry | Session cleaned up via `connectionstatechange` handler |
+| Coordinator reassigns active role | Stop ingest; clear mic state | `ingest.disconnect(channel_id)` called by Socket.IO handler |
+| Interpreter leaves booth | Stop ingest | `leave_participant` + `ingest.disconnect` |
+
+Viewer fallback: if the HLS playlist stops updating, the Eventyay viewer player falls back to the original floor audio.

--- a/docs/architecture/jitsi-integration.md
+++ b/docs/architecture/jitsi-integration.md
@@ -1,0 +1,130 @@
+# Jitsi Integration
+
+This document describes how Jitsi is used in the interpretation portal and what it is explicitly not used for.
+
+---
+
+## Purpose
+
+Jitsi provides the **monitoring path** for interpreters. When an interpreter opens their booth:
+
+1. They see the floor session (speaker audio and video) via an embedded Jitsi iframe.
+2. They can hear their backup interpreter or coordinator if those colleagues also have Jitsi open.
+3. They have a visual context of who is speaking before they begin interpreting.
+
+Jitsi is **not** the ingest transport. Interpreter audio never flows through Jitsi to viewers. The ingest path is a separate WebRTC connection directly to the portal's ingest API.
+
+---
+
+## Embed configuration
+
+The Jitsi iframe is configured to start in receive-only mode. This is enforced by URL hash parameters set in `src/services/jitsiEmbed.js`:
+
+```js
+const JITSI_EMBED_CONFIG = {
+  'config.startWithAudioMuted': 'true',
+  'config.startWithVideoMuted': 'true',
+  'config.prejoinPageEnabled': 'false',
+  'config.disableInitialGUM': 'false',
+  'config.startSilent': 'true'   // start muted
+}
+```
+
+These parameters are appended as URL hash params when constructing the embed URL:
+
+```
+https://meet.jit.si/eventyay-stage-room
+  #config.startWithAudioMuted=true
+  &config.startWithVideoMuted=true
+  &config.prejoinPageEnabled=false
+  &config.disableInitialGUM=true
+  &config.startSilent=true
+```
+
+The result: the Jitsi frame loads, the interpreter can hear floor audio, but their microphone and camera are not published into the Jitsi call by default.
+
+---
+
+## URL validation (`buildJitsiEmbedUrl`)
+
+`buildJitsiEmbedUrl(rawUrl, options)` in `src/services/jitsiEmbed.js`:
+
+1. Parses the raw Jitsi URL with `new URL(rawUrl)`.
+2. Validates that the URL has a room path (not just `/`).
+3. If `options.expectedDomain` is set, validates that the URL's origin matches `https://{expectedDomain}`.
+4. Returns `{ roomName, embedUrl }`.
+
+The `expectedDomain` check is wired to the `JITSI_DOMAIN` environment variable passed from the Flask server into the Vue config. This prevents an interpreter from substituting an arbitrary Jitsi server.
+
+---
+
+## How the interpreter joins
+
+The `JitsiMonitorPanel` renders:
+
+- A text input for the Jitsi room URL (pre-filled from `DEFAULT_JITSI_ROOM`)
+- A **Join Monitor Room** button
+- The Jitsi iframe (hidden until joined)
+
+On join:
+
+```js
+// useInterpreterBooth.js
+function joinJitsi(rawUrl) {
+  const { roomName, embedUrl } = buildJitsiEmbedUrl(rawUrl, {
+    expectedDomain: env.jitsiDomain
+  })
+  state.jitsi.roomName = roomName
+  state.jitsi.embedUrl = embedUrl
+  state.jitsi.status = 'joined'
+}
+```
+
+The `embedUrl` is set as the `src` attribute of the `<iframe>`. The Jitsi JS API is not used — the portal interacts with Jitsi solely via iframe embed.
+
+---
+
+## Why no Jitsi JS API
+
+The Jitsi JS API (`JitsiMeetExternalAPI`) would allow programmatic control (mute/unmute, participant events, etc.). The portal deliberately does not use it because:
+
+1. **Scope separation.** The portal does not need to control the Jitsi call. It only needs to display it.
+2. **Dependency reduction.** Loading the Jitsi external API JS adds a large dependency and cross-origin complexity.
+3. **Robustness.** A pure iframe embed degrades gracefully if the Jitsi server is momentarily unreachable — the rest of the console (ingest, chat, participant grid) continues to work.
+
+If future requirements need Jitsi API features (e.g., detecting when the speaker is muted, or auto-joining with a display name), the `jitsiEmbed.js` service is the right place to extend.
+
+---
+
+## Jitsi server configuration
+
+The portal works with any Jitsi server. The default is `meet.jit.si` (the public Jitsi instance). For production events:
+
+- Deploy a dedicated Jitsi server or use a managed Jitsi service.
+- Set `DEFAULT_JITSI_ROOM` and `JITSI_DOMAIN` in `.env` to point to it.
+- Ensure the Jitsi server has appropriate capacity for the expected number of participants.
+
+There is no Jitsi configuration managed by this portal. Room creation, access control, and capacity management are handled by whoever operates the Jitsi server.
+
+---
+
+## Echo risk and headphone requirement
+
+The monitoring path (Jitsi floor audio playing from the interpreter's speakers) would create acoustic echo if the interpreter does not use headphones. The portal enforces headphone use via the preflight checklist.
+
+The `headphonesConnected` item in `PreflightChecklist` must be checked before the **Go Live** button is enabled. This is an operational control, not a technical detection. The portal trusts the interpreter to self-report headphone use.
+
+Browser echo cancellation (`echoCancellation: true` in `getUserMedia`) provides a fallback if headphones are partially insufficient, but it cannot eliminate severe echo from open speakers.
+
+---
+
+## Jitsi in the booth vs. ingest paths
+
+| Attribute | Jitsi (monitoring) | WebRTC ingest |
+|---|---|---|
+| Direction | Receive only | Send only (mic upload) |
+| Transport | Jitsi's own WebRTC stack | Direct RTCPeerConnection to portal API |
+| Audio source | Floor session (speakers, presenter) | Interpreter's microphone |
+| Destination | Interpreter's ears | aiortc → FFmpeg → HLS → viewer |
+| Echo risk | High (if no headphones) | None (never routed to speakers) |
+| Failure impact | Interpreter loses monitoring | Viewer loses language audio |

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -1,0 +1,159 @@
+# System Overview
+
+## Full system diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         LIVE EVENT                                       │
+│                                                                           │
+│  Speaker/Presenter                                                        │
+│       │                                                                   │
+│       ▼                                                                   │
+│  Jitsi meeting room  ◄──────────────────────────────────────────────┐   │
+│       │  (floor audio + video)                                        │   │
+│       │                                                               │   │
+│       │  iframe embed (receive-only)                                  │   │
+│       ▼                                                               │   │
+│  ┌────────────────────────────────────────────┐                      │   │
+│  │         Interpreter Console (this repo)     │                      │   │
+│  │                                             │                      │   │
+│  │  ┌─────────────────┐  ┌──────────────────┐ │                      │   │
+│  │  │ Jitsi Monitor   │  │ Mic Ingest Panel │ │                      │   │
+│  │  │ Panel           │  │                  │ │                      │   │
+│  │  │ (floor audio)   │  │ Preflight        │ │                      │   │
+│  │  │                 │  │ Level meter      │ │                      │   │
+│  │  │                 │  │ Go Live / Stop   │ │                      │   │
+│  │  └─────────────────┘  └────────┬─────────┘ │                      │   │
+│  │                                │            │                      │   │
+│  │  ┌─────────────────┐  ┌────────┴─────────┐ │                      │   │
+│  │  │ Participant Grid│  │ Booth Health     │ │                      │   │
+│  │  │ (active/standby)│  │ Panel            │ │                      │   │
+│  │  └─────────────────┘  └──────────────────┘ │                      │   │
+│  │                                             │                      │   │
+│  │  ┌────────────────────────────────────────┐ │                      │   │
+│  │  │ Booth Chat Panel (Socket.IO)           │ │ ──── booth:join ─────┘   │
+│  │  └────────────────────────────────────────┘ │                          │
+│  └────────────────────┬────────────────────────┘                          │
+│                       │ WebRTC SDP offer/answer                           │
+│                       ▼                                                   │
+│  ┌────────────────────────────────────────────┐                          │
+│  │         Flask + Socket.IO server (app.py)  │                          │
+│  │                                             │                          │
+│  │  POST /api/interpreter/connect/{channel}   │                          │
+│  │  portal/ingest.py  (aiortc)                │                          │
+│  └────────────────────┬────────────────────────┘                          │
+│                       │ PCM / Opus tracks                                 │
+│                       ▼                                                   │
+│  ┌─────────────────────────────┐                                          │
+│  │  FFmpeg transcode + segment │                                          │
+│  └──────────────┬──────────────┘                                          │
+│                 │ .m3u8 + .ts segments                                    │
+│                 ▼                                                         │
+│  hls-output/ ──► CDN / HLS origin server                                 │
+│                 │                                                         │
+│                 ▼                                                         │
+│  ┌──────────────────────────────────────────────────┐                    │
+│  │  Eventyay Viewer (stage page)                    │                    │
+│  │                                                  │                    │
+│  │  YouTube player  +  Hidden HLS audio player      │                    │
+│  │  (master clock)      (drift-corrected)           │                    │
+│  └──────────────────────────────────────────────────┘                    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Component map
+
+### Frontend (Vue 3 SPA)
+
+| Component | File | Purpose |
+|---|---|---|
+| `InterpreterConsoleView` | `src/views/InterpreterConsoleView.vue` | Top-level view; wires all panels together |
+| `JitsiMonitorPanel` | `src/components/JitsiMonitorPanel.vue` | Jitsi iframe embed and join controls |
+| `MicIngestPanel` | `src/components/MicIngestPanel.vue` | Device selector, level meter, Go Live / Stop |
+| `PreflightChecklist` | `src/components/PreflightChecklist.vue` | Checklist gating the Go Live button |
+| `ParticipantGrid` | `src/components/ParticipantGrid.vue` | Booth participant list with role/status badges |
+| `BoothChatPanel` | `src/components/BoothChatPanel.vue` | Internal booth chat |
+| `BoothHealthPanel` | `src/components/BoothHealthPanel.vue` | Live ingest health indicators |
+| `useInterpreterBooth` | `src/composables/useInterpreterBooth.js` | Central state machine and event wiring |
+| `IngestClient` | `src/services/ingestClient.js` | WebRTC SDP negotiation with the ingest API |
+| `MicStreamingManager` | `src/services/micStreamingManager.js` | getUserMedia, level meter, peer connection |
+| `buildJitsiEmbedUrl` | `src/services/jitsiEmbed.js` | Jitsi URL parsing and embed URL construction |
+| `BoothRealtimeClient` | `src/services/boothRealtime.js` | Socket.IO + BroadcastChannel realtime transport |
+
+### Backend (Flask + Socket.IO)
+
+| Module | File | Purpose |
+|---|---|---|
+| Flask app | `app.py` | Routes, Socket.IO handlers, access token checks |
+| `BoothRegistry` | `portal/booth_state.py` | In-memory booth state, roles, handoff, chat |
+| `IngestService` | `portal/ingest.py` | aiortc peer connection management, async runtime |
+| `Settings` | `portal/config.py` | Environment variable loading and validation |
+
+### Templates
+
+| Template | Purpose |
+|---|---|
+| `templates/base.html` | Eventyay-style page shell |
+| `templates/interpreter_booth.html` | Server-rendered booth page (passes config to Vue) |
+
+---
+
+## Data flow summary
+
+### Monitoring path (Jitsi)
+
+```
+Speaker → Jitsi meeting → Jitsi iframe in interpreter console → interpreter's ears
+```
+
+The Jitsi iframe loads with `startWithAudioMuted=false` (it plays floor audio) but `startWithVideoMuted=true` and `disableInitialGUM=true` so the interpreter's mic/camera is never accidentally published into the Jitsi call.
+
+### Ingest path (WebRTC → HLS)
+
+```
+Interpreter mic
+  → getUserMedia (echoCancellation + noiseSuppression + autoGainControl)
+  → RTCPeerConnection (audio track only)
+  → SDP offer → POST /api/interpreter/connect/{channel_id}
+  → aiortc RTCPeerConnection (server-side)
+  → SDP answer returned
+  → RTP Opus stream received server-side
+  → aiortc MediaRecorder → FFmpeg command or HLS recorder
+  → hls-output/{channel_id}/playlist.m3u8 + segments
+```
+
+### Coordination path (Socket.IO)
+
+```
+Browser → socket.io connect → booth:join
+       ← booth:joined + booth:state
+       ↔ booth:chat / booth:set-active / booth:update-state
+       ← booth:state (broadcast to all booth participants on any change)
+```
+
+---
+
+## State ownership
+
+| State | Owned by |
+|---|---|
+| Booth participants and roles | `portal/booth_state.py` (server, in-memory) |
+| Active interpreter assignment | `portal/booth_state.py` (server) |
+| Handoff state | `portal/booth_state.py` (server) |
+| Chat history (last 500 messages) | `portal/booth_state.py` (server) |
+| Ingest session (peer connection) | `portal/ingest.py` (server, async runtime) |
+| Local mic stream | `MicStreamingManager` (browser) |
+| Local WebRTC peer connection | `MicStreamingManager` (browser) |
+| UI state (preflight, level, chat display) | `useInterpreterBooth` composable (browser) |
+| Persisted chat (localStorage) | `BoothRealtimeClient` (browser) |
+
+---
+
+## Security model
+
+- Booth URLs carry an optional `BOOTH_ACCESS_TOKEN`. When set, all HTTP API calls and Socket.IO events must include the matching token.
+- The ingest endpoint (`POST /api/interpreter/connect/{channel}`) additionally checks that the requesting participant is the active interpreter for the channel before accepting the SDP offer.
+- Non-interpreter roles (coordinator, listener) cannot publish ingest audio.
+- Booth state is private to booth participants; there is no public viewer-facing API in this module.

--- a/docs/architecture/webrtc-ingest.md
+++ b/docs/architecture/webrtc-ingest.md
@@ -1,0 +1,199 @@
+# WebRTC Ingest
+
+This document describes the WebRTC ingest design: how the interpreter's microphone audio gets from the browser to the server-side aiortc endpoint, and how the SDP negotiation works.
+
+---
+
+## Overview
+
+The ingest path uses the standard WebRTC offer/answer exchange:
+
+1. **Browser** captures mic audio via `getUserMedia`.
+2. **Browser** creates a `RTCPeerConnection`, adds the audio track, and generates an SDP offer.
+3. **Browser** POSTs the offer to `POST /api/interpreter/connect/{channel_id}`.
+4. **Server** (`portal/ingest.py`) creates a server-side `aiortc.RTCPeerConnection`, sets the offer as the remote description, creates an answer, and returns it.
+5. **Browser** sets the answer as its remote description.
+6. ICE candidates embedded in the SDP allow the connection to establish.
+7. **RTP Opus stream** flows from browser to server.
+8. Server hands the audio to `aiortc.contrib.media.MediaRecorder` → FFmpeg → HLS.
+
+---
+
+## SDP offer construction (browser)
+
+`MicStreamingManager.createIngestConnection(onConnectionStateChange)`:
+
+```js
+this.peerConnection = new RTCPeerConnection({
+  iceServers: createIceServers(this.stunServers)   // from VITE_STUN_SERVERS env var
+})
+
+for (const track of this.stream.getAudioTracks()) {
+  this.peerConnection.addTrack(track, this.stream)
+}
+
+const offer = await this.peerConnection.createOffer({
+  offerToReceiveAudio: false,   // send-only
+  offerToReceiveVideo: false
+})
+
+await this.peerConnection.setLocalDescription(offer)
+await waitForIceGathering(this.peerConnection)   // 3 s timeout
+
+return this.peerConnection.localDescription
+```
+
+Key points:
+- The offer is audio-only and send-only.
+- ICE gathering runs for up to 3 seconds. Any candidates gathered are embedded in the SDP before it is sent (vanilla ICE / non-trickle). This avoids needing a separate ICE candidate signalling channel.
+- `offerToReceiveAudio: false` prevents the server from sending audio back to the browser (which would create a loopback risk).
+
+---
+
+## Ingest API endpoint
+
+`POST /api/interpreter/connect/{channel_id}`
+
+Request body (JSON):
+
+```json
+{
+  "type": "offer",
+  "sdp": "v=0\r\no=- ...",
+  "booth_id": "hall-a-fr",
+  "participant_id": "abc123",
+  "token": "optional-token",
+  "language": "French"
+}
+```
+
+Authorization checks (in order):
+
+1. `require_access_token(token)` — validates against `BOOTH_ACCESS_TOKEN` if set.
+2. `booths.is_active_interpreter(booth_id, participant_id, language, channel_id)` — only the active interpreter may publish.
+
+If either check fails, the endpoint returns `403`. The browser surfaces this as an ingest error.
+
+Response body (JSON):
+
+```json
+{
+  "type": "answer",
+  "sdp": "v=0\r\no=- ..."
+}
+```
+
+The browser also accepts a Janus-style wrapper `{ jsep: { type, sdp } }` for compatibility with Janus-based ingest backends (handled by `normalizeAnswerPayload` in `ingestClient.js`).
+
+---
+
+## Server-side SDP handling (aiortc)
+
+`IngestService._connect()` in `portal/ingest.py`:
+
+```python
+await peer_connection.setRemoteDescription(
+    RTCSessionDescription(sdp=offer_sdp, type=offer_type)
+)
+answer = await peer_connection.createAnswer()
+await peer_connection.setLocalDescription(answer)
+await self._wait_for_ice_completion(peer_connection)
+```
+
+After the connection is established:
+
+```python
+@peer_connection.on('track')
+async def on_track(track):
+    if track.kind != 'audio':
+        return
+    recorder.addTrack(track)
+    if not session.recorder_started:
+        await recorder.start()
+        session.recorder_started = True
+```
+
+The recorder is an `aiortc.contrib.media.MediaRecorder` pointed at the HLS output path. It uses FFmpeg under the hood to transcode the incoming Opus/RTP audio and segment it into HLS.
+
+---
+
+## Async runtime
+
+aiortc is an asyncio library. The Flask server uses threading (not asyncio). The `AsyncRuntime` class bridges these:
+
+```python
+class AsyncRuntime:
+    def __init__(self):
+        self.loop = asyncio.new_event_loop()
+        self.thread = Thread(target=self._run_forever, daemon=True)
+        self.thread.start()
+
+    def run(self, coroutine):
+        future = asyncio.run_coroutine_threadsafe(coroutine, self.loop)
+        return future.result()   # blocks the calling thread until done
+```
+
+All aiortc operations (`_connect`, `_disconnect`) run on this dedicated event loop. The Flask request thread blocks on `future.result()` during SDP negotiation (typically < 2 s).
+
+---
+
+## One session per channel
+
+The `IngestService.sessions` dict is keyed by `channel_id`. When a new offer arrives for a channel that already has an active session, the old session is disconnected first:
+
+```python
+async def _connect(self, *, channel_id, ...):
+    await self._disconnect(channel_id)   # clean up any existing session
+    ...
+```
+
+This ensures that when a coordinator performs a handoff and the new active interpreter goes live, the previous interpreter's ingest connection is terminated server-side.
+
+---
+
+## HLS output
+
+The `MediaRecorder` writes to `INGEST_HLS_ROOT/{channel_id}/playlist.m3u8`. FFmpeg creates the directory if it does not exist.
+
+HLS parameters (configurable via `.env`):
+
+| Variable | Default | Effect |
+|---|---|---|
+| `HLS_SEGMENT_SECONDS` | `2` | Target segment duration |
+| `HLS_PLAYLIST_LENGTH` | `8` | Number of segments in the live playlist |
+
+At 2 s segments with 8 in the playlist, the live edge latency is approximately 16 s. This can be tuned for lower latency (at the cost of increased segment overhead) or higher stability (at the cost of latency).
+
+---
+
+## STUN server configuration
+
+The default configuration does not require a TURN server for local development (browser and server are on the same machine or LAN). For production:
+
+- Configure `VITE_STUN_SERVERS` with a reliable STUN server list.
+- If the ingest server is behind a NAT that does not support hairpinning, a TURN server is required. Configure it alongside STUN in the `iceServers` array.
+
+The `createIceServers` helper in `micStreamingManager.js` maps the `VITE_STUN_SERVERS` array to the `RTCIceServer` format.
+
+---
+
+## Ingest availability flag
+
+`AIORTC_AVAILABLE` in `portal/ingest.py` reflects whether `aiortc` is importable. It is exposed via:
+
+- `GET /healthz` response: `{ "ok": true, "aiortc_available": true }`
+- `GET /api/interpreter/status/{channel_id}` response: `{ "reachable": true, "state": "..." }`
+- Template variable `aiortc_available` passed to the booth page
+
+When `AIORTC_AVAILABLE` is `False` (aiortc not installed), the ingest endpoint returns `503` and the Vue console shows an appropriate warning. All other booth features (monitoring, chat, participant grid) continue to work.
+
+---
+
+## Future: Janus ingest backend
+
+The `normalizeAnswerPayload` function in `ingestClient.js` already handles the Janus `jsep` wrapper format. Swapping the ingest backend from aiortc to a Janus WebRTC gateway requires only:
+
+1. Changing the `VITE_INGEST_BASE_URL` to point to the Janus endpoint.
+2. Ensuring the Janus room/plugin returns a compatible SDP answer (with or without the `jsep` wrapper).
+
+No changes to the browser-side WebRTC or SDP offer logic are needed.

--- a/docs/backend/backend-architecture.md
+++ b/docs/backend/backend-architecture.md
@@ -1,0 +1,264 @@
+# Backend Architecture
+
+The backend is a Flask application with Flask-SocketIO for realtime communication and aiortc for WebRTC ingest.
+
+---
+
+## Technology stack
+
+| Technology | Version | Role |
+|---|---|---|
+| Flask | 3.1.3 | HTTP server and route handling |
+| Flask-SocketIO | 5.6.1 | WebSocket/Socket.IO server |
+| aiortc | 1.14.0 | Server-side WebRTC peer connection |
+| av (PyAV) | 16.1.0 | FFmpeg bindings used by aiortc |
+| python-dotenv | 1.2.2 | `.env` file loading |
+| Python | 3.13.x | Runtime |
+| uv | — | Dependency management and venv |
+
+---
+
+## Module structure
+
+```
+app.py                   # Flask app, routes, Socket.IO handlers, access control
+portal/
+├── __init__.py
+├── config.py            # Settings dataclass loaded from env vars
+├── booth_state.py       # In-memory booth registry and state machine
+└── ingest.py            # aiortc ingest service and async runtime
+templates/
+├── base.html            # Page shell (Eventyay-style header)
+└── interpreter_booth.html  # Booth page (passes config to Vue)
+```
+
+---
+
+## `app.py` — Flask routes and Socket.IO handlers
+
+### HTTP routes
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/` | Redirect to `/interpreter/demo-booth` |
+| `GET` | `/healthz` | Health check; includes `aiortc_available` flag |
+| `GET` | `/interpreter/<booth_id>` | Render interpreter booth page |
+| `GET` | `/api/booth/<booth_id>/state` | Fetch current booth state snapshot |
+| `POST` | `/api/interpreter/connect/<channel_id>` | Accept WebRTC SDP offer; return answer |
+| `POST` | `/api/interpreter/disconnect/<channel_id>` | Disconnect ingest session |
+| `GET` | `/api/interpreter/status/<channel_id>` | Query ingest session state |
+
+### Socket.IO events (server receives)
+
+| Event | Payload | Purpose |
+|---|---|---|
+| `booth:join` | `{ booth_id, token, display_name, role, language, channel_id, participant_id }` | Join booth; creates participant |
+| `booth:leave` | `{ booth_id, participant_id, language, channel_id }` | Leave booth; remove participant |
+| `booth:chat` | `{ booth_id, sender_id, body, language, channel_id }` | Send chat message |
+| `booth:set-active` | `{ booth_id, requester_id, target_id, language, channel_id }` | Assign active interpreter |
+| `booth:update-state` | `{ booth_id, participant_id, mic_active, ingest_connected, connected, ... }` | Update participant state |
+| `disconnect` | — | Socket.IO disconnect; auto-leave booth |
+
+### Socket.IO events (server emits)
+
+| Event | Target | Payload |
+|---|---|---|
+| `booth:state` | All booth room members | Full booth state snapshot |
+| `booth:joined` | Connecting client only | `{ participant_id, state }` |
+| `booth:chat` | All booth room members | Chat message object |
+| `booth:error` | Connecting client only | `{ message }` |
+
+### Access control
+
+`require_access_token(token)` checks the token against `settings.booth_access_token`. If the token is set in the environment and the request/event does not provide a matching value, a `PermissionError` is raised and translated to a `403` HTTP response or a `booth:error` Socket.IO event.
+
+The ingest endpoint (`POST /api/interpreter/connect/{channel_id}`) additionally enforces that the requesting participant is the active interpreter for the channel via `booths.is_active_interpreter(...)`.
+
+### Room management
+
+Each booth has a Socket.IO room named `booth:{booth_id}`. All `booth:state` broadcasts are scoped to this room so participants only receive state for their booth.
+
+The `sid_index` dict maps Socket.IO session IDs to `{ booth_id, participant_id, language, channel_id }` to enable automatic leave-on-disconnect.
+
+---
+
+## `portal/booth_state.py` — BoothRegistry
+
+The `BoothRegistry` is the single source of truth for all booth state at runtime. It is a thread-safe in-memory registry using an `RLock`.
+
+### Data model
+
+```
+BoothRegistry
+└── _booths: dict[booth_id → Booth]
+
+Booth
+├── booth_id: str
+├── language: str
+├── channel_id: str
+├── active_interpreter_id: str | None
+├── handoff_state: 'idle' | 'pending' | 'completed'
+├── ingest_status: 'connected' | 'disconnected'
+├── participants: dict[participant_id → Participant]
+└── chat_messages: list[ChatMessage]  (capped at 500)
+
+Participant
+├── participant_id: str  (UUID hex)
+├── display_name: str
+├── role: 'interpreter' | 'coordinator' | 'listener'
+├── language: str
+├── channel_id: str
+├── mic_active: bool
+├── ingest_connected: bool
+├── connected: bool
+├── joined_at: ISO datetime string
+└── updated_at: ISO datetime string
+
+ChatMessage
+├── message_id: str  (UUID hex)
+├── sender_id: str
+├── sender_name: str
+├── body: str
+└── sent_at: ISO datetime string
+```
+
+### Key operations
+
+**`join_participant`**: Creates a `Participant` and adds it to the booth. If no active interpreter exists and the new participant is an interpreter, they automatically become active.
+
+**`leave_participant`**: Removes the participant. If the leaving participant was the active interpreter, the next available interpreter in the roster is promoted (FCFS). `handoff_state` is set to `'pending'` if a replacement is found.
+
+**`set_active_interpreter`**: Reassigns the active role. Enforces that:
+- The requester is a coordinator, the current active interpreter, or is assigning themselves.
+- The target has the `interpreter` role.
+- Clears `mic_active` and `ingest_connected` for all non-target participants.
+
+**`update_participant_state`**: Updates individual participant flags. Enforces that only the active interpreter can set `mic_active=True` or `ingest_connected=True`.
+
+**`add_chat_message`**: Appends a message. Enforces that the sender is registered in the booth and the message body is non-empty. Trims history to the last 500 messages.
+
+---
+
+## `portal/ingest.py` — IngestService
+
+Manages server-side WebRTC peer connections using aiortc.
+
+### AsyncRuntime
+
+aiortc is asyncio-based. Flask uses threading. `AsyncRuntime` runs a dedicated asyncio event loop on a daemon thread:
+
+```python
+class AsyncRuntime:
+    def __init__(self):
+        self.loop = asyncio.new_event_loop()
+        self.thread = Thread(target=self._run_forever, daemon=True)
+        self.thread.start()
+
+    def run(self, coroutine):
+        future = asyncio.run_coroutine_threadsafe(coroutine, self.loop)
+        return future.result()   # blocks calling thread
+```
+
+All Flask request handlers call `ingest.connect(...)` or `ingest.disconnect(...)` which dispatch to this runtime and block until the result is available.
+
+### IngestSession
+
+```python
+@dataclass
+class IngestSession:
+    channel_id: str
+    booth_id: str
+    participant_id: str
+    peer_connection: RTCPeerConnection
+    recorder: MediaRecorder
+    connection_state: str = 'new'
+    recorder_started: bool = False
+```
+
+Sessions are keyed by `channel_id` in `IngestService.sessions`.
+
+### Connect sequence
+
+1. Disconnect any existing session for the channel.
+2. Create a new `RTCPeerConnection`.
+3. Create a `MediaRecorder` pointed at `{INGEST_HLS_ROOT}/{channel_id}/playlist.m3u8`.
+4. Register `connectionstatechange` handler — tears down on `failed`/`closed`.
+5. Register `track` handler — adds audio tracks to the recorder and starts it.
+6. `setRemoteDescription(offer)` → `createAnswer()` → `setLocalDescription(answer)`.
+7. Wait for ICE gathering.
+8. Store session; return `{ type, sdp }` answer.
+
+### Disconnect sequence
+
+1. Stop the recorder if started.
+2. Close the peer connection.
+3. Remove session from `sessions` dict.
+
+### Graceful shutdown
+
+`@atexit.register close_ingest()` calls `ingest.shutdown()`, which stops all active sessions and shuts down the async runtime thread.
+
+---
+
+## `portal/config.py` — Settings
+
+A frozen dataclass loaded from environment variables via `python-dotenv`. All settings have safe development defaults.
+
+```python
+@dataclass(frozen=True)
+class Settings:
+    host: str
+    port: int
+    debug: bool
+    secret_key: str
+    booth_access_token: str
+    socket_cors_origins: list[str] | str
+    default_jitsi_room: str
+    jitsi_domain: str
+    ingest_hls_root: Path
+    hls_segment_seconds: int
+    hls_playlist_length: int
+```
+
+`settings` is a module-level singleton created at import time. It is injected into `IngestService` at startup.
+
+---
+
+## Templates
+
+### `templates/base.html`
+
+Provides the Eventyay-style page shell: meta tags, CSS imports, and a `{% block content %}` for the booth page.
+
+### `templates/interpreter_booth.html`
+
+Extends `base.html`. Renders a `<div id="app">` where Vue mounts. Passes server-side config to Vue via `<script>` data attributes or a JSON config object:
+
+- `booth_id`, `booth_token`, `booth_language`, `booth_channel_id`
+- `default_jitsi_room`, `jitsi_domain`
+- `aiortc_available`
+
+---
+
+## Production considerations
+
+### In-memory state
+
+`BoothRegistry` stores all state in a Python dict. This means:
+
+- Booth state is lost on server restart.
+- Multi-worker deployments (Gunicorn with multiple processes) will have separate state per worker — participants in different workers will not see each other.
+
+**Production fix:** Add PostgreSQL persistence for `Booth` and `Participant` records, and use Redis as the Flask-SocketIO message queue (`socketio = SocketIO(app, message_queue='redis://...')`).
+
+### Secret key
+
+`SECRET_KEY` must be changed in production and kept secret. It is used for Flask session signing.
+
+### CORS
+
+`BOOTH_WS_CORS_ORIGINS` defaults to `*` (development). In production, set it to the explicit Eventyay origin(s).
+
+### HTTPS
+
+The browser will not grant microphone access on non-HTTPS origins (except `localhost`). Production deployments must use HTTPS.

--- a/docs/context/project-context.md
+++ b/docs/context/project-context.md
@@ -1,0 +1,105 @@
+# Project Context
+
+## What is the Eventyay Interpretation Portal?
+
+The Eventyay Interpretation Portal is a browser-based subsystem of the Eventyay live event platform that enables human simultaneous interpreters to broadcast their translations to viewers in real time.
+
+It is modelled on the real-world interpretation workflow at multilingual conferences (UN, EU Parliament, large international events) but eliminates the hardware and specialist knowledge requirements. An interpreter needs only:
+
+- a laptop or desktop with a modern browser
+- a headset with microphone
+- the tokenized booth URL from the event organizer
+
+There is no OBS, no RTMP, no hardware encoder, no sound card routing. Everything runs in one browser tab.
+
+---
+
+## Background and motivation
+
+Traditional conference interpretation requires:
+
+- Physical glass booths with relay consoles
+- Professional hardware (Bosch, Televic, or similar interpreter desks)
+- Trained audio engineers for mix-minus routing
+- Proprietary software for remote interpretation (Interprefy, KUDO, etc.)
+
+For community-run, volunteer-driven, and open-source events (such as those hosted on Eventyay), these options are either cost-prohibitive or logistically impossible. The Interpretation Portal aims to provide a viable, self-hosted alternative that integrates natively with Eventyay's existing video infrastructure.
+
+---
+
+## Design philosophy
+
+**Interpreter-centric.** The portal is designed from the interpreter's point of view. The entire workflow — monitoring the session, coordinating with colleagues, testing the mic, and going live — happens in one browser tab.
+
+**Separation of monitoring and ingest.** Jitsi handles the monitoring path (what the interpreter hears and sees). The WebRTC ingest handles the audio uplink. These two paths are deliberately kept separate so that Jitsi is never the bottleneck for broadcast quality.
+
+**Operational safety over features.** The portal enforces a preflight checklist before allowing an interpreter to go live. Headphone use is a hard operational requirement to prevent acoustic echo.
+
+**No single point of failure for viewers.** If the ingest connection drops, the viewer side falls back to the original floor audio while the interpreter reconnects.
+
+---
+
+## Current phase: Interpreter Console MVP
+
+The current implementation covers:
+
+- Single-tab interpreter console (Vue 3 + Flask)
+- Jitsi embedded monitoring panel (receive-only iframe)
+- Mic capture with DSP flags (echo cancellation, noise suppression, AGC)
+- Level meter for mic test
+- Preflight checklist gating Go Live
+- WebRTC offer/answer flow to the ingest API
+- Booth participant grid (active, backup, coordinator, listener)
+- Internal booth chat (Socket.IO)
+- Coordinator handoff controls
+- In-memory booth state (server-side)
+
+**Not yet in scope (future phases):**
+
+- Production ingest server deployment (aiortc endpoint at scale)
+- PostgreSQL persistence for booth/session records
+- Redis-backed Socket.IO for multi-worker deployments
+- CDN delivery of HLS segments
+- Relay interpretation (interpreter-to-interpreter language chain)
+- Sign language video channel support
+- Organizer UI for managing interpretation channels
+
+---
+
+## How it fits into the Eventyay ecosystem
+
+```
+Eventyay core (Django app)
+  │
+  ├── Event stage page
+  │     ├── YouTube video embed (master clock)
+  │     └── HLS language audio player (drift-corrected)
+  │
+  └── Interpretation Portal (this repo)
+        ├── Flask + Socket.IO server
+        ├── Vue 3 interpreter console
+        └── aiortc ingest endpoint → FFmpeg → HLS output
+```
+
+The portal feeds language-specific HLS streams to the Eventyay viewer. It does not modify or replace the YouTube video path. Viewer-side synchronization is handled by a drift-correction loop in the Eventyay video module.
+
+---
+
+## Key stakeholders
+
+| Stakeholder | Interaction with this system |
+|---|---|
+| **Interpreter** | Opens booth URL; monitors floor via Jitsi; broadcasts translation via WebRTC |
+| **Coordinator** | Supervises booth; manages handoffs; uses internal chat |
+| **Event organizer** | Generates tokenized booth URLs; configures language channels |
+| **Viewer** | Selects language on the Eventyay stage page; receives HLS audio |
+| **Eventyay infrastructure** | Receives HLS segments from this portal's FFmpeg output |
+
+---
+
+## Non-goals
+
+- The portal does not host or manage the Jitsi server. It embeds a Jitsi room via iframe.
+- The portal does not deliver video to viewers. It delivers audio-only HLS.
+- The portal does not replace Eventyay's main event management or ticketing surfaces.
+- The portal does not support browser-based OBS or canvas mixing.

--- a/docs/frontend/frontend-architecture.md
+++ b/docs/frontend/frontend-architecture.md
@@ -1,0 +1,275 @@
+# Frontend Architecture
+
+The frontend is a Vue 3 single-page application built with Vite. It is served from Flask in production and from the Vite dev server during development.
+
+---
+
+## Technology stack
+
+| Technology | Version | Role |
+|---|---|---|
+| Vue 3 | 3.x | Component framework (Composition API) |
+| Vite | 5.x | Build tool and dev server |
+| Vue Router | 4.x | Client-side routing |
+| Socket.IO client | 4.x | Realtime booth communication |
+| WebRTC (native browser API) | — | Microphone ingest |
+| Web Audio API (native) | — | Level meter |
+| BroadcastChannel API (native) | — | Cross-tab coordination |
+
+There is no global state management library (no Pinia, no Vuex). All shared state lives in the `useInterpreterBooth` composable.
+
+---
+
+## Directory structure
+
+```
+src/
+├── App.vue                          # Root component; renders <RouterView>
+├── main.js                          # App bootstrap; creates Vue app and mounts
+├── config/
+│   └── env.js                       # Environment variable access (VITE_* vars)
+├── router/
+│   └── index.js                     # Route definitions
+├── views/
+│   └── InterpreterConsoleView.vue   # The single console view
+├── composables/
+│   └── useInterpreterBooth.js       # Central state machine and event wiring
+├── services/
+│   ├── ingestClient.js              # WebRTC SDP negotiation
+│   ├── micStreamingManager.js       # getUserMedia, level meter, peer connection
+│   ├── jitsiEmbed.js                # Jitsi URL parsing and embed URL construction
+│   └── boothRealtime.js             # Socket.IO + BroadcastChannel transport
+├── components/
+│   ├── JitsiMonitorPanel.vue        # Jitsi iframe embed and join controls
+│   ├── MicIngestPanel.vue           # Device selector, level meter, Go Live / Stop
+│   ├── PreflightChecklist.vue       # Checklist gating Go Live
+│   ├── ParticipantGrid.vue          # Booth participant list
+│   ├── BoothChatPanel.vue           # Internal booth chat
+│   ├── BoothHealthPanel.vue         # Live ingest health
+│   └── common/                      # Shared UI primitives
+└── styles/
+    └── main.css                     # Global CSS and CSS custom properties
+```
+
+---
+
+## Routing
+
+The console has a single route:
+
+```
+/interpreter/:eventSlug/:boothId
+```
+
+Route params are read by `InterpreterConsoleView` on mount and passed to `useInterpreterBooth.initialize({ eventSlug, boothId })`.
+
+A redirect from `/` to a default booth URL is handled by Flask, not the Vue router.
+
+---
+
+## `useInterpreterBooth` composable
+
+This is the central state machine for the interpreter console. It owns:
+
+- `state` — reactive object containing all UI state (session metadata, Jitsi status, mic status, ingest status, preflight flags, participant list, chat messages)
+- `health` — computed object derived from `state` for the health panel
+- All actions: `initialize`, `teardown`, `joinJitsi`, `setAudioDevice`, `runMicTest`, `startInterpretation`, `stopInterpretation`, `setActiveInterpreter`, `toggleChecklistItem`, `sendBoothChatMessage`
+
+The composable creates and manages three service instances:
+
+| Service | Purpose |
+|---|---|
+| `IngestClient` | POST SDP offer to the ingest API |
+| `MicStreamingManager` | Manage getUserMedia stream and peer connection |
+| `BoothRealtimeClient` | Manage Socket.IO and BroadcastChannel connections |
+
+### State shape
+
+```js
+state = reactive({
+  initialized: false,
+  localParticipantId: String,
+  localRole: String,
+  session: {
+    eventSlug, boothId, language, channelId
+  },
+  jitsi: {
+    inputUrl, embedUrl, roomName, status, error
+  },
+  mic: {
+    status,          // 'idle' | 'testing' | 'ready' | 'error'
+    level,           // 0–1 float
+    devices,         // MediaDeviceInfo[]
+    selectedDeviceId
+  },
+  ingest: {
+    status,          // 'disconnected' | 'connecting' | 'connected' | 'error'
+    connectionState, // RTCPeerConnection.connectionState
+    reconnecting,
+    retries,
+    streamingLive,
+    bitrateKbps,
+    error
+  },
+  preflight: {
+    headphonesConnected,
+    monitoringActive,
+    micTestComplete,
+    ingestReachable
+  },
+  participants: Participant[],
+  activeParticipantId: String,
+  chatMessages: ChatMessage[]
+})
+```
+
+### Preflight gate
+
+The **Go Live** button is disabled until all four preflight items are satisfied:
+
+- `headphonesConnected` — manually checked by interpreter
+- `monitoringActive` — set when Jitsi iframe loads successfully
+- `micTestComplete` — set after mic test level is confirmed
+- `ingestReachable` — set after `IngestClient.checkReachable()` returns true
+
+---
+
+## Service layer
+
+### `IngestClient`
+
+Handles the HTTP layer for WebRTC ingest:
+
+- `checkReachable(channelId)` — OPTIONS request to verify the ingest endpoint is up
+- `negotiate(channelId, localDescription)` — POST SDP offer, receive SDP answer
+
+Constructed with `{ baseUrl, authToken }` from `env.ingestBaseUrl` and `env.ingestAuthToken`.
+
+### `MicStreamingManager`
+
+Manages the browser audio pipeline:
+
+- `listInputDevices()` — enumerates audioinput devices
+- `startMicrophone(deviceId, onLevel)` — getUserMedia + level meter
+- `createIngestConnection(onConnectionStateChange)` — creates RTCPeerConnection, adds track, creates offer, gathers ICE, returns local description
+- `applyRemoteAnswer(answer)` — sets remote description on the peer connection
+- `collectStats(onStats)` — polls getStats() for bitrate
+- `stopMeter()` — cancels animation frame loop
+- `stopTracks()` — stops all MediaStreamTrack instances
+- `stopPeerConnection()` — closes RTCPeerConnection
+
+### `buildJitsiEmbedUrl` / `parseJitsiMeetingUrl`
+
+Pure functions for Jitsi URL handling. No side effects.
+
+### `BoothRealtimeClient`
+
+Manages two realtime transports:
+
+1. **BroadcastChannel** — for cross-tab coordination within the same browser origin
+2. **WebSocket** — for multi-machine coordination (optional; requires `VITE_BOOTH_WS_URL`)
+
+Both transports deliver event envelopes of the shape:
+
+```js
+{
+  eventType: 'booth-chat' | 'active-interpreter' | 'participant-state',
+  payload: { ... },
+  sentAt: timestamp
+}
+```
+
+Chat messages are also persisted to `localStorage` so they survive page refreshes.
+
+---
+
+## Component responsibilities
+
+### `InterpreterConsoleView`
+
+Top-level layout using CSS Grid:
+
+```
+grid-template-rows: topbar | console-layout | participant-grid | chat-panel
+```
+
+The `console-layout` row uses a two-column grid:
+- Left: `JitsiMonitorPanel` (2fr)
+- Right: sidebar (`MicIngestPanel` + `PreflightChecklist` + `BoothHealthPanel`) (1fr, min 300px)
+
+Below 1080px viewport width, the layout collapses to a single column.
+
+### `JitsiMonitorPanel`
+
+- Renders a URL input pre-filled with `state.jitsi.inputUrl`
+- Emits `join` when the interpreter clicks Join
+- Renders the Jitsi `<iframe>` once `state.jitsi.embedUrl` is set
+- Emits `loaded` when the iframe fires `load`
+
+### `MicIngestPanel`
+
+- Renders a `<select>` for audio device selection
+- Renders a level meter bar driven by `state.mic.level`
+- Renders **Test Mic**, **Go Live**, and **Stop** buttons
+- The Go Live button is disabled unless all preflight items are complete and the local participant is the active interpreter
+- Emits `set-device`, `mic-test`, `start`, `stop`
+
+### `PreflightChecklist`
+
+- Renders four checkbox items from `state.preflight`
+- `headphonesConnected` is manually toggled by the interpreter
+- `monitoringActive`, `micTestComplete`, `ingestReachable` are set programmatically
+- Emits `toggle` for items that can be manually toggled
+
+### `ParticipantGrid`
+
+- Renders a card for each participant in `state.participants`
+- Shows role badge, connection state, mic state, and ingest state
+- Shows a **Set Live** button on non-active interpreter cards (visible to coordinator or active interpreter)
+- Emits `set-live` with the target participant ID
+
+### `BoothChatPanel`
+
+- Renders a scrollable message list
+- Auto-scrolls to the newest message
+- Renders a text input for sending new messages
+- Emits `send` with the message body
+
+### `BoothHealthPanel`
+
+- Renders ingest status (connected/disconnected/reconnecting)
+- Renders live streaming indicator
+- Renders active interpreter name
+- Renders bitrate and packet health (healthy / degraded / idle)
+
+---
+
+## Environment variables (Vite)
+
+Set in `.env` with the `VITE_` prefix:
+
+| Variable | Default | Description |
+|---|---|---|
+| `VITE_INGEST_BASE_URL` | `http://127.0.0.1:5000` | Base URL of the ingest API |
+| `VITE_INGEST_AUTH_TOKEN` | _(empty)_ | Bearer token for ingest API auth |
+| `VITE_BOOTH_WS_URL` | _(empty)_ | WebSocket URL for booth realtime (optional) |
+| `VITE_STUN_SERVERS` | `stun:stun.l.google.com:19302` | STUN server(s) for ICE |
+| `VITE_JITSI_DOMAIN` | `meet.jit.si` | Expected Jitsi domain for URL validation |
+| `VITE_DEFAULT_JITSI_URL` | `https://meet.jit.si/eventyay-stage-room` | Default monitoring room |
+| `VITE_DEFAULT_EVENT_SLUG` | `demo-event` | Default event slug for dev |
+| `VITE_DEFAULT_BOOTH_ID` | `demo-booth` | Default booth ID for dev |
+| `VITE_DEFAULT_LANGUAGE` | `English` | Default language label |
+| `VITE_DEFAULT_CHANNEL_ID` | `demo-booth-audio` | Default channel ID |
+
+---
+
+## Build
+
+```bash
+npm install
+npm run build    # outputs to static/dist/
+```
+
+The Vite build output is served by Flask as static files. The Flask template (`templates/interpreter_booth.html`) includes the Vite manifest entry point.
+
+For development, run both the Flask server and the Vite dev server in parallel. The Vite dev server proxies API requests to Flask.

--- a/docs/phases/implementation-roadmap.md
+++ b/docs/phases/implementation-roadmap.md
@@ -1,0 +1,156 @@
+# Implementation Roadmap
+
+This document tracks what has been built, what is in progress, and what is planned for future phases.
+
+---
+
+## Current phase: Interpreter Console MVP
+
+**Status:** In progress
+
+The goal of the MVP is a fully functional single-tab interpreter console that allows an interpreter to:
+
+- Monitor the floor session via Jitsi
+- Test their microphone locally (level meter, device selection)
+- Complete a preflight checklist before going live
+- Go live with one click (WebRTC → ingest API)
+- Coordinate with booth colleagues (participant grid, internal chat, handoff)
+
+### What is done
+
+- [x] Vue 3 interpreter console (single-tab layout)
+- [x] Jitsi iframe monitoring panel (receive-only embed)
+- [x] Mic capture via `getUserMedia` with DSP flags
+- [x] Level meter (Web Audio API analyser, no loopback)
+- [x] Device selector for audio input
+- [x] Preflight checklist (4 items gating Go Live)
+- [x] WebRTC SDP offer/answer flow (`IngestClient`)
+- [x] `MicStreamingManager` (getUserMedia, peer connection, ICE gathering, stats)
+- [x] Booth participant grid (active/backup/coordinator/listener with state badges)
+- [x] Internal booth chat (Socket.IO)
+- [x] Coordinator handoff controls (Set Live button in participant grid)
+- [x] `BoothRealtimeClient` (Socket.IO + BroadcastChannel)
+- [x] Flask + Socket.IO server with in-memory booth state
+- [x] `BoothRegistry` with role enforcement and handoff policy
+- [x] `IngestService` with aiortc peer connection and async runtime
+- [x] Access token for booth URL security
+- [x] Auto-reconnect on WebRTC disconnection
+- [x] `GET /healthz` with `aiortc_available` flag
+- [x] Graceful degradation when aiortc is unavailable
+- [x] Unit tests for booth state and Flask routes
+
+### What is remaining for MVP completion
+
+- [ ] Vite build integrated with Flask static file serving (production build flow)
+- [ ] Vue component unit tests (Vitest)
+- [ ] End-to-end test with real mic in CI
+- [ ] Production deployment instructions
+
+---
+
+## Phase 2: Production ingest infrastructure
+
+**Status:** Not started
+
+The current aiortc ingest is suitable for development and small-scale testing. Phase 2 replaces or augments it with production-grade ingest infrastructure.
+
+### Goals
+
+- Handle multiple simultaneous interpreters across multiple language channels
+- Reliable HLS delivery at medium event scale (hundreds of concurrent viewers per language)
+- Ingest server monitoring and alerting
+
+### Planned work
+
+- [ ] Evaluate Janus WebRTC gateway as an alternative ingest backend
+  - `normalizeAnswerPayload` in `ingestClient.js` already supports the Janus `jsep` response format
+  - Janus has better NAT traversal and TURN integration than raw aiortc
+- [ ] Deploy aiortc endpoint behind a reverse proxy (nginx)
+- [ ] Configure TURN server for NAT traversal
+- [ ] Benchmark aiortc with 4–8 simultaneous interpreter channels
+- [ ] Move FFmpeg to a dedicated transcode/packaging service
+- [ ] CDN integration for HLS delivery (S3 + CloudFront, or equivalent)
+- [ ] HLS latency tuning (Low-Latency HLS if required)
+
+---
+
+## Phase 3: Persistent booth state
+
+**Status:** Not started
+
+### Goals
+
+- Booth state survives server restarts
+- Multi-worker deployments work correctly
+- Session history is auditable
+
+### Planned work
+
+- [ ] PostgreSQL models for `Booth`, `Participant`, `ChatMessage`, `IngestSession`
+- [ ] SQLAlchemy or Django ORM integration (if merging into main Eventyay Django app)
+- [ ] Redis adapter for Flask-SocketIO (`message_queue='redis://...'`)
+- [ ] Migration from in-memory `BoothRegistry` to DB-backed registry
+- [ ] Session replay / chat history API for organizer review
+
+---
+
+## Phase 4: Eventyay core integration
+
+**Status:** Not started
+
+### Goals
+
+- Booth URLs are generated from within the Eventyay event management UI
+- Language channels are configured per event/session in Eventyay
+- Viewer language selection is managed by the Eventyay stage page
+- Authentication uses Eventyay user accounts rather than one-time tokens
+
+### Planned work
+
+- [ ] Eventyay Django app: `InterpretationChannel` model (language, channel_id, event, session)
+- [ ] Eventyay organizer UI: configure interpretation channels per session
+- [ ] Eventyay organizer UI: generate and revoke booth invite tokens
+- [ ] Eventyay stage page: language audio selector wired to interpretation HLS streams
+- [ ] Drift-correction HLS player integrated into the Eventyay video module
+- [ ] SSO: interpreter login with Eventyay account (remove separate token auth)
+
+---
+
+## Phase 5: Advanced booth features
+
+**Status:** Planned
+
+### Relay interpretation
+
+Relay interpretation is used when no interpreter can translate directly from the source language. A relay chain is: source language → relay language → target language.
+
+Example: Turkish speaker → English relay interpreter → French final interpreter.
+
+Planned:
+- [ ] Booth can subscribe to another channel's HLS stream as their "floor" audio instead of Jitsi
+- [ ] Relay chain configuration in the organizer UI
+- [ ] Latency management for relay chains (relay adds ~15–30 s)
+
+### Sign language video channels
+
+- [ ] Video ingest path (not just audio)
+- [ ] Interpreter camera capture via `getUserMedia` video track
+- [ ] Video-over-WebRTC to ingest endpoint
+- [ ] HLS video stream for sign language channels
+
+### Interpreter analytics
+
+- [ ] Speaking time per interpreter per session
+- [ ] Handoff event log
+- [ ] Ingest quality metrics (bitrate, packet loss, jitter)
+- [ ] Post-event report for organizers
+
+---
+
+## Design principles that must not change across phases
+
+1. **Single-tab interpreter workflow.** No matter how complex the backend becomes, the interpreter console must remain a single browser tab.
+2. **Separation of monitoring and ingest.** Jitsi is monitoring. WebRTC/HLS is broadcast. They must never be the same path.
+3. **One active publisher per language channel.** This rule is enforced server-side and must never be relaxed.
+4. **No local audio loopback.** The interpreter must never hear their own interpretation audio through the browser.
+5. **Graceful degradation.** If ingest is unavailable, monitoring and coordination still work.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -1,0 +1,225 @@
+# Local Development Setup
+
+This guide covers everything needed to run the interpretation portal locally, including troubleshooting for common environment issues.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|---|---|---|
+| `uv` | 0.9+ | Python package manager. [Install guide](https://docs.astral.sh/uv/getting-started/installation/) |
+| Python | 3.13.x | Managed by `uv`; do not use system Python or Conda |
+| Node.js | 18+ | For the Vue frontend build |
+| npm | 9+ | Comes with Node.js |
+| A headset | — | Required for testing mic ingest without echo |
+
+A system `ffmpeg` binary is useful for inspecting HLS output manually but is **not required** for dependency installation or running the backend. aiortc uses PyAV (prebuilt wheel) which bundles its own FFmpeg libraries.
+
+---
+
+## Backend setup
+
+### 1. Clone and enter the directory
+
+```bash
+git clone <repo-url>
+cd eventyay-interpretation-portal
+```
+
+### 2. Copy and review the environment file
+
+```bash
+cp .env.example .env
+```
+
+Review `.env`. The defaults work for local development. Change `SECRET_KEY` if you plan to run tests with real sessions.
+
+### 3. Install Python dependencies
+
+```bash
+uv sync --python 3.13 --dev
+```
+
+This creates `.venv/` and installs all pinned dependencies from `uv.lock`. It uses a prebuilt `av` wheel and does not require building from source.
+
+### 4. Verify the environment
+
+```bash
+uv run python -c "import aiortc, av; print('aiortc', aiortc.__version__, 'av', av.__version__)"
+```
+
+Expected output: `aiortc 1.14.0 av 16.1.0`
+
+### 5. Run the server
+
+```bash
+uv run python app.py
+```
+
+The server starts at `http://127.0.0.1:5000`.
+
+### 6. Verify the health endpoint
+
+```bash
+curl http://127.0.0.1:5000/healthz
+# Expected: {"aiortc_available": true, "ok": true}
+```
+
+---
+
+## Frontend setup
+
+### 1. Install Node dependencies
+
+```bash
+npm install
+```
+
+### 2. Run the Vite dev server
+
+```bash
+npm run dev
+```
+
+Vite starts at `http://localhost:5173`. API requests are proxied to Flask at `http://127.0.0.1:5000`.
+
+### 3. Build for production
+
+```bash
+npm run build
+```
+
+Output goes to `static/dist/`. Flask serves this in production.
+
+---
+
+## Opening a booth
+
+With both servers running:
+
+```
+http://127.0.0.1:5000/interpreter/hall-a-fr?language=French
+```
+
+Or via the Vite dev server:
+
+```
+http://localhost:5173/interpreter/demo-event/hall-a-fr
+```
+
+To test multi-user booth behaviour, open multiple tabs:
+- Tab 1: `?role=interpreter` (defaults to interpreter, becomes active automatically)
+- Tab 2: `?role=interpreter` (joins as backup)
+- Tab 3: `?role=coordinator`
+
+---
+
+## Running tests
+
+```bash
+uv run pytest
+```
+
+Tests are in `tests/`. They cover:
+
+- `test_app.py` — Flask routes and Socket.IO event handlers
+- `test_booth_state.py` — `BoothRegistry` state machine
+
+Tests run without a browser. Ingest tests are skipped if aiortc is unavailable.
+
+To run with verbose output:
+
+```bash
+uv run pytest -v
+```
+
+---
+
+## Environment variable reference
+
+All variables are loaded from `.env` by `portal/config.py` via `python-dotenv`.
+
+| Variable | Default | Description |
+|---|---|---|
+| `HOST` | `127.0.0.1` | Bind address. Use `0.0.0.0` for LAN access. |
+| `PORT` | `5000` | Flask/Socket.IO port. |
+| `FLASK_DEBUG` | `1` | Flask debug mode (auto-reload, error pages). |
+| `SECRET_KEY` | `change-me` | Flask session signing key. **Change in production.** |
+| `BOOTH_ACCESS_TOKEN` | _(empty)_ | If set, all API calls and Socket.IO events must include this token. |
+| `BOOTH_WS_CORS_ORIGINS` | `*` | Allowed Socket.IO origins. Set to your origin in production. |
+| `DEFAULT_JITSI_ROOM` | `https://meet.jit.si/eventyay-stage-room` | Pre-filled Jitsi URL. |
+| `JITSI_DOMAIN` | `meet.jit.si` | Domain validation for Jitsi embed URLs. |
+| `INGEST_HLS_ROOT` | `./hls-output` | Directory for FFmpeg HLS output. Created automatically. |
+| `HLS_SEGMENT_SECONDS` | `2` | HLS segment duration. |
+| `HLS_PLAYLIST_LENGTH` | `8` | Live playlist segment count. |
+
+---
+
+## Troubleshooting
+
+### `uv sync` resolves to Python 3.14
+
+```bash
+uv sync --python 3.13 --dev
+```
+
+Confirm `.python-version` is present in the repo root and contains `3.13`.
+
+### `av` tries to compile from source
+
+1. Delete `.venv` and retry: `rm -rf .venv && uv sync --python 3.13 --dev`
+2. Confirm you are on Python 3.13, not 3.14.
+3. Do not modify `uv.lock` without revalidating the media stack.
+
+### `aiortc_available` is `False`
+
+```bash
+uv run python -c "import aiortc, av; print(aiortc.__version__, av.__version__)"
+```
+
+If this fails with `ImportError`, the virtual environment is broken. Delete `.venv` and re-run `uv sync`.
+
+### Browser mic test shows no level
+
+1. Check that the browser has microphone permissions for `localhost` / `127.0.0.1`.
+2. Confirm the correct device is selected in the device dropdown.
+3. Check the browser console for `getUserMedia` errors.
+
+### Go Live button is disabled
+
+All four preflight items must be checked:
+1. Headphones: manually click the checkbox.
+2. Monitoring: the Jitsi iframe must have loaded (click **Join Monitor Room** first).
+3. Mic test: click **Test Mic** and confirm level.
+4. Ingest reachable: the server must be running at the configured `VITE_INGEST_BASE_URL`.
+
+### WebRTC connection fails
+
+1. On `localhost`, STUN is not required — ICE host candidates should suffice.
+2. Inspect `/api/interpreter/status/{channel_id}` for the server-side session state.
+3. Check the browser console for `RTCPeerConnection` errors.
+4. If on a corporate network with strict firewall rules, a TURN server may be needed. Configure `VITE_STUN_SERVERS` with your TURN server.
+
+### HLS output not appearing
+
+1. Confirm `INGEST_HLS_ROOT` directory exists or is writable.
+2. Check that aiortc successfully started the recorder — look for errors in the Flask console.
+3. The recorder starts only after a WebRTC connection is established and the first audio track arrives.
+
+### Flask restarts wipe booth state
+
+This is expected. Booth state is in-memory. Restart Flask and all browser tabs will need to rejoin. In production, add PostgreSQL persistence.
+
+---
+
+## macOS notes
+
+- Install `uv` via Homebrew: `brew install uv` or via the official installer.
+- If you have multiple Python installations (pyenv, Conda, system), `uv` manages its own Python. Do not use `python3` directly.
+- Homebrew `ffmpeg` is useful for inspecting HLS playlists but is not required for development.
+
+## Linux notes
+
+- `uv sync --python 3.13 --dev` should install the locked wheel set on x86_64 and aarch64 Linux.
+- If `uv` falls back to building `av` from source, treat this as an environment problem. Confirm you are using the locked Python version.

--- a/docs/specifications/booth-collaboration-spec.md
+++ b/docs/specifications/booth-collaboration-spec.md
@@ -1,0 +1,199 @@
+# Booth Collaboration Specification
+
+This document defines the rules for booth participation: roles, active interpreter assignment, handoff protocol, and internal chat.
+
+---
+
+## Roles
+
+Each participant in a booth has exactly one role, set at join time.
+
+| Role | Can publish ingest audio | Can reassign active role | Can use booth chat |
+|---|---|---|---|
+| **Active Interpreter** | Yes — exclusively | Yes (can hand off to backup) | Yes |
+| **Backup Interpreter** | No — standby only | No (can request; coordinator approves) | Yes |
+| **Coordinator** | No | Yes — full authority | Yes |
+| **Listener** | No | No | Yes (read-only by convention) |
+
+Roles are set via the `role` parameter in the `booth:join` Socket.IO event. The server validates the role against allowed values `['interpreter', 'coordinator', 'listener']`.
+
+---
+
+## Active interpreter enforcement
+
+At any point in time, there is **at most one active interpreter** per booth (per language channel).
+
+### Auto-assignment on join
+
+When the first interpreter joins a booth, they are automatically set as the active interpreter:
+
+```python
+if participant.role == 'interpreter' and booth.active_interpreter_id is None:
+    booth.active_interpreter_id = participant.participant_id
+```
+
+Subsequent interpreters join as backup (standby) regardless of join order.
+
+### Manual assignment
+
+The active role can be reassigned via the `booth:set-active` Socket.IO event. Authorization rules:
+
+1. A **coordinator** can reassign active from any participant to any interpreter.
+2. The **current active interpreter** can hand off to any other interpreter (self-initiated handoff).
+3. An interpreter can assign themselves active if no other active interpreter is set.
+4. **No other combinations are permitted** — backup interpreters cannot promote themselves without coordinator or active interpreter approval.
+
+Server enforcement (`BoothRegistry.set_active_interpreter`):
+
+```python
+requester_is_coordinator = requester.role == 'coordinator'
+requester_is_active_interpreter = booth.active_interpreter_id == requester_id
+requester_is_target = requester_id == target_id
+
+if not (requester_is_coordinator or requester_is_active_interpreter or requester_is_target):
+    raise PermissionError(...)
+```
+
+### Side effects of reassignment
+
+When the active interpreter changes:
+
+1. `booth.active_interpreter_id` is updated.
+2. All participants' `mic_active` and `ingest_connected` flags are cleared except for the new active interpreter (who retains their existing state).
+3. `booth.ingest_status` is recomputed.
+4. If a previous active interpreter had an open ingest session, `ingest.disconnect(channel_id)` is called to terminate it server-side.
+5. The updated state is broadcast to all booth participants via `booth:state`.
+
+---
+
+## Handoff protocol
+
+A handoff is the process of transferring the active interpreter role from one person to another.
+
+### Planned handoff (coordinator-initiated)
+
+1. Coordinator identifies that rotation is needed (time, fatigue, terminology preference).
+2. Coordinator selects the backup interpreter in the participant grid and clicks **Set Live**.
+3. Server calls `set_active_interpreter(requester=coordinator, target=backup)`.
+4. Previous active interpreter's ingest connection is terminated.
+5. New active interpreter sees their participant card updated to active status.
+6. New active interpreter clicks **Go Live** to start their ingest session.
+
+### Self-initiated handoff (active interpreter to backup)
+
+1. Active interpreter selects the backup interpreter in the participant grid.
+2. Clicks **Set Live** (visible because they are the active interpreter).
+3. Same server flow as coordinator-initiated.
+
+### Emergency handoff (active interpreter disconnects)
+
+1. Active interpreter's Socket.IO connection drops.
+2. `socket_disconnect()` handler calls `booths.leave_participant(...)`.
+3. `leave_participant` detects the leaving participant was active and calls `_pick_next_interpreter(booth)`.
+4. `_pick_next_interpreter` returns the first available interpreter in the roster (FCFS).
+5. `booth.handoff_state` is set to `'pending'`.
+6. Updated state is broadcast to all booth participants.
+7. The new active interpreter is expected to click **Go Live** promptly.
+
+### Handoff state machine
+
+```
+idle
+ │  (first interpreter joins with no active)
+ ▼
+active (normal operating state)
+ │  (coordinator or active reassigns to backup)
+ ▼
+completed  →  active (new active interpreter)
+ │  (active interpreter disconnects unexpectedly)
+ ▼
+pending  →  active (next interpreter accepts)
+      └──►  idle (no more interpreters in booth)
+```
+
+---
+
+## Booth chat
+
+Internal booth chat is visible only to booth participants. It is not accessible to viewers or other booths.
+
+### Rules
+
+- Any participant can send a message.
+- Messages are broadcast to all participants in the booth room.
+- The server retains the last 500 messages per booth (in memory).
+- Messages are also persisted to `localStorage` in the browser for the duration of the session.
+- Empty messages are rejected by the server.
+- Message body is stripped of leading/trailing whitespace before storage.
+
+### Chat message structure
+
+```json
+{
+  "message_id": "uuid-hex",
+  "sender_id": "participant-id",
+  "sender_name": "Display Name",
+  "body": "Message text",
+  "sent_at": "2025-01-01T12:00:00+00:00"
+}
+```
+
+### Use cases
+
+- Coordinator announces rotation time: "Switch in 10 minutes."
+- Backup interpreter flags a terminology question.
+- Active interpreter signals they need relief: "Can someone take over? Struggling with the accent."
+- Coordinator acknowledges: "Amira, you're live in 2 minutes."
+
+---
+
+## Participant state model
+
+Each participant's card in the booth grid reflects their real-time state:
+
+| State field | Possible values | Meaning |
+|---|---|---|
+| `role` | `interpreter` / `coordinator` / `listener` | Assigned role |
+| `connected` | `true` / `false` | Socket.IO connection alive |
+| `mic_active` | `true` / `false` | Microphone stream active |
+| `ingest_connected` | `true` / `false` | WebRTC ingest session active |
+| Active badge | computed from `active_interpreter_id` | Whether this participant is currently live |
+
+`mic_active` and `ingest_connected` can only be `true` for the active interpreter. The server enforces this in `update_participant_state`:
+
+```python
+if wants_publisher_state and booth.active_interpreter_id != participant_id:
+    raise PermissionError('Only the active interpreter can mark mic or ingest active.')
+```
+
+---
+
+## Coordinator display
+
+The coordinator's view of the participant grid shows all participants with full state visibility, plus **Set Live** buttons on all non-active interpreter cards.
+
+The coordinator does not see a **Go Live** button — coordinators cannot publish ingest audio.
+
+---
+
+## Listener role
+
+A listener can join the booth (e.g., a supervisor, a relay interpreter from another language booth waiting for context). They see the participant grid and booth chat but cannot:
+
+- Go live
+- Reassign the active interpreter
+
+---
+
+## Multi-booth isolation
+
+Each `booth_id` has a completely independent state in the `BoothRegistry`. Participants in `hall-a-fr` do not see participants in `hall-a-de`. There is no cross-booth communication.
+
+---
+
+## Known limitations (current phase)
+
+- Booth state is in-memory. If the server restarts, all participants must rejoin.
+- There is no authentication of participant identity beyond the booth access token. Any user with the token URL can join as any role.
+- The backup interpreter cannot request a handoff — they must wait for coordinator or active interpreter to initiate.
+- There is no typing indicator in booth chat.

--- a/docs/specifications/interpreter-portal-spec.md
+++ b/docs/specifications/interpreter-portal-spec.md
@@ -1,0 +1,172 @@
+# Interpreter Portal Specification
+
+This document defines the functional specification for the interpreter console — what the interpreter sees, what they can do, and what guardrails are in place.
+
+---
+
+## Overview
+
+The interpreter console is a single browser tab that combines:
+
+1. A **Jitsi monitoring panel** — the interpreter hears and sees the floor session.
+2. A **mic ingest panel** — the interpreter tests their mic and goes live.
+3. A **preflight checklist** — gates the Go Live button until all requirements are confirmed.
+4. A **participant grid** — shows who is in the booth and their current role/status.
+5. A **booth chat panel** — internal text communication between booth participants.
+6. A **booth health panel** — live ingest status and stream health indicators.
+
+The interpreter never leaves this tab. Jitsi monitoring and live translation are both driven from this single surface.
+
+---
+
+## Booth URL format
+
+```
+/interpreter/<booth_id>?token=<token>&language=<language>&channel=<channel_id>
+```
+
+| Parameter | Required | Description |
+|---|---|---|
+| `booth_id` | Yes (path) | Unique identifier for the booth (e.g., `hall-a-fr`) |
+| `token` | If `BOOTH_ACCESS_TOKEN` is set | Temporary invite token from the organizer |
+| `language` | No (default: `English`) | Human-readable language name for display |
+| `channel` | No (default: `{booth_id}-audio`) | HLS channel identifier |
+
+The organizer generates one URL per language per session and distributes it to the booth team. The URL encodes the booth assignment; the interpreter does not need to configure anything.
+
+---
+
+## Preflight checklist
+
+The **Go Live** button is disabled until all four items are completed. This is enforced in `PreflightChecklist.vue` and `useInterpreterBooth.js`.
+
+| Item | How it is satisfied |
+|---|---|
+| Headphones connected | Interpreter manually checks the checkbox |
+| Monitoring active | Set automatically when the Jitsi iframe loads |
+| Mic test complete | Set after interpreter clicks **Test Mic** and confirms level |
+| Ingest reachable | Set after `IngestClient.checkReachable()` returns `true` |
+
+The checklist prevents an interpreter from accidentally going live without headphones (echo risk) or without confirming their mic is working.
+
+### Mic test flow
+
+1. Interpreter clicks **Test Mic**.
+2. `MicStreamingManager.startMicrophone(deviceId, onLevel)` is called.
+3. The level meter bar begins animating.
+4. The interpreter speaks into their mic and observes the level.
+5. The interpreter confirms the level is responding (via a separate confirm action or by the system detecting a non-zero level above a threshold).
+6. `preflight.micTestComplete` is set to `true`.
+
+The mic test does **not** send any audio to the server. It only exercises the `getUserMedia` and `AudioContext` paths locally.
+
+---
+
+## Go Live / Stop
+
+### Go Live
+
+Prerequisites:
+- All four preflight items are complete.
+- The local participant is the active interpreter for the channel.
+- No existing ingest session is active for this participant.
+
+Sequence:
+1. `MicStreamingManager.createIngestConnection(onConnectionStateChange)` — creates RTCPeerConnection and returns the SDP offer.
+2. `IngestClient.negotiate(channelId, localDescription)` — POSTs offer to `POST /api/interpreter/connect/{channel_id}`, receives answer.
+3. `MicStreamingManager.applyRemoteAnswer(answer)` — sets remote description.
+4. State transitions: `ingest.status = 'connecting'` → `'connected'` (on `connectionstatechange`).
+5. Socket.IO `booth:update-state` emitted to server with `mic_active: true, ingest_connected: true`.
+6. Server broadcasts updated `booth:state` to all booth participants.
+
+The **Go Live** button is replaced by a **Stop** button while live.
+
+### Stop
+
+1. `MicStreamingManager.stopPeerConnection()` — closes the peer connection.
+2. `IngestClient` calls `POST /api/interpreter/disconnect/{channel_id}`.
+3. State transitions: `ingest.status = 'disconnected'`, `ingest.streamingLive = false`.
+4. Socket.IO `booth:update-state` emitted with `mic_active: false, ingest_connected: false`.
+
+---
+
+## Device selection
+
+The `MicIngestPanel` shows a `<select>` element populated by `MicStreamingManager.listInputDevices()`. The interpreter can switch devices at any time. Switching a device:
+
+1. Stops the current mic stream and level meter.
+2. Calls `getUserMedia` with the new `deviceId`.
+3. If live, re-negotiates the ingest connection with the new track.
+
+---
+
+## Auto-reconnect
+
+If the WebRTC connection drops while the interpreter is live:
+
+1. `onConnectionStateChange` fires with `'disconnected'` or `'failed'`.
+2. `ingest.reconnecting` is set to `true` and a warning is shown in the console.
+3. After a brief delay, the system attempts to re-negotiate (up to `MAX_RECONNECT_ATTEMPTS = 5`).
+4. If reconnect succeeds, `ingest.reconnecting` is cleared.
+5. If all retries are exhausted, the interpreter is shown an error and must manually click **Go Live** again.
+
+On the viewer side: the HLS playlist stops updating. The viewer player falls back to the original floor audio automatically (this is handled by the Eventyay video module, not this portal).
+
+---
+
+## Ingest unavailability
+
+If `aiortc` is not installed on the server (e.g., during frontend-only development), the backend sets `aiortc_available = False`. In this case:
+
+- `GET /healthz` returns `{ "aiortc_available": false }`.
+- `POST /api/interpreter/connect/{channel_id}` returns `503`.
+- The Vue console shows a warning banner: "Ingest server not available. Mic test is still usable."
+- The Go Live button is disabled.
+- All other features (Jitsi monitoring, booth chat, participant grid) continue to work.
+
+This allows frontend development to proceed without a working aiortc environment.
+
+---
+
+## Layout and responsiveness
+
+The console uses a CSS Grid layout:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Topbar (brand + session metadata)                  │
+├──────────────────────────┬──────────────────────────┤
+│  JitsiMonitorPanel (2fr) │  Sidebar (1fr, min 300px)│
+│                          │  ┌──────────────────────┐│
+│                          │  │ MicIngestPanel       ││
+│                          │  ├──────────────────────┤│
+│                          │  │ PreflightChecklist   ││
+│                          │  ├──────────────────────┤│
+│                          │  │ BoothHealthPanel     ││
+│                          │  └──────────────────────┘│
+├──────────────────────────┴──────────────────────────┤
+│  ParticipantGrid                                     │
+├──────────────────────────────────────────────────────┤
+│  BoothChatPanel                                      │
+└──────────────────────────────────────────────────────┘
+```
+
+Below 1080px viewport width, the layout collapses to a single column (Jitsi panel stacked above the sidebar).
+
+---
+
+## Accessibility considerations
+
+- All interactive controls (buttons, selects, checkboxes) use semantic HTML elements.
+- The level meter is a `<progress>` or `<div>` with `aria-valuenow` / `aria-valuemax` attributes.
+- Role badges in the participant grid use `aria-label` to describe the role.
+- The booth chat panel traps focus correctly when typing.
+
+---
+
+## Security considerations
+
+- The booth URL token is sent as a query parameter on initial page load and included in all subsequent API calls and Socket.IO events.
+- The token is never stored in `localStorage` or `IndexedDB`.
+- All API calls use HTTPS in production (required for `getUserMedia`).
+- The ingest endpoint validates both the token and the active interpreter status before accepting an SDP offer, preventing unauthorized publishing.

--- a/docs/specifications/jitsi-room-management-spec.md
+++ b/docs/specifications/jitsi-room-management-spec.md
@@ -1,0 +1,106 @@
+# Jitsi Room Management Specification
+
+This document defines the policy for how Jitsi rooms are used in the interpretation portal, and what the portal does and does not control.
+
+---
+
+## Scope
+
+The interpretation portal **embeds** Jitsi rooms via iframe. It does not:
+
+- Create or destroy Jitsi rooms.
+- Configure Jitsi server-side settings.
+- Manage Jitsi user accounts or moderation.
+- Use the Jitsi External API JavaScript library.
+
+All Jitsi room management (capacity, access control, moderation) is the responsibility of whoever operates the Jitsi server.
+
+---
+
+## Room naming convention
+
+There is no enforced naming convention for Jitsi rooms used as monitoring rooms. However, the recommended pattern is:
+
+```
+{event-slug}-{stage-id}
+```
+
+For example: `eventyay-2025-hall-a`
+
+The room name is configured via `DEFAULT_JITSI_ROOM` in `.env`. Interpreters can also manually enter a different Jitsi URL in the monitoring panel if needed.
+
+---
+
+## Embed policy
+
+The portal embeds Jitsi using a URL hash parameter configuration that enforces receive-only mode by default:
+
+| Hash parameter | Value | Effect |
+|---|---|---|
+| `config.startWithAudioMuted` | `true` | Interpreter's mic is muted in Jitsi on join |
+| `config.startWithVideoMuted` | `true` | Interpreter's camera is off in Jitsi on join |
+| `config.prejoinPageEnabled` | `false` | Skip the Jitsi prejoin/lobby page |
+| `config.disableInitialGUM` | `true` | Skip initial getUserMedia prompt in Jitsi |
+| `config.startSilent` | `true` | Start with audio muted (belt and braces) |
+
+The goal is to prevent the interpreter from accidentally publishing into the Jitsi call. The Jitsi call is for monitoring only; the ingest path is the separate WebRTC connection.
+
+**Important:** These parameters configure the Jitsi client's local behaviour. A determined user could unmute their mic in Jitsi and accidentally publish floor audio. The operational mitigation is to remind interpreters that the Jitsi frame is monitoring-only and to use their headphones.
+
+---
+
+## Domain validation
+
+The portal validates that the Jitsi URL entered by the interpreter uses the configured `JITSI_DOMAIN`. This prevents:
+
+- Accidental use of an arbitrary Jitsi server.
+- URL substitution attacks where a malicious link redirects the interpreter to a hostile Jitsi room.
+
+Validation is performed by `buildJitsiEmbedUrl(rawUrl, { expectedDomain: env.jitsiDomain })` in `src/services/jitsiEmbed.js`.
+
+If the URL's origin does not match `https://{JITSI_DOMAIN}`, an error is shown and the iframe is not loaded.
+
+This check can be bypassed in development by setting `JITSI_DOMAIN` to an empty string, which disables domain validation.
+
+---
+
+## What interpreters see in the Jitsi frame
+
+The Jitsi frame shows the floor session as a normal Jitsi meeting participant view. The interpreter sees:
+
+- The speaker's video (if the speaker has video enabled in Jitsi)
+- The floor audio (speaker's microphone)
+- Other Jitsi participants (e.g., the event presenter, moderator)
+- Jitsi's own UI (mute/unmute, etc.)
+
+The interpreter can interact with the Jitsi UI (e.g., manually unmute if they need to ask a quick clarification to the presenter). This is intentional — the portal does not lock down the Jitsi UI.
+
+---
+
+## Simultaneous Jitsi and ingest audio
+
+The interpreter hears two audio sources simultaneously:
+
+1. **Jitsi floor audio** — from the floor session (the speech they are interpreting).
+2. **Ingest feedback** — there is none. The ingest audio is never played back to the interpreter.
+
+This is the correct configuration. The interpreter hears the speaker and speaks their translation without hearing themselves. Headphones are required to prevent the Jitsi floor audio from leaking into the ingest mic.
+
+---
+
+## Multiple booths, one Jitsi room
+
+Multiple interpreter booths for the same event (e.g., French booth and German booth) will typically use the **same Jitsi room** for monitoring. This is intentional — they are all monitoring the same floor session.
+
+Each booth has its own ingest channel (`channel_id`), its own HLS stream, and its own Socket.IO room. Only the Jitsi monitoring room is shared.
+
+---
+
+## Future: Jitsi API integration
+
+If future requirements need programmatic Jitsi control, the extension point is `src/services/jitsiEmbed.js`. Specifically:
+
+- Replace or augment the `<iframe>` embed with `new JitsiMeetExternalAPI(...)`.
+- This would allow: detecting interpreter mic state in Jitsi, auto-muting/unmuting the Jitsi participant, participant event tracking.
+
+This is not planned for the current phase. Keep the Jitsi integration as a simple iframe embed.

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -1,0 +1,165 @@
+# Testing Guide
+
+This document describes the test suite, what is covered, and how to run manual end-to-end scenarios.
+
+---
+
+## Running the test suite
+
+```bash
+uv run pytest
+```
+
+Or with verbose output:
+
+```bash
+uv run pytest -v
+```
+
+Tests are located in `tests/`. All tests must pass before a PR can be merged.
+
+---
+
+## Test files
+
+### `tests/test_app.py`
+
+Tests for Flask routes and Socket.IO event handlers in `app.py`.
+
+**HTTP route tests:**
+
+| Test | What it covers |
+|---|---|
+| `test_healthz` | `/healthz` returns `ok: true` |
+| `test_home_redirect` | `/` redirects to `/interpreter/demo-booth` |
+| `test_interpreter_booth_page` | `/interpreter/<booth_id>` renders the booth template |
+| `test_booth_state_api` | `/api/booth/<booth_id>/state` returns valid state JSON |
+| `test_booth_state_api_token_required` | Returns `403` when token is wrong |
+| `test_connect_ingest_missing_fields` | Returns `400` when required fields are missing |
+| `test_connect_ingest_not_active` | Returns `403` when requester is not active interpreter |
+| `test_disconnect_ingest` | `/api/interpreter/disconnect/{channel}` returns `ok: true` |
+| `test_ingest_status` | `/api/interpreter/status/{channel}` returns state |
+
+**Socket.IO event tests:**
+
+| Test | What it covers |
+|---|---|
+| `test_socket_join_booth` | `booth:join` creates participant and emits `booth:joined` |
+| `test_socket_join_invalid_token` | `booth:join` with wrong token emits `booth:error` |
+| `test_socket_leave_booth` | `booth:leave` removes participant |
+| `test_socket_chat_message` | `booth:chat` broadcasts message to room |
+| `test_socket_chat_missing_sender` | `booth:chat` without sender_id emits `booth:error` |
+| `test_socket_set_active` | `booth:set-active` reassigns active interpreter |
+| `test_socket_disconnect` | Socket disconnect auto-removes participant |
+
+### `tests/test_booth_state.py`
+
+Unit tests for `BoothRegistry` in `portal/booth_state.py`.
+
+| Test | What it covers |
+|---|---|
+| `test_get_or_create_booth` | Creates booth on first access; returns same instance on second |
+| `test_join_first_interpreter_becomes_active` | First interpreter auto-assigned as active |
+| `test_join_second_interpreter_is_standby` | Second interpreter does not replace active |
+| `test_join_coordinator_not_active` | Coordinator role does not set active interpreter |
+| `test_leave_active_interpreter_promotes_next` | Next interpreter promoted on active leave |
+| `test_leave_last_participant_resets_booth` | Booth resets when empty |
+| `test_set_active_coordinator_can_assign` | Coordinator can reassign active |
+| `test_set_active_active_can_hand_off` | Active interpreter can hand off to backup |
+| `test_set_active_backup_cannot_self_promote` | Backup cannot promote without authority |
+| `test_set_active_non_interpreter_rejected` | Coordinator cannot be set active |
+| `test_update_state_non_active_cannot_set_mic` | Only active interpreter can set mic/ingest flags |
+| `test_add_chat_message` | Message stored and returned |
+| `test_add_chat_empty_body_rejected` | Empty messages rejected |
+| `test_add_chat_unknown_sender_rejected` | Unknown sender rejected |
+
+### `tests/conftest.py`
+
+Shared pytest fixtures:
+
+- `client` — Flask test client
+- `socketio_client` — Flask-SocketIO test client
+- `booth_registry` — Fresh `BoothRegistry` instance
+- `settings` — Test settings with `BOOTH_ACCESS_TOKEN` set to `test-token`
+
+---
+
+## Manual end-to-end scenarios
+
+These scenarios require a browser and both the Flask server and Vite dev server running.
+
+### Scenario 1 — Single interpreter, mic test, go live
+
+**Setup:** Flask + Vite running. `aiortc_available = True`.
+
+1. Open `http://localhost:5173/interpreter/demo-event/hall-a-fr` (or the Flask URL).
+2. Verify the console loads with all panels visible.
+3. Click **Join Monitor Room** — Jitsi iframe loads. Verify `monitoringActive` is checked.
+4. Click the headphones checkbox manually. Verify it toggles.
+5. Click **Test Mic**. Verify the level meter animates when you speak.
+6. After mic test confirms level, verify `micTestComplete` is checked.
+7. Verify `ingestReachable` auto-checks after page load.
+8. Click **Go Live**. Verify the button changes to **Stop** and the health panel shows connected.
+9. Click **Stop**. Verify state resets.
+
+### Scenario 2 — Two interpreters, handoff
+
+**Setup:** Two browser windows (or tabs in incognito).
+
+1. Window A: Open booth as interpreter (auto-becomes active).
+2. Window B: Open the same booth URL as interpreter (joins as backup).
+3. Verify Window A shows the active badge. Window B shows backup/standby.
+4. In Window A: Click **Set Live** on Window B's participant card.
+5. Verify Window B's participant card is now marked active.
+6. Verify Window A's Go Live button is now disabled (no longer active).
+7. In Window B: Click **Go Live** to confirm the handoff.
+
+### Scenario 3 — Coordinator handoff
+
+**Setup:** Three tabs — interpreter (active), interpreter (backup), coordinator.
+
+1. Open interpreter 1 as active.
+2. Open interpreter 2 as backup.
+3. Open tab 3 with `?role=coordinator`.
+4. In the coordinator tab: click **Set Live** on interpreter 2's card.
+5. Verify interpreter 2 becomes active across all three tabs.
+
+### Scenario 4 — Booth chat
+
+1. Open two tabs in the same booth.
+2. Send a message from tab 1.
+3. Verify the message appears in tab 2.
+4. Refresh tab 1. Verify chat history is restored from localStorage.
+
+### Scenario 5 — aiortc unavailable (frontend-only development)
+
+**Setup:** Install `aiortc` is not available (e.g., run `uv run python -c "import aiortc"` fails in a stripped env).
+
+1. Start the Flask server. Check `/healthz` returns `"aiortc_available": false`.
+2. Open the booth.
+3. Verify a warning is shown ("Ingest server not available").
+4. Verify Go Live button is disabled.
+5. Verify Jitsi monitoring, participant grid, and booth chat all work normally.
+
+---
+
+## CI
+
+The CI pipeline (`.github/workflows/tests.yml`) runs:
+
+```bash
+uv sync --python 3.13 --dev
+uv run pytest
+```
+
+All tests must pass. There is no separate lint step currently; follow the code style of the surrounding files.
+
+---
+
+## What is not tested
+
+- Browser-side Vue components (no Vitest or browser-based test framework is configured yet).
+- FFmpeg HLS output (integration test requiring a real media pipeline).
+- Multi-worker Socket.IO behaviour (requires Redis; not tested in CI).
+
+These are identified gaps for future test coverage.


### PR DESCRIPTION
- Rewrite README with interpreter booth explanation, system diagram, workflow tables, env var reference, and doc index
- Expand agents.md with module ownership table, flow diagrams, and explicit agent restrictions
- Add .github/copilot-instructions.md scoped to this sub-repo
- Add docs/context/project-context.md (product background, design philosophy, current phase scope)
- Add docs/architecture/system-overview.md (full component map, data flow, state ownership, security model)
- Add docs/architecture/interpreter-flow.md (end-to-end audio pipeline from mic to HLS, echo prevention, reconnect table)
- Add docs/architecture/jitsi-integration.md (embed config, domain validation, monitoring vs ingest separation)
- Add docs/architecture/webrtc-ingest.md (SDP flow, async runtime, HLS output, STUN/TURN notes)
- Add docs/frontend/frontend-architecture.md (Vue 3 structure, composable state shape, service layer, component responsibilities, env vars)
- Add docs/backend/backend-architecture.md (Flask routes, Socket.IO events, BoothRegistry data model, IngestService, production notes)
- Add docs/specifications/interpreter-portal-spec.md (booth URL format, preflight checklist, Go Live/Stop, device selection, auto-reconnect)
- Add docs/specifications/booth-collaboration-spec.md (roles, active interpreter enforcement, handoff protocol, chat rules)
- Add docs/specifications/jitsi-room-management-spec.md (embed policy, domain validation, receive-only rationale)
- Add docs/setup/local-development.md (prerequisites, backend setup, frontend setup, env vars, troubleshooting)
- Add docs/testing/e2e-testing.md (test file coverage, manual scenarios, CI, known gaps)
- Add docs/phases/implementation-roadmap.md (MVP status, phases 2-5, design principles)