### PR TITLE
Integrate browser WHIP publishing with MediaMTX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,5 @@ HLS_SEGMENT_SECONDS=2
 HLS_PLAYLIST_LENGTH=8
 
 # MediaMTX integration (Phase 1)
-MEDIAMTX_WHIP_BASE=http://localhost:8889/whip
+MEDIAMTX_WHIP_BASE=http://localhost:8889
 MEDIAMTX_HLS_BASE=http://localhost:8888

--- a/app.py
+++ b/app.py
@@ -70,6 +70,8 @@ def interpreter_booth(booth_id: str) -> Any:
         default_jitsi_room=settings.default_jitsi_room,
         jitsi_domain=settings.jitsi_domain,
         aiortc_available=AIORTC_AVAILABLE,
+        mediamtx_whip_base=settings.mediamtx_whip_base,
+        mediamtx_hls_base=settings.mediamtx_hls_base,
     )
 
 

--- a/docker-compose.interpretation.yml
+++ b/docker-compose.interpretation.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8888:8888"    # HLS output
       - "8889:8889"    # WHIP (WebRTC HTTP ingest)
-      - "8189:8189/udp" # WebRTC ICE/UDP mux (matches webrtcICEUDPMuxAddress in mediamtx.yml)
+      - "8189:8189/udp" # WebRTC ICE/UDP mux (matches webrtcLocalUDPAddress in mediamtx.yml)
     restart: unless-stopped
     # No HTTP healthcheck: the HLS root path always returns 404 until a stream is
     # published, which would falsely mark the container as unhealthy. The MediaMTX

--- a/portal/config.py
+++ b/portal/config.py
@@ -38,6 +38,8 @@ class Settings:
     ingest_hls_root: Path
     hls_segment_seconds: int
     hls_playlist_length: int
+    mediamtx_whip_base: str
+    mediamtx_hls_base: str
 
 
 def load_settings() -> Settings:
@@ -53,6 +55,8 @@ def load_settings() -> Settings:
         ingest_hls_root=Path(os.getenv('INGEST_HLS_ROOT', './hls-output')).resolve(),
         hls_segment_seconds=int(os.getenv('HLS_SEGMENT_SECONDS', '2')),
         hls_playlist_length=int(os.getenv('HLS_PLAYLIST_LENGTH', '8')),
+        mediamtx_whip_base=os.getenv('MEDIAMTX_WHIP_BASE', 'http://localhost:8889'),
+        mediamtx_hls_base=os.getenv('MEDIAMTX_HLS_BASE', 'http://localhost:8888'),
     )
 
 

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -22,6 +22,8 @@ const state = {
   ingestReachable: portal.dataset.aiortcAvailable === 'true',
   defaultJitsiRoom: portal.dataset.defaultJitsi || '',
   jitsiDomain: portal.dataset.jitsiDomain || '',
+  whipBase: portal.dataset.whipBase || '',
+  hlsBase: portal.dataset.hlsBase || '',
 }
 
 const elements = {
@@ -171,6 +173,13 @@ async function fetchBoothState() {
 }
 
 async function fetchIngestReachability() {
+  if (state.whipBase) {
+    // WHIP path: MediaMTX is configured; treat as reachable. Actual connectivity
+    // is validated at publish time (startLiveIngest will surface errors on failure).
+    state.ingestReachable = true
+    return
+  }
+  // Legacy: check aiortc/FFmpeg reachability via Flask
   const response = await fetch(`/api/interpreter/status/${encodeURIComponent(state.channelId)}`)
   if (!response.ok) return
   const payload = await response.json()
@@ -274,7 +283,7 @@ async function startLiveIngest() {
     return
   }
   if (!state.ingestReachable) {
-    showError('Ingest backend is unavailable. Check aiortc/FFmpeg setup.')
+    showError('Ingest backend is unavailable. Check server configuration.')
     return
   }
   const isActive = state.activeInterpreterId === state.participantId
@@ -306,24 +315,43 @@ async function startLiveIngest() {
     await peerConnection.setLocalDescription(offer)
     await waitForIceGathering(peerConnection)
 
-    const response = await fetch(`/api/interpreter/connect/${encodeURIComponent(state.channelId)}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        booth_id: state.boothId,
-        participant_id: state.participantId,
-        language: state.language,
-        token: state.token,
-        type: peerConnection.localDescription.type,
-        sdp: peerConnection.localDescription.sdp,
-      }),
-    })
-    if (!response.ok) {
-      const payload = await response.json().catch(() => ({ error: response.statusText }))
-      throw new Error(payload.error || 'Ingest negotiation failed.')
+    if (state.whipBase) {
+      // WHIP path: POST raw SDP offer to MediaMTX; receive SDP answer as plain text.
+      // MediaMTX WHIP URL format is /{channelId}/whip (not /whip/{channelId}).
+      const whipUrl = `${state.whipBase}/${encodeURIComponent(state.channelId)}/whip`
+      const response = await fetch(whipUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/sdp' },
+        body: peerConnection.localDescription.sdp,
+      })
+      if (!response.ok) {
+        const detail = await response.text().catch(() => response.statusText)
+        throw new Error(`WHIP error ${response.status}: ${detail}`)
+      }
+      const answerSdp = await response.text()
+      await peerConnection.setRemoteDescription({ type: 'answer', sdp: answerSdp })
+    } else {
+      // Legacy: aiortc path via Flask
+      const response = await fetch(`/api/interpreter/connect/${encodeURIComponent(state.channelId)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          booth_id: state.boothId,
+          participant_id: state.participantId,
+          language: state.language,
+          token: state.token,
+          type: peerConnection.localDescription.type,
+          sdp: peerConnection.localDescription.sdp,
+        }),
+      })
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({ error: response.statusText }))
+        throw new Error(payload.error || 'Ingest negotiation failed.')
+      }
+      const answer = await response.json()
+      await peerConnection.setRemoteDescription(answer)
     }
