### PR TITLE
Add Google Meet-style control bar and mute/unmute controls

### DIFF
--- a/static/css/interpreter.css
+++ b/static/css/interpreter.css
@@ -326,27 +326,10 @@ label {
   font-size: 0.88rem;
 }
 
-/* ── Device selection ─────────────────────────────────────── */
-.device-row {
-  display: grid;
-  gap: 0.35rem;
-}
-
-.device-label {
-  color: var(--color-muted);
-  font-size: 0.88rem;
-  font-weight: 500;
-}
-
-.device-select-row {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 0.5rem;
-  align-items: center;
-}
-
+/* ── Device select (used inside ctrl-popup) ───────────────── */
 .device-select {
-  min-width: 0; /* prevent overflow in grid */
+  min-width: 0;
+  width: 100%;
 }
 
 /* ── Mic level meter ──────────────────────────────────────── */
@@ -373,12 +356,6 @@ label {
   border: 1px solid var(--color-border);
 }
 
-.mic-divider {
-  border: none;
-  border-top: 1px solid var(--color-panel-border);
-  margin: 0.1rem 0;
-}
-
 /* ── HLS URL row ──────────────────────────────────────────── */
 .hls-url-cell {
   display: flex;
@@ -397,6 +374,189 @@ label {
   padding: 0.15rem 0.4rem;
   font-size: 0.78rem;
   flex-shrink: 0;
+}
+
+/* ── Google Meet–style control bar ───────────────────────── */
+.control-bar {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1rem;
+  background: #f8f9fa;
+  border-top: 1px solid var(--color-panel-border);
+  border-bottom: 1px solid var(--color-panel-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lightest);
+}
+
+.ctrl-row {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+/* Compound button wrapper (mic toggle + chevron arrow) */
+.ctrl-compound {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+}
+
+/* Base icon button */
+.ctrl-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.18rem;
+  min-width: 3.2rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.6rem;
+  border: none;
+  background: #e4e6e8;
+  color: #1c1e21;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    box-shadow 0.15s;
+}
+
+.ctrl-btn:hover:not(:disabled) {
+  background: #d0d2d5;
+}
+
+.ctrl-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Left side of compound: same radius but square on the right */
+.ctrl-btn--mic {
+  border-radius: 0.6rem 0 0 0.6rem;
+}
+
+/* Right side of compound: the chevron arrow */
+.ctrl-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.45rem;
+  border: none;
+  background: #e4e6e8;
+  border-radius: 0 0.6rem 0.6rem 0;
+  cursor: pointer;
+  color: #444;
+  transition: background 0.15s;
+}
+
+.ctrl-chevron:hover {
+  background: #d0d2d5;
+}
+
+/* SVG icon inside a ctrl-btn */
+.ctrl-icon {
+  width: 1.3rem;
+  height: 1.3rem;
+  flex-shrink: 0;
+}
+
+/* Small text label under icon */
+.ctrl-label {
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: inherit;
+  line-height: 1;
+}
+
+/* ── Muted state ─────────────────────────────────────────── */
+.ctrl-btn--mic.muted,
+.ctrl-compound.muted .ctrl-btn--mic,
+.ctrl-compound.muted .ctrl-chevron {
+  background: rgb(226 14 58 / 0.14);
+  color: #c0163e;
+}
+
+.ctrl-btn--mic.muted:hover,
+.ctrl-compound.muted .ctrl-btn--mic:hover {
+  background: rgb(226 14 58 / 0.22);
+}
+
+@keyframes pulse-muted {
+  0%, 100% { box-shadow: 0 0 0 0 rgb(192 22 62 / 0.45); }
+  50%       { box-shadow: 0 0 0 7px rgb(192 22 62 / 0); }
+}
+
+.ctrl-btn--mic.muted {
+  animation: pulse-muted 1.6s ease-in-out infinite;
+}
+
+/* ── Live state ──────────────────────────────────────────── */
+#go-live.live {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+#go-live.live:hover {
+  background: var(--color-primary-text);
+}
+
+/* ── Danger button (leave) ──────────────────────────────── */
+.ctrl-btn--danger {
+  background: #c0392b;
+  color: #fff;
+}
+
+.ctrl-btn--danger:hover:not(:disabled) {
+  background: #a93226;
+}
+
+/* ── Keyboard shortcut hint ──────────────────────────────── */
+.ctrl-shortcut-hint {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--color-muted);
+}
+
+.ctrl-shortcut-hint kbd {
+  display: inline-block;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  padding: 0 0.3em;
+  font-size: 0.7rem;
+  font-family: inherit;
+  background: #fff;
+  color: var(--color-text);
+  line-height: 1.4;
+}
+
+/* ── Mic device picker popup ────────────────────────────── */
+.ctrl-popup {
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  left: 0;
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 20px rgb(0 0 0 / 0.15);
+  padding: 0.85rem;
+  min-width: 280px;
+  z-index: 200;
+}
+
+.ctrl-popup-title {
+  margin: 0 0 0.55rem 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.ctrl-popup-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.55rem;
 }
 
 /* ── Utility ─────────────────────────────────────────────── */

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -58,6 +58,12 @@ const elements = {
   hlsUrlRow: document.getElementById('hls-url-row'),
   hlsUrlDisplay: document.getElementById('hls-url-display'),
   copyHlsUrl: document.getElementById('copy-hls-url'),
+  micChevron: document.getElementById('mic-chevron'),
+  ctrlMicPopup: document.getElementById('ctrl-mic-popup'),
+  muteLabel: document.getElementById('mute-label'),
+  liveLabel: document.getElementById('live-label'),
+  ctrlCompound: document.querySelector('.ctrl-compound'),
+  leaveBooth: document.getElementById('leave-booth-btn'),
 }
 
 // ── Audio context state (not reflected directly in UI) ────────────────────
