### PR TITLE
Add mic device selection, level meter, and HLS URL display

### DIFF
--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -50,3 +50,9 @@ hlsSegmentMaxSize: 50MB
 # provides a network-level guard on top of the in-process booth_state.py check.
 pathDefaults:
   record: no             # disable on-disk recording for local dev
+
+# all_others is the wildcard entry that allows any path to be auto-created on
+# first WHIP publish. Without this, MediaMTX v1.x returns 400
+# "path not configured" even though pathDefaults is set.
+paths:
+  all_others:

--- a/static/css/interpreter.css
+++ b/static/css/interpreter.css
@@ -325,3 +325,81 @@ label {
   color: var(--color-danger);
   font-size: 0.88rem;
 }
+
+/* ── Device selection ─────────────────────────────────────── */
+.device-row {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.device-label {
+  color: var(--color-muted);
+  font-size: 0.88rem;
+  font-weight: 500;
+}
+
+.device-select-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.device-select {
+  min-width: 0; /* prevent overflow in grid */
+}
+
+/* ── Mic level meter ──────────────────────────────────────── */
+.meter-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.35rem 0;
+}
+
+.meter-label {
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.mic-meter {
+  display: block;
+  width: 100%;
+  height: 10px;
+  border-radius: 5px;
+  background: #e9ecef;
+  border: 1px solid var(--color-border);
+}
+
+.mic-divider {
+  border: none;
+  border-top: 1px solid var(--color-panel-border);
+  margin: 0.1rem 0;
+}
+
+/* ── HLS URL row ──────────────────────────────────────────── */
+.hls-url-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  word-break: break-all;
+}
+
+.hls-url-cell code {
+  font-size: 0.82rem;
+  color: var(--color-primary-text);
+}
+
+.btn-xs {
+  padding: 0.15rem 0.4rem;
+  font-size: 0.78rem;
+  flex-shrink: 0;
+}
+
+/* ── Utility ─────────────────────────────────────────────── */
+.hidden {
+  display: none !important;
+}

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -24,6 +24,7 @@ const state = {
   jitsiDomain: portal.dataset.jitsiDomain || '',
   whipBase: portal.dataset.whipBase || '',
   hlsBase: portal.dataset.hlsBase || '',
+  micDeviceId: localStorage.getItem('mic-device-id') || '',
 }
 
 const elements = {
@@ -50,7 +51,20 @@ const elements = {
   toggleMic: document.getElementById('toggle-mic'),
   goLive: document.getElementById('go-live'),
   passRelay: document.getElementById('pass-relay'),
+  micDeviceSelect: document.getElementById('mic-device-select'),
+  micMeter: document.getElementById('mic-meter'),
+  meterRow: document.getElementById('meter-row'),
+  micTestBtn: document.getElementById('mic-test-btn'),
+  hlsUrlRow: document.getElementById('hls-url-row'),
+  hlsUrlDisplay: document.getElementById('hls-url-display'),
+  copyHlsUrl: document.getElementById('copy-hls-url'),
 }
+
+// ── Audio context state (not reflected directly in UI) ────────────────────
+let micTestStream = null
+let micAnimFrame = null
+let micAudioCtx = null
+let micAnalyser = null
 
 const socket = io()
 
@@ -62,6 +76,7 @@ async function boot() {
   elements.jitsiUrl.value = state.defaultJitsiRoom
   await fetchBoothState()
   await fetchIngestReachability()
+  await populateMicDevices()
   bindEventHandlers()
   render()
 }
@@ -130,6 +145,38 @@ function bindEventHandlers() {
 
   elements.passRelay.addEventListener('click', () => {
     passRelayToNextInterpreter()
+  })
+
+  elements.micDeviceSelect.addEventListener('change', () => {
+    state.micDeviceId = elements.micDeviceSelect.value
+    localStorage.setItem('mic-device-id', state.micDeviceId)
+    // If a test or live stream is active with a different device, restart it
+    if (micTestStream) {
+      stopMicTest().then(startMicTest).catch(() => {})
+    }
+  })
+
+  elements.micTestBtn.addEventListener('click', async () => {
+    if (micTestStream) {
+      stopMicTest()
+    } else {
+      await startMicTest()
+    }
+  })
+
+  elements.copyHlsUrl.addEventListener('click', () => {
+    const url = elements.hlsUrlDisplay.textContent
+    if (!url) return
+    navigator.clipboard.writeText(url).then(() => {
+      elements.copyHlsUrl.textContent = 'Copied!'
+      setTimeout(() => {
+        elements.copyHlsUrl.textContent = 'Copy'
+      }, 2000)
+    }).catch(() => {})
+  })
+
+  navigator.mediaDevices.addEventListener('devicechange', () => {
+    populateMicDevices().catch(() => {})
   })
 
   elements.participantList.addEventListener('click', (event) => {
@@ -245,16 +292,149 @@ function joinMonitoringFeed() {
   }
 }
 
+async function populateMicDevices() {
+  // A brief getUserMedia call is required before enumerateDevices returns device labels.
+  // The stream is immediately stopped — this only grants the label permission.
+  try {
+    const tempStream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    tempStream.getTracks().forEach((t) => t.stop())
+  } catch {
+    // Permission denied or no device — continue without labels
+  }
+  const devices = await navigator.mediaDevices.enumerateDevices()
+  const audioInputs = devices.filter((d) => d.kind === 'audioinput')
+  const previous = elements.micDeviceSelect.value
+  elements.micDeviceSelect.innerHTML = ''
+
+  const defaultOpt = document.createElement('option')
+  defaultOpt.value = ''
+  defaultOpt.textContent = 'Default microphone'
+  elements.micDeviceSelect.appendChild(defaultOpt)
+
+  for (const device of audioInputs) {
+    const opt = document.createElement('option')
+    opt.value = device.deviceId
+    opt.textContent = device.label || `Microphone ${elements.micDeviceSelect.options.length}`
+    elements.micDeviceSelect.appendChild(opt)
+  }
+
+  // Restore saved selection
+  const saved = state.micDeviceId
+  if (saved && elements.micDeviceSelect.querySelector(`option[value="${CSS.escape(saved)}"]`)) {
+    elements.micDeviceSelect.value = saved
+  } else if (previous && elements.micDeviceSelect.querySelector(`option[value="${CSS.escape(previous)}"]`)) {
+    elements.micDeviceSelect.value = previous
+  }
+}
+
 async function ensureMicStream() {
   if (state.micStream) return state.micStream
+  // If a test stream is active on the same device, stop it — live stream replaces it
+  if (micTestStream) {
+    stopMicTest()
+  }
+  const deviceId = state.micDeviceId
   state.micStream = await navigator.mediaDevices.getUserMedia({
     audio: {
+      deviceId: deviceId ? { exact: deviceId } : undefined,
       echoCancellation: true,
       noiseSuppression: true,
       autoGainControl: true,
     },
   })
+  startMicMeter(state.micStream)
   return state.micStream
+}
+
+async function startMicTest() {
+  if (micTestStream) return
+  try {
+    const deviceId = state.micDeviceId
+    micTestStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        deviceId: deviceId ? { exact: deviceId } : undefined,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+    })
+    startMicMeter(micTestStream)
+    elements.micTestBtn.textContent = '⏹ Stop'
+    elements.micTestBtn.classList.add('btn-primary')
+    showError('')
+  } catch (error) {
+    showError(`Cannot access microphone: ${error.message}`)
+  }
+}
+
+function stopMicTest() {
+  if (!micTestStream) return
+  micTestStream.getTracks().forEach((t) => t.stop())
+  micTestStream = null
+  elements.micTestBtn.textContent = '⚙ Test'
+  elements.micTestBtn.classList.remove('btn-primary')
+  // Only stop the meter if we're not currently live
+  if (!state.ingestConnected) {
+    stopMicMeter()
+  }
+}
+
+function startMicMeter(stream) {
+  stopMicMeter() // clean up any previous context first
+  try {
+    micAudioCtx = new AudioContext()
+    micAnalyser = micAudioCtx.createAnalyser()
+    micAnalyser.fftSize = 256
+    const source = micAudioCtx.createMediaStreamSource(stream)
+    source.connect(micAnalyser)
+  } catch {
+    return
+  }
+
+  elements.meterRow.classList.remove('hidden')
+  const canvas = elements.micMeter
+  const ctx = canvas.getContext('2d')
+  const data = new Uint8Array(micAnalyser.frequencyBinCount)
+
+  function draw() {
+    micAnimFrame = requestAnimationFrame(draw)
+    micAnalyser.getByteFrequencyData(data)
+    const avg = data.reduce((a, b) => a + b, 0) / data.length
+    const volume = avg / 128 // normalise 0..1
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    // Track background
+    ctx.fillStyle = '#e9ecef'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    // Active bar — colour reflects level
+    if (volume > 0.95) {
+      ctx.fillStyle = '#dc3545' // red — clipping
+    } else if (volume > 0.75) {
+      ctx.fillStyle = '#fd7e14' // amber — loud
+    } else {
+      ctx.fillStyle = '#22c55e' // green — normal
+    }
+    ctx.fillRect(0, 0, volume * canvas.width, canvas.height)
+  }
+  draw()
+}
+
+function stopMicMeter() {
+  if (micAnimFrame) {
+    cancelAnimationFrame(micAnimFrame)
+    micAnimFrame = null
+  }
+  if (micAudioCtx) {
+    micAudioCtx.close().catch(() => {})
+    micAudioCtx = null
+    micAnalyser = null
+  }
+  const canvas = elements.micMeter
+  if (canvas) {
+    const ctx = canvas.getContext('2d')
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+  }
+  elements.meterRow.classList.add('hidden')
 }
 
 async function toggleMicMute() {
@@ -373,6 +553,14 @@ async function stopLiveIngest() {
   if (state.peerConnection) {
     state.peerConnection.close()
     state.peerConnection = null
+  }
+  // Release live mic stream and stop the meter (unless a test is still active)
+  if (state.micStream) {
+    state.micStream.getTracks().forEach((t) => t.stop())
+    state.micStream = null
+  }
+  if (!micTestStream) {
+    stopMicMeter()
   }
   if (state.joined && state.participantId) {
     if (!state.whipBase) {
@@ -514,6 +702,16 @@ function renderMicControls() {
   elements.toggleMic.disabled = !state.joined
   elements.goLive.disabled = !state.ingestConnected && (!joinedActiveInterpreter || !state.ingestReachable)
   elements.passRelay.disabled = !joinedActiveInterpreter
+  // Disable device selector while streaming — cannot switch device mid-stream
+  elements.micDeviceSelect.disabled = state.ingestConnected
+  // Show HLS stream URL once live so the interpreter can paste it into VLC
+  if (state.ingestConnected && state.hlsBase) {
+    const url = `${state.hlsBase}/${encodeURIComponent(state.channelId)}/index.m3u8`
+    elements.hlsUrlDisplay.textContent = url
+    elements.hlsUrlRow.classList.remove('hidden')
+  } else {
+    elements.hlsUrlRow.classList.add('hidden')
+  }
 }
 
 function setBadge(element, text, tone = '') {

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -93,16 +93,38 @@
       <span id='ingest-status' class='status-badge'>Ingest disconnected</span>
     </header>
     <div class='panel-body mic-controls'>
+
+      <div class='device-row'>
+        <label class='device-label' for='mic-device-select'>🎤 Microphone</label>
+        <div class='device-select-row'>
+          <select id='mic-device-select' class='input device-select'>
+            <option value=''>Default microphone</option>
+          </select>
+          <button id='mic-test-btn' type='button' class='btn' title='Acquire mic and show live level'>⚙ Test</button>
+        </div>
+      </div>
+
+      <div id='meter-row' class='meter-row hidden'>
+        <span class='meter-label'>Input level</span>
+        <canvas id='mic-meter' class='mic-meter' width='400' height='10'></canvas>
+      </div>
+
+      <hr class='mic-divider' />
       <p class='hint'>Only the active interpreter can go live. Headphones are recommended.</p>
       <div class='mic-buttons'>
         <button id='toggle-mic' type='button' class='btn'>Mute</button>
         <button id='go-live' type='button' class='btn btn-primary'>Go Live</button>
         <button id='pass-relay' type='button' class='btn'>Pass Relay</button>
       </div>
+
       <dl class='status-list'>
         <div><dt>Mic state</dt><dd id='mic-state'>Inactive</dd></div>
         <div><dt>Ingest reachable</dt><dd id='ingest-reachable'>Unknown</dd></div>
         <div><dt>Active interpreter</dt><dd id='active-name'>Unassigned</dd></div>
+        <div id='hls-url-row' class='hidden'>
+          <dt>HLS stream (VLC / browser)</dt>
+          <dd class='hls-url-cell'><code id='hls-url-display'></code><button id='copy-hls-url' type='button' class='btn btn-xs'>Copy</button></dd>
+        </div>
       </dl>
       <p id='error-banner' class='error-banner'></p>
     </div>


### PR DESCRIPTION
Implements Phase 1 Step 4. Also fixes the MediaMTX 400 error that prevented WHIP publishing ('path not configured') by adding paths: all_others: to mediamtx.yml — required in MediaMTX v1.x even when pathDefaults is set.

Changes:
- mediamtx.yml: add paths: all_others: wildcard to allow auto-creation of any WHIP path; fixes 400 'path not configured' error
- templates/interpreter_booth.html: replace flat mic controls with device selector + level meter canvas + HLS URL row (shown when live)
- static/css/interpreter.css: add device-row, meter-row, mic-meter, hidden, btn-xs, hls-url-cell styles
- static/js/interpreter-booth.js:
  * state: add micDeviceId (persisted in localStorage)
  * elements: add micDeviceSelect, micMeter, meterRow, micTestBtn, hlsUrlRow, hlsUrlDisplay, copyHlsUrl
  * module vars: micTestStream, micAnimFrame, micAudioCtx, micAnalyser
  * populateMicDevices(): enumerates audio inputs with permission request; restores saved device from localStorage; re-runs on devicechange
  * ensureMicStream(): uses selected deviceId with {exact} constraint; stops test stream before acquiring live stream; starts meter
  * startMicTest() / stopMicTest(): test button acquires mic without going live; drives the level meter; btn toggles between Test / Stop
  * startMicMeter(stream): AnalyserNode driving canvas rAF loop; green < 75%, amber 75-95%, red > 95% (clipping)
  * stopMicMeter(): cancels rAF, closes AudioContext, hides meter row
  * stopLiveIngest(): release micStream tracks; stop meter if no test active
  * renderMicControls(): disable device select while live; show HLS stream URL with Copy button so interpreter can paste into VLC or hls.js player
 


Fixes #44