-    const answer = await response.json()
-    await peerConnection.setRemoteDescription(answer)
+
     state.ingestConnected = true
     socket.emit('booth:update-state', {
       booth_id: state.boothId,
@@ -347,16 +375,19 @@ async function stopLiveIngest() {
     state.peerConnection = null
   }
   if (state.joined && state.participantId) {
-    await fetch(`/api/interpreter/disconnect/${encodeURIComponent(state.channelId)}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        booth_id: state.boothId,
-        participant_id: state.participantId,
-        language: state.language,
-        token: state.token,
-      }),
-    }).catch(() => {})
+    if (!state.whipBase) {
+      // Legacy: notify Flask to release the server-side aiortc peer connection
+      await fetch(`/api/interpreter/disconnect/${encodeURIComponent(state.channelId)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          booth_id: state.boothId,
+          participant_id: state.participantId,
+          language: state.language,
+          token: state.token,
+        }),
+      }).catch(() => {})
+    }
     socket.emit('booth:update-state', {
       booth_id: state.boothId,
       participant_id: state.participantId,

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -13,6 +13,8 @@
   data-default-jitsi='{{ default_jitsi_room }}'
   data-jitsi-domain='{{ jitsi_domain }}'
   data-aiortc-available='{{ "true" if aiortc_available else "false" }}'
+  data-whip-base='{{ mediamtx_whip_base }}'
+  data-hls-base='{{ mediamtx_hls_base }}'
 >
   <section class='panel'>
     <header class='panel-header'>


### PR DESCRIPTION
Replace the aiortc ingest path with direct WebRTC HTTP Ingest Protocol (WHIP) publishing to MediaMTX. The legacy aiortc path is kept as a fallback when MEDIAMTX_WHIP_BASE is unset, enabling side-by-side migration.

Changes:
- portal/config.py: add mediamtx_whip_base / mediamtx_hls_base settings (defaults: http://localhost:8889 / http://localhost:8888)
- app.py: pass whip/hls base URLs as template context vars
- templates/interpreter_booth.html: expose as data-whip-base / data-hls-base
- static/js/interpreter-booth.js:
  * add whipBase/hlsBase to state (read from dataset)
  * fetchIngestReachability: skip Flask check when whipBase is set
  * startLiveIngest: POST raw SDP to /{channelId}/whip (MediaMTX WHIP format); fall back to /api/interpreter/connect/ when whipBase empty
  * stopLiveIngest: skip /api/interpreter/disconnect/ for WHIP path; always emit booth:update-state WebSocket notification
- .env.example: correct MEDIAMTX_WHIP_BASE (no /whip suffix — path format is /{channelId}/whip per MediaMTX convention)
- docker-compose.interpretation.yml: fix stale webrtcICEUDPMuxAddress comment → webrtcLocalUDPAddress


fixes #43