### PR TITLE
feat: introduce FastAPI alongside Flask (Migration 1B)

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1,0 +1,42 @@
+"""FastAPI entry point — Phase 1B: runs alongside Flask on a separate port.
+
+Flask (app.py) keeps handling all Socket.IO events on port 5000.
+This module validates that FastAPI can coexist and read shared config.
+
+Phase 1C will port Socket.IO coordination here and remove Flask.
+
+Start with:
+    uvicorn fastapi_app:app --host 0.0.0.0 --port 8001 --reload
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from portal.config import settings
+
+app = FastAPI(title='Eventyay Interpretation Portal', version='1.0.0')
+
+
+@app.get('/healthz')
+async def healthz() -> dict:
+    return {
+        'ok': True,
+        'server': 'fastapi',
+        'use_legacy_ingest': settings.use_legacy_ingest,
+    }
+
+
+@app.websocket('/ws/booth/{booth_id}')
+async def ws_booth(websocket: WebSocket, booth_id: str) -> None:
+    """Echo endpoint — Phase 1B validation only.
+
+    Socket.IO coordination still targets Flask on port 5000.
+    Full migration (replacing Flask-SocketIO) happens in Phase 1C.
+    """
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await websocket.send_text(f'booth:{booth_id} echo: {data}')
+    except WebSocketDisconnect:
+        pass

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -63,6 +63,7 @@ class Booth:
 class BoothRegistry:
     def __init__(self) -> None:
         self._booths: dict[str, Booth] = {}
+        # TODO(Phase 1C): migrate to asyncio.Lock when Flask-SocketIO is removed
         self._lock = RLock()
 
     def get_or_create_booth(self, booth_id: str, language: str, channel_id: str) -> Booth:

--- a/portal/config.py
+++ b/portal/config.py
@@ -1,65 +1,55 @@
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass
 from pathlib import Path
 
-from dotenv import load_dotenv
-
-load_dotenv()
-
-
-def parse_cors_origins(raw_value: str) -> list[str] | str:
-    value = raw_value.strip()
-    if value == '*':
-        return '*'
-    if not value:
-        return ['http://127.0.0.1:5000', 'http://localhost:5000']
-    return [item.strip() for item in value.split(',') if item.strip()]
+from pydantic import AliasChoices, Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-def parse_bool(raw_value: str, default: bool = False) -> bool:
-    value = raw_value.strip().lower()
-    if not value:
-        return default
-    return value in {'1', 'true', 'yes', 'on'}
-
-
-@dataclass(frozen=True)
-class Settings:
-    host: str
-    port: int
-    debug: bool
-    secret_key: str
-    booth_access_token: str
-    socket_cors_origins: list[str] | str
-    default_jitsi_room: str
-    jitsi_domain: str
-    ingest_hls_root: Path
-    hls_segment_seconds: int
-    hls_playlist_length: int
-    mediamtx_whip_base: str
-    mediamtx_hls_base: str
-    use_legacy_ingest: bool
-
-
-def load_settings() -> Settings:
-    return Settings(
-        host=os.getenv('HOST', '127.0.0.1'),
-        port=int(os.getenv('PORT', '5000')),
-        debug=parse_bool(os.getenv('FLASK_DEBUG', '1'), default=True),
-        secret_key=os.getenv('SECRET_KEY', 'change-me'),
-        booth_access_token=os.getenv('BOOTH_ACCESS_TOKEN', ''),
-        socket_cors_origins=parse_cors_origins(os.getenv('BOOTH_WS_CORS_ORIGINS', '*')),
-        default_jitsi_room=os.getenv('DEFAULT_JITSI_ROOM', 'https://meet.jit.si/eventyay-stage-room'),
-        jitsi_domain=os.getenv('JITSI_DOMAIN', 'meet.jit.si'),
-        ingest_hls_root=Path(os.getenv('INGEST_HLS_ROOT', './hls-output')).resolve(),
-        hls_segment_seconds=int(os.getenv('HLS_SEGMENT_SECONDS', '2')),
-        hls_playlist_length=int(os.getenv('HLS_PLAYLIST_LENGTH', '8')),
-        mediamtx_whip_base=os.getenv('MEDIAMTX_WHIP_BASE', 'http://localhost:8889'),
-        mediamtx_hls_base=os.getenv('MEDIAMTX_HLS_BASE', 'http://localhost:8888'),
-        use_legacy_ingest=parse_bool(os.getenv('USE_LEGACY_INGEST', 'false')),
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file='.env',
+        env_file_encoding='utf-8',
+        extra='ignore',
+        populate_by_name=True,
     )
 
+    host: str = '127.0.0.1'
+    port: int = 5000
+    # FLASK_DEBUG kept as legacy env var name for .env compatibility
+    debug: bool = Field(default=True, validation_alias=AliasChoices('flask_debug', 'debug'))
+    secret_key: str = 'change-me'
+    booth_access_token: str = ''
+    # BOOTH_WS_CORS_ORIGINS kept as legacy env var name for .env compatibility
+    socket_cors_origins: str | list[str] = Field(
+        default='*',
+        validation_alias=AliasChoices('booth_ws_cors_origins', 'socket_cors_origins'),
+    )
+    default_jitsi_room: str = 'https://meet.jit.si/eventyay-stage-room'
+    jitsi_domain: str = 'meet.jit.si'
+    ingest_hls_root: Path = Field(default_factory=lambda: Path('./hls-output').resolve())
+    hls_segment_seconds: int = 2
+    hls_playlist_length: int = 8
+    mediamtx_whip_base: str = 'http://localhost:8889'
+    mediamtx_hls_base: str = 'http://localhost:8888'
+    use_legacy_ingest: bool = False
 
-settings = load_settings()
+    @field_validator('socket_cors_origins', mode='before')
+    @classmethod
+    def _parse_cors(cls, v: str | list) -> str | list[str]:
+        if isinstance(v, list):
+            return v
+        value = str(v).strip()
+        if value == '*':
+            return '*'
+        if not value:
+            return ['http://127.0.0.1:5000', 'http://localhost:5000']
+        return [item.strip() for item in value.split(',') if item.strip()]
+
+    @field_validator('ingest_hls_root', mode='before')
+    @classmethod
+    def _resolve_path(cls, v: str | Path) -> Path:
+        return Path(str(v)).resolve()
+
+
+settings = Settings()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,15 @@ dependencies = [
     "aiortc==1.14.0",
     "av==16.1.0",
     "python-dotenv==1.2.2",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
+    "pydantic-settings>=2.9.0",
 ]
 
 [dependency-groups]
 dev = [
     "pytest==9.0.3",
+    "httpx>=0.28.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from fastapi_app import app
+
+client = TestClient(app)
+
+
+def test_healthz_returns_ok():
+    response = client.get('/healthz')
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data['ok'] is True
+    assert data['server'] == 'fastapi'
+    assert 'use_legacy_ingest' in data
+
+
+def test_ws_booth_echo():
+    with client.websocket_connect('/ws/booth/test-room') as ws:
+        ws.send_text('hello')
+        reply = ws.receive_text()
+
+    assert 'test-room' in reply
+    assert 'echo' in reply
+    assert 'hello' in reply
+
+
+def test_ws_booth_multiple_messages():
+    with client.websocket_connect('/ws/booth/demo') as ws:
+        for msg in ('ping', 'check', 'ready'):
+            ws.send_text(msg)
+            reply = ws.receive_text()
+            assert msg in reply
+            assert 'demo' in reply


### PR DESCRIPTION
- Add fastapi, uvicorn[standard], pydantic-settings, httpx to pyproject.toml
- Port portal/config.py from frozen dataclass to pydantic-settings BaseSettings (backward-compatible interface; FLASK_DEBUG and BOOTH_WS_CORS_ORIGINS env vars kept via AliasChoices for .env compatibility)
- Add fastapi_app.py with /healthz and /ws/booth/{booth_id} echo endpoint (Flask still handles all Socket.IO events on port 5000 unchanged)
- Mark BoothRegistry._lock for asyncio migration in Phase 1C
- Add tests/test_fastapi_app.py covering healthz and WebSocket echo
fixes #49 
fixes #50 