### PR TITLE
Add HLS playback validation with polling

### DIFF
--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -38,6 +38,8 @@ webrtcLocalUDPAddress: :8189  # single UDP port for all ICE traffic (replaces de
 #                     until post-MVP per docs/detailedplan.md § 11.2.
 hlsAddress: :8888
 hlsEncryption: no
+# Allow the browser JS on :5000 to fetch the HLS playlist for validation (cross-origin)
+hlsAllowOrigin: '*'
 hlsAlwaysRemux: yes
 hlsSegmentDuration: 2s
 hlsSegmentMaxSize: 50MB

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -364,6 +364,16 @@ async function validateHlsOutput() {
   try {
     const response = await fetch(url, { cache: 'no-store' })
     if (!response.ok) return false
+
+    const contentType = response.headers.get('content-type') || ''
+    const normalizedContentType = contentType.toLowerCase()
+    const isHlsMimeType =
+      normalizedContentType.startsWith('application/vnd.apple.mpegurl') ||
+      normalizedContentType.startsWith('application/x-mpegurl') ||
+      normalizedContentType.startsWith('audio/mpegurl')
+
+    if (!isHlsMimeType) return false
+
     const text = await response.text()
     return text.includes('#EXTM3U')
   } catch {

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -73,6 +73,7 @@ const elements = {
   checkMicPermission: document.getElementById('check-mic-permission'),
   checkAudioDevice: document.getElementById('check-audio-device'),
   checkServer: document.getElementById('check-server'),
+  hlsValidationStatus: document.getElementById('hls-validation-status'),
 }
 
 // ── Audio context state (not reflected directly in UI) ────────────────────
@@ -80,6 +81,12 @@ let micTestStream = null
 let micAnimFrame = null
 let micAudioCtx = null
 let micAnalyser = null
+
+// ── HLS polling state ────────────────────────────────────────────────────
+let hlsPollTimer = null
+let hlsPollCount = 0
+const HLS_POLL_INTERVAL_MS = 1000
+const HLS_POLL_MAX_ATTEMPTS = 10
 
 const socket = io()
 
@@ -348,6 +355,63 @@ function setPreflightStatus(check, status, message = '') {
   if (iconEl) iconEl.textContent = iconMap[status] ?? '⏳'
   const msgEl = el.querySelector('.preflight-msg')
   if (msgEl) msgEl.textContent = message
+}
+
+// ── HLS validation ───────────────────────────────────────────────────────
+async function validateHlsOutput() {
+  if (!state.hlsBase || !state.channelId) return false
+  const url = `${state.hlsBase}/${encodeURIComponent(state.channelId)}/index.m3u8`
+  try {
+    const response = await fetch(url, { cache: 'no-store' })
+    if (!response.ok) return false
+    const text = await response.text()
+    return text.includes('#EXTM3U')
+  } catch {
+    return false
+  }
+}
+
+function startHlsPolling() {
+  stopHlsPolling()
+  hlsPollCount = 0
+  setHlsValidationStatus('polling')
+
+  async function poll() {
+    hlsPollCount += 1
+    setHlsValidationStatus('polling') // update count in badge
+    const valid = await validateHlsOutput()
+    if (valid) {
+      setHlsValidationStatus('streaming')
+      hlsPollTimer = null
+      return
+    }
+    if (hlsPollCount >= HLS_POLL_MAX_ATTEMPTS) {
+      setHlsValidationStatus('unavailable')
+      hlsPollTimer = null
+      return
+    }
+    hlsPollTimer = window.setTimeout(poll, HLS_POLL_INTERVAL_MS)
+  }
+
+  hlsPollTimer = window.setTimeout(poll, HLS_POLL_INTERVAL_MS)
+}
+
+function stopHlsPolling() {
+  if (hlsPollTimer !== null) {
+    window.clearTimeout(hlsPollTimer)
+    hlsPollTimer = null
+  }
+}
+
+function setHlsValidationStatus(status) {
+  const statusMap = {
+    idle:        { text: 'Not started', tone: '' },
+    polling:     { text: `Validating\u2026 ${hlsPollCount}/${HLS_POLL_MAX_ATTEMPTS}`, tone: 'warning' },
+    streaming:   { text: 'Streaming',   tone: 'success' },
+    unavailable: { text: 'Not available', tone: 'danger' },
+  }
+  const { text, tone } = statusMap[status] ?? { text: status, tone: '' }
+  setBadge(elements.hlsValidationStatus, text, tone)
 }
 
 async function fetchBoothState() {
@@ -680,6 +744,7 @@ async function startLiveIngest() {
     }
 
     state.ingestConnected = true
+    if (state.hlsBase) startHlsPolling()
     socket.emit('booth:update-state', {
       booth_id: state.boothId,
       participant_id: state.participantId,
@@ -732,6 +797,8 @@ async function stopLiveIngest() {
       ingest_connected: false,
     })
   }
+  stopHlsPolling()
+  setHlsValidationStatus('idle')
   state.ingestConnected = false
   renderMicControls()
 }

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -197,6 +197,7 @@
         <div><dt>Mic state</dt><dd id='mic-state'>Inactive</dd></div>
         <div><dt>Ingest reachable</dt><dd id='ingest-reachable'>Unknown</dd></div>
         <div><dt>Active interpreter</dt><dd id='active-name'>Unassigned</dd></div>
+        <div><dt>HLS stream</dt><dd><span id='hls-validation-status' class='status-badge'>Not started</span></dd></div>
         <div id='hls-url-row' class='hidden'>
           <dt>HLS stream (VLC / browser)</dt>
           <dd class='hls-url-cell'><code id='hls-url-display'></code><button id='copy-hls-url' type='button' class='btn btn-xs'>Copy</button></dd>


### PR DESCRIPTION
Fixes  #47


mediamtx.yml:
- Add hlsAllowOrigin: '*' so browser JS on :5000 can fetch the HLS playlist from MediaMTX on :8888 without CORS errors. Restart the container to pick up this change: docker compose -f docker-compose.interpretation.yml restart mediamtx

JS (static/js/interpreter-booth.js):
- Module-level HLS poll state: hlsPollTimer, hlsPollCount, HLS_POLL_INTERVAL_MS (1 s), HLS_POLL_MAX_ATTEMPTS (10)

- validateHlsOutput(): fetches {hlsBase}/{channelId}/index.m3u8 with cache: 'no-store'; returns true only when response is 2xx and body contains '#EXTM3U' (confirms valid HLS playlist)

- startHlsPolling(): resets counter; fires a setTimeout poll loop; each iteration calls validateHlsOutput() and updates the badge: polling → streaming (on success) polling → unavailable (after 10 attempts)

- stopHlsPolling(): clears any pending setTimeout

- setHlsValidationStatus(status): maps idle/polling/streaming/unavailable to badge text + tone (uses existing setBadge())

- startLiveIngest(): calls startHlsPolling() immediately after state.ingestConnected = true (first poll fires 1 s later)

- stopLiveIngest(): calls stopHlsPolling() + setHlsValidationStatus('idle') before clearing state.ingestConnected

Template (templates/interpreter_booth.html):
- Add 'HLS stream' row in Audio Status status list with <span id='hls-validation-status' class='status-badge'> for setBadge() to drive (idle → polling → streaming/unavailable)

## Summary by Sourcery

Add client-side HLS playlist validation with polling and expose its status in the interpreter booth UI while enabling cross-origin HLS access from the browser.

New Features:
- Introduce periodic HLS output validation that checks the channel playlist for a valid HLS manifest before marking streaming as available.
- Display an HLS stream status badge in the interpreter booth audio status panel to reflect validation and streaming state.

Enhancements:
- Start and stop the HLS validation polling loop in sync with live ingest lifecycle to keep the HLS status accurate.
- Allow MediaMTX to accept cross-origin HLS playlist requests from the web UI for validation by configuring hlsAllowOrigin.