### PR TITLE
Make WHIP/MediaMTX the primary ingest path; demote aiortc to fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ HLS_PLAYLIST_LENGTH=8
 # MediaMTX integration (Phase 1)
 MEDIAMTX_WHIP_BASE=http://localhost:8889
 MEDIAMTX_HLS_BASE=http://localhost:8888
+
+# Set to 'true' to fall back to the legacy aiortc/IngestService path when WHIP fails.
+# Default: false (WHIP to MediaMTX is the primary and only ingest path).
+USE_LEGACY_INGEST=false

--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import atexit
+import urllib.error
+import urllib.request
 from threading import RLock
 from typing import Any
 
@@ -41,6 +43,22 @@ def json_error(message: str, code: int) -> tuple[dict[str, str], int]:
     return {'error': message}, code
 
 
+def _check_mediamtx() -> bool:
+    """HEAD-check the MediaMTX HLS address; any HTTP response means the server is up."""
+    if not settings.mediamtx_hls_base:
+        return False
+    try:
+        req = urllib.request.Request(f'{settings.mediamtx_hls_base}/', method='HEAD')
+        with urllib.request.urlopen(req, timeout=2):
+            return True
+    except urllib.error.HTTPError:
+        # 4xx/5xx response — the server is running (404 expected until a stream is published)
+        return True
+    except urllib.error.URLError:
+        # Connection refused, DNS failure, or timeout
+        return False
+
+
 @app.route('/')
 def home() -> Any:
     return redirect('/interpreter/demo-booth')
@@ -52,6 +70,8 @@ def healthz() -> Any:
         {
             'ok': True,
             'aiortc_available': AIORTC_AVAILABLE,
+            'use_legacy_ingest': settings.use_legacy_ingest,
+            'mediamtx_ok': _check_mediamtx(),
         }
     )
 
@@ -72,6 +92,7 @@ def interpreter_booth(booth_id: str) -> Any:
         aiortc_available=AIORTC_AVAILABLE,
         mediamtx_whip_base=settings.mediamtx_whip_base,
         mediamtx_hls_base=settings.mediamtx_hls_base,
+        use_legacy_ingest=settings.use_legacy_ingest,
     )
 
 

--- a/portal/config.py
+++ b/portal/config.py
@@ -40,6 +40,7 @@ class Settings:
     hls_playlist_length: int
     mediamtx_whip_base: str
     mediamtx_hls_base: str
+    use_legacy_ingest: bool
 
 
 def load_settings() -> Settings:
@@ -57,6 +58,7 @@ def load_settings() -> Settings:
         hls_playlist_length=int(os.getenv('HLS_PLAYLIST_LENGTH', '8')),
         mediamtx_whip_base=os.getenv('MEDIAMTX_WHIP_BASE', 'http://localhost:8889'),
         mediamtx_hls_base=os.getenv('MEDIAMTX_HLS_BASE', 'http://localhost:8888'),
+        use_legacy_ingest=parse_bool(os.getenv('USE_LEGACY_INGEST', 'false')),
     )
 
 

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -24,6 +24,10 @@ const state = {
   jitsiDomain: portal.dataset.jitsiDomain || '',
   whipBase: portal.dataset.whipBase || '',
   hlsBase: portal.dataset.hlsBase || '',
+  // USE_LEGACY_INGEST feature flag surfaced from server config.
+  // When true, startLiveIngest() falls back to the legacy aiortc endpoint if WHIP fails.
+  useLegacyIngest: portal.dataset.useLegacyIngest === 'true',
+  usedLegacyFallback: false,
   micDeviceId: localStorage.getItem('mic-device-id') || '',
   preflight: {
     micPermission: 'pending',
@@ -678,6 +682,46 @@ async function toggleMicMute() {
   renderMicControls()
 }
 
+// ── Ingest path helpers ───────────────────────────────────────────────────────
+// MediaMTX WHIP URL format: /{channelId}/whip (not /whip/{channelId})
+async function doWhipIngest(peerConnection) {
+  const whipUrl = `${state.whipBase}/${encodeURIComponent(state.channelId)}/whip`
+  const response = await fetch(whipUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/sdp' },
+    body: peerConnection.localDescription.sdp,
+  })
+  if (!response.ok) {
+    const detail = await response.text().catch(() => response.statusText)
+    throw new Error(`WHIP error ${response.status}: ${detail}`)
+  }
+  const answerSdp = await response.text()
+  await peerConnection.setRemoteDescription({ type: 'answer', sdp: answerSdp })
+}
+
+// Legacy aiortc path via Flask — kept for the migration period (USE_LEGACY_INGEST=true).
+// Phase 1D: remove this function and the /api/interpreter/connect route.
+async function doLegacyIngest(peerConnection) {
+  const response = await fetch(`/api/interpreter/connect/${encodeURIComponent(state.channelId)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      booth_id: state.boothId,
+      participant_id: state.participantId,
+      language: state.language,
+      token: state.token,
+      type: peerConnection.localDescription.type,
+      sdp: peerConnection.localDescription.sdp,
+    }),
+  })
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ error: response.statusText }))
+    throw new Error(payload.error || 'Legacy ingest negotiation failed.')
+  }
+  const answer = await response.json()
+  await peerConnection.setRemoteDescription(answer)
+}
+
 async function startLiveIngest() {
   if (!state.joined || !state.participantId) {
     showError('Join the booth before going live.')
@@ -717,40 +761,26 @@ async function startLiveIngest() {
     await waitForIceGathering(peerConnection)
 
     if (state.whipBase) {
-      // WHIP path: POST raw SDP offer to MediaMTX; receive SDP answer as plain text.
-      // MediaMTX WHIP URL format is /{channelId}/whip (not /whip/{channelId}).
-      const whipUrl = `${state.whipBase}/${encodeURIComponent(state.channelId)}/whip`
-      const response = await fetch(whipUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/sdp' },
-        body: peerConnection.localDescription.sdp,
-      })
-      if (!response.ok) {
-        const detail = await response.text().catch(() => response.statusText)
-        throw new Error(`WHIP error ${response.status}: ${detail}`)
+      // Primary path: WHIP to MediaMTX.
+      try {
+        await doWhipIngest(peerConnection)
+        state.usedLegacyFallback = false
+      } catch (whipError) {
+        if (state.useLegacyIngest) {
+          // USE_LEGACY_INGEST=true — fall back to aiortc endpoint.
+          showError(`WHIP failed (${whipError.message}); retrying via legacy ingest…`)
+          await doLegacyIngest(peerConnection)
+          state.usedLegacyFallback = true
+        } else {
+          throw whipError
+        }
       }
-      const answerSdp = await response.text()
-      await peerConnection.setRemoteDescription({ type: 'answer', sdp: answerSdp })
+    } else if (state.useLegacyIngest) {
+      // No WHIP base configured — use legacy endpoint only if flag is set.
+      await doLegacyIngest(peerConnection)
+      state.usedLegacyFallback = true
     } else {
-      // Legacy: aiortc path via Flask
-      const response = await fetch(`/api/interpreter/connect/${encodeURIComponent(state.channelId)}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          booth_id: state.boothId,
-          participant_id: state.participantId,
-          language: state.language,
-          token: state.token,
-          type: peerConnection.localDescription.type,
-          sdp: peerConnection.localDescription.sdp,
-        }),
-      })
-      if (!response.ok) {
-        const payload = await response.json().catch(() => ({ error: response.statusText }))
-        throw new Error(payload.error || 'Ingest negotiation failed.')
-      }
-      const answer = await response.json()
-      await peerConnection.setRemoteDescription(answer)
+      throw new Error('No ingest path available. Set MEDIAMTX_WHIP_BASE or enable USE_LEGACY_INGEST.')
     }
 
     state.ingestConnected = true