@@ -173,6 +179,53 @@ function bindEventHandlers() {
         elements.copyHlsUrl.textContent = 'Copy'
       }, 2000)
     }).catch(() => {})
+  })
+
+  // Chevron: toggle mic device picker popup
+  elements.micChevron.addEventListener('click', (event) => {
+    event.stopPropagation()
+    const isHidden = elements.ctrlMicPopup.classList.contains('hidden')
+    elements.ctrlMicPopup.classList.toggle('hidden', !isHidden)
+    elements.micChevron.setAttribute('aria-expanded', String(isHidden))
+  })
+
+  // Close popup when clicking outside it
+  document.addEventListener('click', (event) => {
+    if (!elements.ctrlMicPopup.classList.contains('hidden') &&
+        !elements.ctrlMicPopup.contains(event.target) &&
+        event.target !== elements.micChevron) {
+      elements.ctrlMicPopup.classList.add('hidden')
+      elements.micChevron.setAttribute('aria-expanded', 'false')
+    }
+  })
+
+  // Space key: toggle mute (skip when focus is in a text input / select)
+  document.addEventListener('keydown', (event) => {
+    if (event.code !== 'Space') return
+    const tag = document.activeElement?.tagName?.toLowerCase()
+    if (tag === 'input' || tag === 'textarea' || tag === 'select') return
+    event.preventDefault()
+    toggleMicMute().catch(() => {})
+  })
+
+  // Leave booth button
+  elements.leaveBooth.addEventListener('click', async () => {
+    if (state.ingestConnected) {
+      await stopLiveIngest()
+    }
+    if (state.joined && state.participantId) {
+      socket.emit('booth:leave', {
+        booth_id: state.boothId,
+        participant_id: state.participantId,
+        language: state.language,
+        channel_id: state.channelId,
+      })
+      state.joined = false
+      state.participantId = null
+    }
+    socket.disconnect()
+    setBadge(elements.connectionStatus, 'Left', 'warning')
+    renderMicControls()
   })
 
   navigator.mediaDevices.addEventListener('devicechange', () => {
@@ -406,8 +459,10 @@ function startMicMeter(stream) {
     // Track background
     ctx.fillStyle = '#e9ecef'
     ctx.fillRect(0, 0, canvas.width, canvas.height)
-    // Active bar — colour reflects level
-    if (volume > 0.95) {
+    // Active bar — grey when muted, colour reflects level when live
+    if (state.micMuted) {
+      ctx.fillStyle = '#9ca3af' // grey — muted
+    } else if (volume > 0.95) {
       ctx.fillStyle = '#dc3545' // red — clipping
     } else if (volume > 0.75) {
       ctx.fillStyle = '#fd7e14' // amber — loud
@@ -697,8 +752,22 @@ function renderMicControls() {
   setBadge(elements.ingestStatus, state.ingestConnected ? 'Ingest connected' : 'Ingest disconnected', state.ingestConnected ? 'success' : 'warning')
   elements.ingestReachable.textContent = state.ingestReachable ? 'Reachable' : 'Unavailable'
   elements.micState.textContent = state.micMuted ? 'Muted' : state.micStream ? 'Ready' : 'Inactive'
-  elements.toggleMic.textContent = state.micMuted ? 'Unmute' : 'Mute'
-  elements.goLive.textContent = state.ingestConnected ? 'Stop Live' : 'Go Live'
+  // ── Control bar icon states ─────────────────────────────────────────────
+  // Mute button: show mic-off icon + muted class + pulsing when muted
+  const micOnIcon = elements.toggleMic.querySelector('.ctrl-icon--mic-on')
+  const micOffIcon = elements.toggleMic.querySelector('.ctrl-icon--mic-off')
+  if (micOnIcon) micOnIcon.classList.toggle('hidden', state.micMuted)
+  if (micOffIcon) micOffIcon.classList.toggle('hidden', !state.micMuted)
+  elements.toggleMic.classList.toggle('muted', state.micMuted)
+  if (elements.ctrlCompound) elements.ctrlCompound.classList.toggle('muted', state.micMuted)
+  if (elements.muteLabel) elements.muteLabel.textContent = state.micMuted ? 'UNMUTE' : 'MUTE'
+  elements.toggleMic.setAttribute('aria-label', state.micMuted ? 'Unmute microphone' : 'Mute microphone')
+  elements.toggleMic.setAttribute('title', state.micMuted ? 'Unmute (Space)' : 'Mute (Space)')
+
+  // Go Live button
+  elements.goLive.classList.toggle('live', state.ingestConnected)
+  if (elements.liveLabel) elements.liveLabel.textContent = state.ingestConnected ? 'STOP' : 'GO LIVE'
+
   elements.toggleMic.disabled = !state.joined
   elements.goLive.disabled = !state.ingestConnected && (!joinedActiveInterpreter || !state.ingestReachable)
   elements.passRelay.disabled = !joinedActiveInterpreter

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -63,6 +63,72 @@
     </div>
   </section>
 
+  <!-- ── Google Meet–style control bar ───────────────────────────────────── -->
+  <div class='control-bar' id='main-control-bar'>
+    <!-- Mic device picker — floats above bar when chevron is clicked -->
+    <div id='ctrl-mic-popup' class='ctrl-popup hidden' role='dialog' aria-label='Microphone options'>
+      <p class='ctrl-popup-title'>🎤 Microphone</p>
+      <select id='mic-device-select' class='input device-select'>
+        <option value=''>Default microphone</option>
+      </select>
+      <div id='meter-row' class='meter-row hidden'>
+        <span class='meter-label'>Input level</span>
+        <canvas id='mic-meter' class='mic-meter' width='400' height='10'></canvas>
+      </div>
+      <div class='ctrl-popup-actions'>
+        <button id='mic-test-btn' type='button' class='btn' title='Acquire mic and show live level'>⚙ Test</button>
+      </div>
+    </div>
+
+    <div class='ctrl-row'>
+      <!-- Compound mic button: toggle mute + device chevron -->
+      <div class='ctrl-compound'>
+        <button id='toggle-mic' type='button' class='ctrl-btn ctrl-btn--mic' title='Mute / Unmute (Space)' aria-label='Mute microphone'>
+          <!-- mic-on icon -->
+          <svg class='ctrl-icon ctrl-icon--mic-on' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
+            <path d='M12 14c1.66 0 2.99-1.34 2.99-3L15 5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3zm5.3-3c0 3-2.54 5.1-5.3 5.1S6.7 14 6.7 11H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28C16.28 17.23 19 14.41 19 11h-1.7z'/>
+          </svg>
+          <!-- mic-off icon (shown when muted) -->
+          <svg class='ctrl-icon ctrl-icon--mic-off hidden' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
+            <path d='M19 11h-1.7c0 .74-.16 1.43-.43 2.05l1.23 1.23c.56-.98.9-2.09.9-3.28zm-4.02.17c0-.06.02-.11.02-.17V5c0-1.66-1.34-3-3-3S9 3.34 9 5v.18l5.98 5.99zM4.27 3 3 4.27l6.01 6.01V11c0 1.66 1.33 3 2.99 3 .22 0 .44-.03.65-.08l1.66 1.66c-.71.33-1.5.52-2.31.52-2.76 0-5.3-2.1-5.3-5.1H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28c.91-.13 1.77-.45 2.54-.9L19.73 21 21 19.73 4.27 3z'/>
+          </svg>
+          <span class='ctrl-label' id='mute-label'>MUTE</span>
+        </button>
+        <button id='mic-chevron' type='button' class='ctrl-chevron' title='Microphone options' aria-label='Microphone options' aria-expanded='false' aria-controls='ctrl-mic-popup'>
+          <svg viewBox='0 0 24 24' width='12' height='12' fill='currentColor' aria-hidden='true'>
+            <path d='M7 14l5-5 5 5z'/>
+          </svg>
+        </button>
+      </div>
+
+      <!-- Go Live / Stop Live -->
+      <button id='go-live' type='button' class='ctrl-btn' title='Go Live / Stop Live' aria-label='Go live'>
+        <svg class='ctrl-icon' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
+          <path d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z'/>
+        </svg>
+        <span class='ctrl-label' id='live-label'>GO LIVE</span>
+      </button>
+
+      <!-- Pass Relay -->
+      <button id='pass-relay' type='button' class='ctrl-btn' title='Pass relay to next interpreter' aria-label='Pass relay'>
+        <svg class='ctrl-icon' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
+          <path d='M6.99 11 3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z'/>
+        </svg>
+        <span class='ctrl-label'>RELAY</span>
+      </button>
+
+      <!-- Leave booth -->
+      <button id='leave-booth-btn' type='button' class='ctrl-btn ctrl-btn--danger' title='Leave booth' aria-label='Leave booth'>
+        <svg class='ctrl-icon' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
+          <path d='M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5c-1.11 0-2 .9-2 2v4h2V5h14v14H5v-4H3v4c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z'/>
+        </svg>
+        <span class='ctrl-label'>LEAVE</span>
+      </button>
+    </div>
+
+    <p class='ctrl-shortcut-hint'>Press <kbd>Space</kbd> to mute / unmute</p>
+  </div>
+
   <section class='panel'>
     <header class='panel-header'>
       <h2>Participants</h2>
@@ -89,34 +155,11 @@
 
   <section class='panel'>
     <header class='panel-header'>
-      <h2>Mic Controls</h2>
+      <h2>Audio Status</h2>
       <span id='ingest-status' class='status-badge'>Ingest disconnected</span>
     </header>
     <div class='panel-body mic-controls'>
-
-      <div class='device-row'>
-        <label class='device-label' for='mic-device-select'>🎤 Microphone</label>
-        <div class='device-select-row'>
-          <select id='mic-device-select' class='input device-select'>
-            <option value=''>Default microphone</option>
-          </select>
-          <button id='mic-test-btn' type='button' class='btn' title='Acquire mic and show live level'>⚙ Test</button>
-        </div>
-      </div>
-
-      <div id='meter-row' class='meter-row hidden'>
-        <span class='meter-label'>Input level</span>
-        <canvas id='mic-meter' class='mic-meter' width='400' height='10'></canvas>
-      </div>
-
-      <hr class='mic-divider' />
       <p class='hint'>Only the active interpreter can go live. Headphones are recommended.</p>
-      <div class='mic-buttons'>
-        <button id='toggle-mic' type='button' class='btn'>Mute</button>
-        <button id='go-live' type='button' class='btn btn-primary'>Go Live</button>
-        <button id='pass-relay' type='button' class='btn'>Pass Relay</button>
-      </div>
-
       <dl class='status-list'>
         <div><dt>Mic state</dt><dd id='mic-state'>Inactive</dd></div>
         <div><dt>Ingest reachable</dt><dd id='ingest-reachable'>Unknown</dd></div>


### PR DESCRIPTION
Implements Phase 1 Step 5 (issue #45).

Control bar (placed between Jitsi feed and Participants panel):
- Compound mic button: left side toggles mute, right chevron opens device picker popup; reflects muted state with pink/red background, strikethrough mic-off SVG icon, and pulsing amber box-shadow animation
- Go Live / Stop button with blue active state
- Pass Relay button (relay handoff icon)
- Leave Booth button (red, disconnects socket and stops ingest)
- Keyboard shortcut hint showing Space key below the row

Mute behaviour:
- toggleMicMute() sets track.enabled = false (WebRTC stays alive, sends silence) and flips state.micMuted
- Level meter turns grey when muted (not just silent-looking)
- mic-on / mic-off SVG icons swap on the mute button
- aria-label updated on mute toggle for screen readers

Keyboard shortcut:
- Space key fires toggleMicMute() when no text/select field has focus; default scroll action is suppressed

Mic device popup:
- Chevron opens/closes absolutely-positioned popup above the bar
- Contains device <select>, live level meter, and Test button
- Clicking outside the popup closes it
- aria-expanded attribute kept in sync on the chevron

Backend sync:
- booth:update-state emitted with mic_active on every mute toggle (was already wired from Step 4; same event, confirmed working)

CSS additions: .control-bar, .ctrl-row, .ctrl-compound, .ctrl-btn, .ctrl-btn--mic, .ctrl-chevron, .ctrl-icon, .ctrl-label, .ctrl-btn--danger, @keyframes pulse-muted, .ctrl-popup, .ctrl-popup-title, .ctrl-popup-actions, .ctrl-shortcut-hint, kbd


fixes #45 