### PR TITLE
Add MediaMTX docker-compose, config, and README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ JITSI_DOMAIN=meet.jit.si
 INGEST_HLS_ROOT=./hls-output
 HLS_SEGMENT_SECONDS=2
 HLS_PLAYLIST_LENGTH=8
+
+# MediaMTX integration (Phase 1)
+MEDIAMTX_WHIP_BASE=http://localhost:8889/whip
+MEDIAMTX_HLS_BASE=http://localhost:8888

--- a/README.md
+++ b/README.md
@@ -79,6 +79,59 @@ uv sync --python 3.13 --dev
 uv run python app.py
 ```
 
+## MediaMTX (local media server)
+
+MediaMTX handles WebRTC audio ingest (WHIP) and HLS output. It replaces the
+prototype `aiortc` ingest pipeline with a production-grade media server.
+
+### Quick start (Docker Compose)
+
+```bash
+docker compose -f docker-compose.interpretation.yml up -d
+```
+
+This starts MediaMTX with:
+- **WHIP ingest** on `http://localhost:8889` — interpreters publish audio here
+- **HLS output** on `http://localhost:8888` — audience fetches streams here
+
+### Quick start (standalone Docker)
+
+```bash
+docker run --rm -d --name mediamtx \
+  -v $(pwd)/mediamtx.yml:/mediamtx.yml:ro \
+  -p 8888:8888 \
+  -p 8889:8889 \
+  -p 8189:8189/udp \
+  bluenviron/mediamtx:1
+```
+
+### Verify MediaMTX is running
+
+```bash
+# HLS endpoint (should return a page or 200)
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/
+
+# WHIP endpoint (should return 404 — no path specified, but confirms server is up)
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8889/
+
+# Container logs
+docker logs mediamtx
+```
+
+### Configuration
+
+The `mediamtx.yml` file in the repository root configures MediaMTX for local
+development. Key settings:
+
+| Setting | Value | Purpose |
+|---|---|---|
+| `webrtcAddress` | `:8889` | WHIP ingest port |
+| `hlsAddress` | `:8888` | HLS output port |
+| `hlsSegmentDuration` | `2s` | HLS segment length |
+| `webrtcEncryption` | `no` | Disable DTLS for local dev (no TLS) |
+
+See [MediaMTX docs](https://github.com/bluenviron/mediamtx) for full configuration reference.
+
 Open:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ uv run python app.py
 
 ## MediaMTX (local media server)
 
-MediaMTX handles WebRTC audio ingest (WHIP) and HLS output. It replaces the
-prototype `aiortc` ingest pipeline with a production-grade media server.
+MediaMTX handles WebRTC audio ingest (WHIP) and HLS output. It is the planned
+production replacement for the prototype `aiortc` ingest pipeline (`portal/ingest.py`).
+Both run side-by-side during migration — see the Phase 1 migration plan in
+`docs/detailedplan.md` for the full removal schedule.
 
 ### Quick start (Docker Compose)
 
@@ -93,8 +95,8 @@ docker compose -f docker-compose.interpretation.yml up -d
 ```
 
 This starts MediaMTX with:
-- **WHIP ingest** on `http://localhost:8889` — interpreters publish audio here
-- **HLS output** on `http://localhost:8888` — audience fetches streams here
+- **WHIP ingest** on `http://localhost:8889/whip/{path}` — interpreters publish audio here
+- **HLS output** on `http://localhost:8888/{path}/index.m3u8` — audience fetches streams here
 
 ### Quick start (standalone Docker)
 
@@ -110,15 +112,20 @@ docker run --rm -d --name mediamtx \
 ### Verify MediaMTX is running
 
 ```bash
-# HLS endpoint (should return a page or 200)
+# HLS endpoint — 404 is expected here (no stream path specified).
+# A 404 from MediaMTX confirms the server is up and listening.
 curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/
 
-# WHIP endpoint (should return 404 — no path specified, but confirms server is up)
+# WHIP endpoint — 404 is also expected (no stream path specified).
 curl -s -o /dev/null -w "%{http_code}" http://localhost:8889/
 
 # Container logs
 docker logs mediamtx
 ```
+
+Both endpoints return **404 until a stream is published** — this is expected.
+To confirm a live stream, check `http://localhost:8888/{path}/index.m3u8` after
+a publisher connects to `http://localhost:8889/whip/{path}`.
 
 ### Configuration
 
@@ -130,7 +137,7 @@ development. Key settings:
 | `webrtcAddress` | `:8889` | WHIP ingest port |
 | `hlsAddress` | `:8888` | HLS output port |
 | `hlsSegmentDuration` | `2s` | HLS segment length |
-| `webrtcEncryption` | `no` | Disable DTLS for local dev (no TLS) |
+| `webrtcEncryption` | `no` | Disable WebRTC DTLS-SRTP media encryption for local dev. **Do not use in production.** (Distinct from HTTPS/TLS transport — this controls per-packet media encryption.) |
 
 See [MediaMTX docs](https://github.com/bluenviron/mediamtx) for full configuration reference.
 

--- a/docker-compose.interpretation.yml
+++ b/docker-compose.interpretation.yml
@@ -1,0 +1,17 @@
+services:
+
+  # ── MediaMTX audio server ─────────────────────────────────────
+  mediamtx:
+    image: bluenviron/mediamtx:1
+    volumes:
+      - ./mediamtx.yml:/mediamtx.yml:ro
+    ports:
+      - "8888:8888"    # HLS output
+      - "8889:8889"    # WHIP (WebRTC HTTP ingest)
+      - "8189:8189/udp" # WebRTC ICE/UDP mux
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8888/"]
+      interval: 15s
+      timeout: 5s
+      retries: 3

--- a/docker-compose.interpretation.yml
+++ b/docker-compose.interpretation.yml
@@ -10,8 +10,7 @@ services:
       - "8889:8889"    # WHIP (WebRTC HTTP ingest)
       - "8189:8189/udp" # WebRTC ICE/UDP mux
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8888/"]
-      interval: 15s
-      timeout: 5s
-      retries: 3
+    # No HTTP healthcheck: the HLS root path always returns 404 until a stream is
+    # published, which would falsely mark the container as unhealthy. The MediaMTX
+    # base image also does not include wget/curl. Use `docker logs mediamtx` and
+    # port connectivity to verify the container is up during local development.

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -1,0 +1,22 @@
+# mediamtx.yml — local dev configuration
+# See https://github.com/bluenviron/mediamtx for full reference.
+
+logLevel: info
+logDestinations: [stdout]
+
+# ── WHIP ingest (WebRTC HTTP Ingest Protocol) ───────────────────
+webrtcAddress: :8889
+webrtcEncryption: no
+
+# ── HLS output ──────────────────────────────────────────────────
+hlsAddress: :8888
+hlsEncryption: no
+hlsAlwaysRemux: yes
+hlsSegmentDuration: 2s
+hlsSegmentMaxSize: 50MB
+
+# ── Path defaults ───────────────────────────────────────────────
+# All paths are auto-created on first publish.
+# Single publisher per path is enforced by default.
+pathDefaults:
+  record: no


### PR DESCRIPTION
fixes #41 

Phase 1 Step 1: Run MediaMTX locally via Docker. Adds docker-compose.interpretation.yml, mediamtx.yml, updates README and .env.example.