@@ -785,8 +815,8 @@ async function stopLiveIngest() {
     stopMicMeter()
   }
   if (state.joined && state.participantId) {
-    if (!state.whipBase) {
-      // Legacy: notify Flask to release the server-side aiortc peer connection
+    if (state.usedLegacyFallback) {
+      // Release the server-side aiortc peer connection only when the legacy path was used.
       await fetch(`/api/interpreter/disconnect/${encodeURIComponent(state.channelId)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -797,6 +827,7 @@ async function stopLiveIngest() {
           token: state.token,
         }),
       }).catch(() => {})
+      state.usedLegacyFallback = false
     }
     socket.emit('booth:update-state', {
       booth_id: state.boothId,

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -15,6 +15,7 @@
   data-aiortc-available='{{ "true" if aiortc_available else "false" }}'
   data-whip-base='{{ mediamtx_whip_base }}'
   data-hls-base='{{ mediamtx_hls_base }}'
+  data-use-legacy-ingest='{{ "true" if use_legacy_ingest else "false" }}'
 >
   <section class='panel'>
     <header class='panel-header'>


### PR DESCRIPTION
fixes #48

Feature flag (USE_LEGACY_INGEST, default: false):
- portal/config.py: add use_legacy_ingest: bool field (parsed via parse_bool from USE_LEGACY_INGEST env var)
- .env.example: document USE_LEGACY_INGEST=false with explanation
- app.py: pass use_legacy_ingest to interpreter_booth template
- templates/interpreter_booth.html: expose as data-use-legacy-ingest on #interpreter-portal so JS can read it

Frontend ingest path (static/js/interpreter-booth.js):
- state.useLegacyIngest: read from data-use-legacy-ingest (false by default)
- state.usedLegacyFallback: tracks whether the legacy aiortc path was actually used this session (drives disconnect cleanup in stopLiveIngest)
- Extract doWhipIngest(peerConnection): POST SDP to MediaMTX WHIP endpoint, set remote description from plain-text SDP answer
- Extract doLegacyIngest(peerConnection): POST JSON offer to Flask /api/interpreter/connect, set remote description from JSON answer (marked Phase 1D TODO for removal)
- startLiveIngest() decision tree:
    1. WHIP base configured → try doWhipIngest() - success: usedLegacyFallback = false - failure + USE_LEGACY_INGEST=true: warn user, try doLegacyIngest(), set usedLegacyFallback = true - failure + USE_LEGACY_INGEST=false: propagate error (no silent fallback)
    2. No WHIP base + USE_LEGACY_INGEST=true → doLegacyIngest()
    3. No WHIP base + USE_LEGACY_INGEST=false → throw (configuration error)
- stopLiveIngest(): disconnect legacy Flask route only when usedLegacyFallback is true (not just when whipBase is absent)

Backend /healthz (app.py):
- Add _check_mediamtx(): HEAD-check mediamtx_hls_base with 2s timeout; urllib.error.HTTPError (e.g. 404) counts as reachable (server is up); urllib.error.URLError counts as unreachable
- /healthz response now includes mediamtx_ok and use_legacy_ingest

Legacy routes kept but not called by default:
- /api/interpreter/connect still responds (not removed — Phase 1D)
- /api/interpreter/disconnect still responds (not removed — Phase 1D)
- portal/ingest.py unchanged