### PR TITLE
Add preflight checks for mic, audio device, and server

### DIFF
--- a/static/css/interpreter.css
+++ b/static/css/interpreter.css
@@ -559,6 +559,59 @@ label {
   margin-top: 0.55rem;
 }
 
+/* ── Preflight checklist ─────────────────────────────────── */
+.preflight-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.preflight-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: var(--radius);
+  transition: background 0.15s;
+}
+
+.preflight-icon {
+  font-size: 1rem;
+  line-height: 1.35;
+  flex-shrink: 0;
+  width: 1.4rem;
+  text-align: center;
+}
+
+.preflight-info {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.preflight-name {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.preflight-msg {
+  font-size: 0.78rem;
+  color: var(--color-muted);
+}
+
+.preflight--pending { background: rgb(108 117 125 / 0.06); }
+
+.preflight--pass { background: rgb(42 143 76 / 0.08); }
+.preflight--pass .preflight-name { color: var(--color-success); }
+
+.preflight--fail { background: rgb(178 62 101 / 0.08); }
+.preflight--fail .preflight-name { color: var(--color-danger); }
+
+.preflight--warn { background: rgb(209 133 56 / 0.08); }
+.preflight--warn .preflight-name { color: var(--color-warning); }
+
 /* ── Utility ─────────────────────────────────────────────── */
 .hidden {
   display: none !important;

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -25,6 +25,11 @@ const state = {
   whipBase: portal.dataset.whipBase || '',
   hlsBase: portal.dataset.hlsBase || '',
   micDeviceId: localStorage.getItem('mic-device-id') || '',
+  preflight: {
+    micPermission: 'pending',
+    audioDevice: 'pending',
+    serverReachable: 'pending',
+  },
 }
 
 const elements = {
@@ -64,6 +69,10 @@ const elements = {
   liveLabel: document.getElementById('live-label'),
   ctrlCompound: document.querySelector('.ctrl-compound'),
   leaveBooth: document.getElementById('leave-booth-btn'),
+  preflightRetry: document.getElementById('preflight-retry'),
+  checkMicPermission: document.getElementById('check-mic-permission'),
+  checkAudioDevice: document.getElementById('check-audio-device'),
+  checkServer: document.getElementById('check-server'),
 }
 
 // ── Audio context state (not reflected directly in UI) ────────────────────
@@ -84,7 +93,10 @@ async function boot() {
   await fetchIngestReachability()
   await populateMicDevices()
   bindEventHandlers()
-  render()
+  render() // show page with pending preflight state first
+  runPreflightChecks().catch((error) => {
+    showError(`Preflight checks failed: ${error.message}`)
+  })
 }
 
 function bindEventHandlers() {
@@ -209,6 +221,12 @@ function bindEventHandlers() {
   })
 
   // Leave booth button
+  elements.preflightRetry.addEventListener('click', () => {
+    runPreflightChecks().catch((error) => {
+      showError(`Preflight checks failed: ${error.message}`)
+    })
+  })
+
   elements.leaveBooth.addEventListener('click', async () => {
     if (state.ingestConnected) {
       await stopLiveIngest()
@@ -256,6 +274,80 @@ function bindEventHandlers() {
       channel_id: state.channelId,
     })
   })
+}
+
+async function runPreflightChecks() {
+  setPreflightStatus('micPermission', 'pending', 'Checking…')
+  setPreflightStatus('audioDevice', 'pending', 'Checking…')
+  setPreflightStatus('serverReachable', 'pending', 'Checking…')
+
+  // 1. Microphone permission
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    stream.getTracks().forEach((t) => t.stop())
+    setPreflightStatus('micPermission', 'pass', 'Permission granted')
+  } catch (error) {
+    const msg =
+      error.name === 'NotAllowedError'
+        ? 'Denied — allow microphone access in browser settings'
+        : `Error: ${error.message}`
+    setPreflightStatus('micPermission', 'fail', msg)
+  }
+
+  // 2. Audio device detected
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices()
+    const audioInputs = devices.filter((d) => d.kind === 'audioinput')
+    if (audioInputs.length > 0) {
+      setPreflightStatus('audioDevice', 'pass', `${audioInputs.length} device${audioInputs.length > 1 ? 's' : ''} found`)
+    } else {
+      setPreflightStatus('audioDevice', 'fail', 'No microphone detected — connect a USB mic or headset')
+    }
+  } catch {
+    setPreflightStatus('audioDevice', 'warn', 'Could not enumerate devices')
+  }
+
+  // 3. Media server reachability — any HTTP response (even 404) means the server is up;
+  //    only a network error (connection refused / timeout) means it is down.
+  if (!state.hlsBase) {
+    setPreflightStatus('serverReachable', 'warn', 'HLS base not configured — server check skipped')
+  } else {
+    try {
+      const controller = new AbortController()
+      const timeoutId = window.setTimeout(() => controller.abort(), 4000)
+      // no-cors avoids CORS errors; opaque response (status 0) is fine — network errors throw
+      await fetch(`${state.hlsBase}/`, { method: 'HEAD', mode: 'no-cors', signal: controller.signal })
+      window.clearTimeout(timeoutId)
+      setPreflightStatus('serverReachable', 'pass', 'MediaMTX is reachable')
+      state.ingestReachable = true
+    } catch (error) {
+      const msg =
+        error.name === 'AbortError'
+          ? 'Timed out — start MediaMTX: docker compose up mediamtx'
+          : 'Unreachable — start MediaMTX: docker compose up mediamtx'
+      setPreflightStatus('serverReachable', 'fail', msg)
+      state.ingestReachable = false
+    }
+  }
+
+  renderMicControls()
+}
+
+function setPreflightStatus(check, status, message = '') {
+  state.preflight[check] = status
+  const idMap = {
+    micPermission: 'check-mic-permission',
+    audioDevice: 'check-audio-device',
+    serverReachable: 'check-server',
+  }
+  const iconMap = { pass: '✅', fail: '❌', warn: '⚠️', pending: '⏳' }
+  const el = document.getElementById(idMap[check])
+  if (!el) return
+  el.className = `preflight-item preflight--${status}`
+  const iconEl = el.querySelector('.preflight-icon')
+  if (iconEl) iconEl.textContent = iconMap[status] ?? '⏳'
+  const msgEl = el.querySelector('.preflight-msg')
+  if (msgEl) msgEl.textContent = message
 }
 
 async function fetchBoothState() {
@@ -769,7 +861,10 @@ function renderMicControls() {
   if (elements.liveLabel) elements.liveLabel.textContent = state.ingestConnected ? 'STOP' : 'GO LIVE'
 
   elements.toggleMic.disabled = !state.joined
-  elements.goLive.disabled = !state.ingestConnected && (!joinedActiveInterpreter || !state.ingestReachable)
+  const preflightCriticalPass =
+    state.preflight.micPermission === 'pass' &&
+    state.preflight.serverReachable !== 'fail'
+  elements.goLive.disabled = !state.ingestConnected && (!joinedActiveInterpreter || !state.ingestReachable || !preflightCriticalPass)
   elements.passRelay.disabled = !joinedActiveInterpreter
   // Disable device selector while streaming — cannot switch device mid-stream
   elements.micDeviceSelect.disabled = state.ingestConnected

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -63,6 +63,39 @@
     </div>
   </section>
 
+  <!-- ── Preflight checks ─────────────────────────────────────────────────── -->
+  <section class='panel panel--preflight'>
+    <header class='panel-header'>
+      <h2>Preflight Checks</h2>
+      <button id='preflight-retry' type='button' class='btn btn-xs'>↺ Retry</button>
+    </header>
+    <div class='panel-body'>
+      <ul class='preflight-list'>
+        <li id='check-mic-permission' class='preflight-item preflight--pending'>
+          <span class='preflight-icon'>⏳</span>
+          <div class='preflight-info'>
+            <span class='preflight-name'>Microphone permission</span>
+            <span class='preflight-msg'></span>
+          </div>
+        </li>
+        <li id='check-audio-device' class='preflight-item preflight--pending'>
+          <span class='preflight-icon'>⏳</span>
+          <div class='preflight-info'>
+            <span class='preflight-name'>Audio device detected</span>
+            <span class='preflight-msg'></span>
+          </div>
+        </li>
+        <li id='check-server' class='preflight-item preflight--pending'>
+          <span class='preflight-icon'>⏳</span>
+          <div class='preflight-info'>
+            <span class='preflight-name'>Media server reachable</span>
+            <span class='preflight-msg'></span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </section>
+
   <!-- ── Google Meet–style control bar ───────────────────────────────────── -->
   <div class='control-bar' id='main-control-bar'>
     <!-- Mic device picker — floats above bar when chevron is clicked -->


### PR DESCRIPTION
fixes  #46

Preflight checks panel (above the control bar):
- Runs automatically on page load (non-blocking — page renders first with ⏳ pending state, then each check updates inline)
- ↺ Retry button re-runs all three checks without page reload

Checks:
1. Microphone permission — getUserMedia({ audio: true }); surfaces 'Denied — allow microphone access in browser settings' on NotAllowedError
2. Audio device detected — enumerateDevices(); counts audioinput entries; warns 'No microphone detected — connect a USB mic or headset'
3. Media server reachable — HEAD fetch to HLS base with no-cors mode; 4-second AbortController timeout; 'warn' (skip) when hlsBase is not configured (legacy aiortc path); updates state.ingestReachable on result

Go Live gate update:
- preflightCriticalPass = mic permission granted AND server not 'fail'
- Go Live button stays disabled until both critical checks pass
- Pending state also blocks Go Live (safe default during check run)

Backend WebSocket: no change — preflight is client-side validation only

setPreflightStatus(check, status, message):
- Updates state.preflight[check]
- Swaps CSS class (preflight--pending/pass/fail/warn) on the <li>
- Updates ⏳/✅/❌/⚠️ icon and inline message text

CSS: .preflight-list, .preflight-item, .preflight-icon, .preflight-info, .preflight-name, .preflight-msg, colour variants per state

## Summary by Sourcery

Add a preflight checklist panel that runs on page load to validate microphone permission, audio device availability, and media server reachability before allowing interpreters to go live.

New Features:
- Introduce a preflight checks UI panel with retry control to show mic permission, audio device detection, and media server reachability status.
- Automatically run client-side preflight checks on page load and allow manual re-run without reloading the page.

Enhancements:
- Gate the Go Live button on successful microphone permission and non-failing server reachability states to prevent starting without critical prerequisites.
- Add styling for preflight checklist items with distinct visual states for pending, pass, fail, and warning outcomes.