### PR TITLE
Add booth identity schema: {event_slug}-{language_code} IDs and Media…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,10 +91,46 @@ flowchart LR
   Listener --> Jitsi
 ```
 
-## 6. Runtime components in this repository
+## 6. Booth identity scheme
+
+A booth is identified by three coordinates:
+
+| Coordinate      | Format                          | Example         |
+|-----------------|---------------------------------|-----------------|
+| `event_slug`    | Lowercase alphanumeric + hyphens, no consecutive hyphens, max 64 chars | `pycon2026` |
+| `language_code` | ISO 639-1 two-letter code       | `en`            |
+| `instance`      | `primary` or `backup`           | `primary`       |
+
+**Booth ID:** `{event_slug}-{language_code}` → `pycon2026-en`
+
+**MediaMTX path:** `{event_slug}/{language_code}` → `pycon2026/en` (one active stream per language per event)
+
+### Validation rules
+
+- **Event slug:** `^[a-z0-9]+(?:-[a-z0-9]+)*$`, 1–64 characters. Must start and end with alphanumeric. No consecutive hyphens, no underscores, no spaces.
+- **Language code:** Exactly two lowercase ASCII letters matching a recognised ISO 639-1 code.
+- **Instance:** Either `primary` or `backup`. Only one instance publishes at a time.
+
+### Bidirectional conversion
+
+```
+booth_id_to_mediamtx_path("pycon2026-en")  →  "pycon2026/en"
+mediamtx_path_to_booth_id("pycon2026/en")  →  "pycon2026-en"
+parse_booth_id("my-great-event-fr")        →  ("my-great-event", "fr")
+```
+
+The language code is always the last two characters after the final hyphen.
+
+### Legacy compatibility
+
+Existing free-form booth IDs (e.g. `hall-a-fr`) that happen to end with a valid ISO 639-1 code are parsed automatically. IDs that cannot be parsed are accepted with empty identity fields during the migration window.
+
+## 7. Runtime components in this repository
 
 - `fastapi_app.py`
   - FastAPI routes, WebSocket event handlers, JWT auth, Jinja2 templates, health checks
+- `portal/booth_identity.py`
+  - booth identity scheme: validation (event slug, ISO 639-1 language code, instance), booth ID generation, MediaMTX path mapping, bidirectional conversion
 - `portal/booth_state.py`
   - async in-memory booth registry, participant role policy, active interpreter ownership, handoff state, chat history
 - `portal/auth.py`
@@ -120,11 +156,12 @@ flowchart LR
 - `docker-compose.yml`
   - all services: portal, mediamtx, jitsi-web, jitsi-prosody, jitsi-jicofo, jitsi-jvb
 
-## 7. State model and ownership
+## 8. State model and ownership
 
 `BoothRegistry` tracks:
 
-- booth metadata (`booth_id`, `language`, `channel_id`)
+- booth identity (`booth_id`, `event_slug`, `language_code`, `instance`, `mediamtx_path`)
+- booth metadata (`language`, `channel_id`)
 - active interpreter id
 - participant roster and roles
 - per-participant connection, mic, and ingest state
@@ -134,7 +171,7 @@ flowchart LR
 
 The browser keeps only local UI/session state: joined participant id, mic stream, peer connection, current booth snapshot, and current chat messages. Server state remains the source of truth for who is active.
 
-## 8. Active interpreter enforcement
+## 9. Active interpreter enforcement
 
 Enforcement rules:
 
@@ -145,7 +182,7 @@ Enforcement rules:
 5. Coordinator role can override active ownership.
 6. Non-interpreter roles cannot become active publishers.
 
-## 9. Reconnect and teardown behavior
+## 10. Reconnect and teardown behavior
 
 Reconnect:
 
@@ -160,7 +197,7 @@ Teardown:
 - update booth state over WebSocket
 - remove participant from in-memory booth on WebSocket disconnect
 
-## 10. Jitsi role vs ingest role
+## 11. Jitsi role vs ingest role
 
 Jitsi responsibilities:
 
@@ -178,7 +215,7 @@ Ingest responsibilities:
 - receive interpreter mic audio uplink via WHIP → MediaMTX
 - MediaMTX produces WHEP for low-latency WebRTC playback and HLS as fallback for viewer consumption
 
-## 11. Deployment assumptions
+## 12. Deployment assumptions
 
 - interpreter portal is served as an ASGI application (FastAPI + uvicorn)
 - WHIP endpoint (MediaMTX) is reachable from interpreter browsers
@@ -189,7 +226,7 @@ Ingest responsibilities:
 - PostgreSQL and Redis can be added later for persistence and multi-worker scale
 - in Docker, `DOCKER_HOST_ADDRESS` must be set to the host's LAN IP for JVB ICE to work
 
-## 12. Reliability and operational constraints
+## 13. Reliability and operational constraints
 
 - recommend headphones-first operation to reduce feedback risk
 - prevent local audio loopback in mic capture path

--- a/portal/booth_identity.py
+++ b/portal/booth_identity.py
@@ -1,0 +1,200 @@
+"""Booth identity scheme: {event_slug}-{language_code} IDs and MediaMTX path mapping.
+
+A booth is identified by three coordinates:
+- event_slug: alphanumeric + hyphens (e.g. "pycon2026")
+- language_code: ISO 639-1 two-letter code (e.g. "en")
+- instance: "primary" or "backup" — only one publishes at a time
+
+The booth ID is ``{event_slug}-{language_code}`` (e.g. ``pycon2026-en``).
+The MediaMTX stream path is ``{event_slug}/{language_code}`` (one active
+stream per language per event).
+"""
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+BoothInstance = Literal['primary', 'backup']
+
+# ── Validation patterns ──────────────────────────────────────────────────────
+
+# Alphanumeric and hyphens, must start and end with alphanumeric,
+# at least 1 character, no consecutive hyphens.
+_EVENT_SLUG_RE = re.compile(r'^[a-z0-9]+(?:-[a-z0-9]+)*$')
+_EVENT_SLUG_MAX_LENGTH = 64
+
+# ISO 639-1: exactly two lowercase ASCII letters.
+_LANGUAGE_CODE_RE = re.compile(r'^[a-z]{2}$')
+
+# Full booth ID: {event_slug}-{language_code}
+# The language code is always the last two-letter segment after the final hyphen.
+_BOOTH_ID_RE = re.compile(r'^[a-z0-9]+(?:-[a-z0-9]+)*-[a-z]{2}$')
+
+# ISO 639-1 codes (subset of most common; validated against this set).
+ISO_639_1_CODES: frozenset[str] = frozenset({
+    'aa', 'ab', 'af', 'ak', 'am', 'an', 'ar', 'as', 'av', 'ay', 'az',
+    'ba', 'be', 'bg', 'bh', 'bi', 'bm', 'bn', 'bo', 'br', 'bs',
+    'ca', 'ce', 'ch', 'co', 'cr', 'cs', 'cu', 'cv', 'cy',
+    'da', 'de', 'dv', 'dz',
+    'ee', 'el', 'en', 'eo', 'es', 'et', 'eu',
+    'fa', 'ff', 'fi', 'fj', 'fo', 'fr', 'fy',
+    'ga', 'gd', 'gl', 'gn', 'gu', 'gv',
+    'ha', 'he', 'hi', 'ho', 'hr', 'ht', 'hu', 'hy', 'hz',
+    'ia', 'id', 'ie', 'ig', 'ii', 'ik', 'io', 'is', 'it', 'iu',
+    'ja', 'jv',
+    'ka', 'kg', 'ki', 'kj', 'kk', 'kl', 'km', 'kn', 'ko', 'kr', 'ks',
+    'ku', 'kv', 'kw', 'ky',
+    'la', 'lb', 'lg', 'li', 'ln', 'lo', 'lt', 'lu', 'lv',
+    'mg', 'mh', 'mi', 'mk', 'ml', 'mn', 'mr', 'ms', 'mt', 'my',
+    'na', 'nb', 'nd', 'ne', 'ng', 'nl', 'nn', 'no', 'nr', 'nv', 'ny',
+    'oc', 'oj', 'om', 'or', 'os',
+    'pa', 'pi', 'pl', 'ps', 'pt',
+    'qu',
+    'rm', 'rn', 'ro', 'ru', 'rw',
+    'sa', 'sc', 'sd', 'se', 'sg', 'si', 'sk', 'sl', 'sm', 'sn', 'so',
+    'sq', 'sr', 'ss', 'st', 'su', 'sv', 'sw',
+    'ta', 'te', 'tg', 'th', 'ti', 'tk', 'tl', 'tn', 'to', 'tr', 'ts',
+    'tt', 'tw', 'ty',
+    'ug', 'uk', 'ur', 'uz',
+    've', 'vi', 'vo',
+    'wa', 'wo',
+    'xh',
+    'yi', 'yo',
+    'za', 'zh', 'zu',
+})
+
+
+# ── Validation helpers ────────────────────────────────────────────────────────
+
+def validate_event_slug(slug: str) -> str:
+    """Validate and normalise an event slug.
+
+    Returns the lowercased slug on success.
+    Raises ``ValueError`` with a descriptive message on failure.
+    """
+    normalised = slug.strip().lower()
+    if not normalised:
+        raise ValueError('Event slug must not be empty.')
+    if len(normalised) > _EVENT_SLUG_MAX_LENGTH:
+        raise ValueError(
+            'Event slug must not exceed %d characters (got %d).',
+            _EVENT_SLUG_MAX_LENGTH,
+            len(normalised),
+        )
+    if not _EVENT_SLUG_RE.match(normalised):
+        raise ValueError(
+            "Event slug must contain only lowercase alphanumeric characters and hyphens, "
+            "must start and end with an alphanumeric character, and must not contain "
+            f"consecutive hyphens. Got: '{normalised}'."
+        )
+    return normalised
+
+
+def validate_language_code(code: str) -> str:
+    """Validate an ISO 639-1 language code.
+
+    Returns the lowercased code on success.
+    Raises ``ValueError`` with a descriptive message on failure.
+    """
+    normalised = code.strip().lower()
+    if not _LANGUAGE_CODE_RE.match(normalised):
+        raise ValueError(
+            "Language code must be exactly two lowercase ASCII letters "
+            f"(ISO 639-1). Got: '{code}'."
+        )
+    if normalised not in ISO_639_1_CODES:
+        raise ValueError(
+            f"'{normalised}' is not a recognised ISO 639-1 language code."
+        )
+    return normalised
+
+
+def validate_instance(instance: str) -> BoothInstance:
+    """Validate a booth instance identifier.
+
+    Returns ``'primary'`` or ``'backup'``.
+    Raises ``ValueError`` on invalid input.
+    """
+    normalised = instance.strip().lower()
+    if normalised not in ('primary', 'backup'):
+        raise ValueError(
+            f"Booth instance must be 'primary' or 'backup'. Got: '{instance}'."
+        )
+    return normalised  # type: ignore[return-value]
+
+
+# ── Identity construction / conversion ────────────────────────────────────────
+
+def make_booth_id(event_slug: str, language_code: str) -> str:
+    """Build a booth ID from validated coordinates.
+
+    Format: ``{event_slug}-{language_code}`` (e.g. ``pycon2026-en``).
+    Inputs are validated before construction.
+    """
+    slug = validate_event_slug(event_slug)
+    code = validate_language_code(language_code)
+    return f'{slug}-{code}'
+
+
+def make_mediamtx_path(event_slug: str, language_code: str) -> str:
+    """Build a MediaMTX stream path from validated coordinates.
+
+    Format: ``{event_slug}/{language_code}`` (e.g. ``pycon2026/en``).
+    """
+    slug = validate_event_slug(event_slug)
+    code = validate_language_code(language_code)
+    return f'{slug}/{code}'
+
+
+def booth_id_to_mediamtx_path(booth_id: str) -> str:
+    """Convert a booth ID to its corresponding MediaMTX path.
+
+    ``pycon2026-en`` → ``pycon2026/en``
+
+    Raises ``ValueError`` if the booth ID is malformed.
+    """
+    event_slug, language_code = parse_booth_id(booth_id)
+    return f'{event_slug}/{language_code}'
+
+
+def mediamtx_path_to_booth_id(path: str) -> str:
+    """Convert a MediaMTX path to the corresponding booth ID.
+
+    ``pycon2026/en`` → ``pycon2026-en``
+
+    Raises ``ValueError`` if the path is malformed.
+    """
+    normalised = path.strip().strip('/')
+    parts = normalised.split('/')
+    if len(parts) != 2:
+        raise ValueError(
+            f"MediaMTX path must have exactly two segments "
+            f"(event_slug/language_code). Got: '{path}'."
+        )
+    event_slug = validate_event_slug(parts[0])
+    language_code = validate_language_code(parts[1])
+    return f'{event_slug}-{language_code}'
+
+
+def parse_booth_id(booth_id: str) -> tuple[str, str]:
+    """Split a booth ID into (event_slug, language_code).
+
+    The language code is always the last two characters after the final
+    hyphen. Everything before that hyphen is the event slug.
+
+    Raises ``ValueError`` if the booth ID format is invalid.
+    """
+    normalised = booth_id.strip().lower()
+    if not _BOOTH_ID_RE.match(normalised):
+        raise ValueError(
+            f"Booth ID must follow the format '{{event_slug}}-{{language_code}}' "
+            f"where language_code is a two-letter ISO 639-1 code. Got: '{booth_id}'."
+        )
+    # Last hyphen separates slug from language code
+    last_hyphen = normalised.rfind('-')
+    event_slug = normalised[:last_hyphen]
+    language_code = normalised[last_hyphen + 1:]
+    # Validate both halves
+    validate_event_slug(event_slug)
+    validate_language_code(language_code)
+    return event_slug, language_code

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -6,6 +6,16 @@ from datetime import datetime, timezone
 from typing import Literal
 from uuid import uuid4
 
+from portal.booth_identity import (
+    BoothInstance,
+    make_booth_id,
+    make_mediamtx_path,
+    parse_booth_id,
+    validate_event_slug,
+    validate_instance,
+    validate_language_code,
+)
+
 ParticipantRole = Literal['interpreter', 'coordinator', 'listener']
 
 
@@ -39,17 +49,29 @@ class ChatMessage:
 @dataclass
 class Booth:
     booth_id: str
+    event_slug: str
+    language_code: str
     language: str
     channel_id: str
+    instance: BoothInstance = 'primary'
+    mediamtx_path: str = ''
     active_interpreter_id: str | None = None
     handoff_state: str = 'idle'
     participants: dict[str, Participant] = field(default_factory=dict)
     chat_messages: list[ChatMessage] = field(default_factory=list)
     ingest_status: str = 'disconnected'
 
+    def __post_init__(self) -> None:
+        if not self.mediamtx_path and self.event_slug and self.language_code:
+            self.mediamtx_path = make_mediamtx_path(self.event_slug, self.language_code)
+
     def as_public_dict(self) -> dict:
         return {
             'booth_id': self.booth_id,
+            'event_slug': self.event_slug,
+            'language_code': self.language_code,
+            'instance': self.instance,
+            'mediamtx_path': self.mediamtx_path,
             'language': self.language,
             'channel_id': self.channel_id,
             'active_interpreter_id': self.active_interpreter_id,
@@ -78,12 +100,63 @@ class BoothRegistry:
         ``language`` and ``channel_id`` are only used when *creating* the booth;
         they are treated as immutable once set so that a later request from a
         different client cannot silently change the booth's canonical values.
+
+        The ``booth_id`` is parsed into ``event_slug`` and ``language_code``
+        using :func:`parse_booth_id`.  If parsing fails (legacy free-form ID),
+        the booth is still created with empty identity fields so existing
+        callers continue to work during the migration window.
         """
         booth = self._booths.get(booth_id)
         if booth is None:
-            booth = Booth(booth_id=booth_id, language=language, channel_id=channel_id)
+            try:
+                event_slug, language_code = parse_booth_id(booth_id)
+            except ValueError:
+                event_slug = ''
+                language_code = ''
+            booth = Booth(
+                booth_id=booth_id,
+                event_slug=event_slug,
+                language_code=language_code,
+                language=language,
+                channel_id=channel_id,
+            )
             self._booths[booth_id] = booth
         return booth
+
+    async def create_booth(
+        self,
+        event_slug: str,
+        language_code: str,
+        language: str,
+        channel_id: str = '',
+        instance: BoothInstance = 'primary',
+    ) -> dict:
+        """Create a booth using validated identity coordinates.
+
+        This is the preferred entry point for new code.  The booth ID and
+        MediaMTX path are derived automatically from the coordinates.
+
+        Raises ``ValueError`` if the slug or language code is invalid, or if
+        a booth with the same ID already exists.
+        """
+        slug = validate_event_slug(event_slug)
+        code = validate_language_code(language_code)
+        inst = validate_instance(instance)
+        booth_id = make_booth_id(slug, code)
+
+        async with self._lock:
+            if booth_id in self._booths:
+                raise ValueError(f"Booth '{booth_id}' already exists.")
+            booth = Booth(
+                booth_id=booth_id,
+                event_slug=slug,
+                language_code=code,
+                language=language,
+                channel_id=channel_id or f'{booth_id}-audio',
+                instance=inst,
+            )
+            self._booths[booth_id] = booth
+            return booth.as_public_dict()
 
     async def snapshot(self, booth_id: str, language: str, channel_id: str) -> dict:
         async with self._lock:

--- a/tests/test_booth_identity.py
+++ b/tests/test_booth_identity.py
@@ -1,0 +1,264 @@
+"""Tests for booth identity scheme — validation, ID generation, and path conversion."""
+from __future__ import annotations
+
+import pytest
+
+from portal.booth_identity import (
+    booth_id_to_mediamtx_path,
+    make_booth_id,
+    make_mediamtx_path,
+    mediamtx_path_to_booth_id,
+    parse_booth_id,
+    validate_event_slug,
+    validate_instance,
+    validate_language_code,
+)
+
+
+# ── validate_event_slug ──────────────────────────────────────────────────────
+
+class TestValidateEventSlug:
+    def test_simple_slug(self):
+        assert validate_event_slug('pycon2026') == 'pycon2026'
+
+    def test_slug_with_hyphens(self):
+        assert validate_event_slug('my-great-event') == 'my-great-event'
+
+    def test_normalises_to_lowercase(self):
+        assert validate_event_slug('PyCon2026') == 'pycon2026'
+
+    def test_strips_whitespace(self):
+        assert validate_event_slug('  pycon2026  ') == 'pycon2026'
+
+    def test_empty_slug_raises(self):
+        with pytest.raises(ValueError, match='must not be empty'):
+            validate_event_slug('')
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(ValueError, match='must not be empty'):
+            validate_event_slug('   ')
+
+    def test_consecutive_hyphens_rejected(self):
+        with pytest.raises(ValueError, match='consecutive hyphens'):
+            validate_event_slug('my--event')
+
+    def test_leading_hyphen_rejected(self):
+        with pytest.raises(ValueError, match='start and end with an alphanumeric'):
+            validate_event_slug('-pycon')
+
+    def test_trailing_hyphen_rejected(self):
+        with pytest.raises(ValueError, match='start and end with an alphanumeric'):
+            validate_event_slug('pycon-')
+
+    def test_special_characters_rejected(self):
+        with pytest.raises(ValueError):
+            validate_event_slug('my_event')
+
+    def test_spaces_in_slug_rejected(self):
+        with pytest.raises(ValueError):
+            validate_event_slug('my event')
+
+    def test_too_long_slug_rejected(self):
+        with pytest.raises(ValueError, match='must not exceed'):
+            validate_event_slug('a' * 65)
+
+    def test_max_length_slug_accepted(self):
+        slug = 'a' * 64
+        assert validate_event_slug(slug) == slug
+
+
+# ── validate_language_code ────────────────────────────────────────────────────
+
+class TestValidateLanguageCode:
+    def test_valid_code(self):
+        assert validate_language_code('en') == 'en'
+
+    def test_normalises_to_lowercase(self):
+        assert validate_language_code('FR') == 'fr'
+
+    def test_strips_whitespace(self):
+        assert validate_language_code('  de  ') == 'de'
+
+    def test_three_letter_code_rejected(self):
+        with pytest.raises(ValueError, match='two lowercase ASCII letters'):
+            validate_language_code('eng')
+
+    def test_single_letter_rejected(self):
+        with pytest.raises(ValueError, match='two lowercase ASCII letters'):
+            validate_language_code('e')
+
+    def test_numeric_code_rejected(self):
+        with pytest.raises(ValueError, match='two lowercase ASCII letters'):
+            validate_language_code('12')
+
+    def test_unrecognised_code_rejected(self):
+        with pytest.raises(ValueError, match='not a recognised ISO 639-1'):
+            validate_language_code('zz')
+
+    def test_empty_code_rejected(self):
+        with pytest.raises(ValueError):
+            validate_language_code('')
+
+    def test_common_codes_accepted(self):
+        for code in ('en', 'fr', 'de', 'es', 'zh', 'ja', 'ar', 'hi', 'pt', 'ru'):
+            assert validate_language_code(code) == code
+
+
+# ── validate_instance ─────────────────────────────────────────────────────────
+
+class TestValidateInstance:
+    def test_primary(self):
+        assert validate_instance('primary') == 'primary'
+
+    def test_backup(self):
+        assert validate_instance('backup') == 'backup'
+
+    def test_case_insensitive(self):
+        assert validate_instance('PRIMARY') == 'primary'
+        assert validate_instance('Backup') == 'backup'
+
+    def test_strips_whitespace(self):
+        assert validate_instance('  primary  ') == 'primary'
+
+    def test_invalid_instance_rejected(self):
+        with pytest.raises(ValueError, match="must be 'primary' or 'backup'"):
+            validate_instance('secondary')
+
+    def test_empty_instance_rejected(self):
+        with pytest.raises(ValueError):
+            validate_instance('')
+
+
+# ── make_booth_id ─────────────────────────────────────────────────────────────
+
+class TestMakeBoothId:
+    def test_basic(self):
+        assert make_booth_id('pycon2026', 'en') == 'pycon2026-en'
+
+    def test_with_hyphens_in_slug(self):
+        assert make_booth_id('my-great-event', 'fr') == 'my-great-event-fr'
+
+    def test_normalises_inputs(self):
+        assert make_booth_id('PyCon2026', 'EN') == 'pycon2026-en'
+
+    def test_invalid_slug_raises(self):
+        with pytest.raises(ValueError):
+            make_booth_id('', 'en')
+
+    def test_invalid_code_raises(self):
+        with pytest.raises(ValueError):
+            make_booth_id('pycon2026', 'xyz')
+
+
+# ── make_mediamtx_path ────────────────────────────────────────────────────────
+
+class TestMakeMediamtxPath:
+    def test_basic(self):
+        assert make_mediamtx_path('pycon2026', 'en') == 'pycon2026/en'
+
+    def test_with_hyphens(self):
+        assert make_mediamtx_path('my-great-event', 'fr') == 'my-great-event/fr'
+
+    def test_normalises_inputs(self):
+        assert make_mediamtx_path('PyCon2026', 'EN') == 'pycon2026/en'
+
+
+# ── parse_booth_id ────────────────────────────────────────────────────────────
+
+class TestParseBoothId:
+    def test_simple(self):
+        assert parse_booth_id('pycon2026-en') == ('pycon2026', 'en')
+
+    def test_slug_with_hyphens(self):
+        assert parse_booth_id('my-great-event-fr') == ('my-great-event', 'fr')
+
+    def test_normalises_case(self):
+        assert parse_booth_id('PyCon2026-EN') == ('pycon2026', 'en')
+
+    def test_strips_whitespace(self):
+        assert parse_booth_id('  pycon2026-en  ') == ('pycon2026', 'en')
+
+    def test_missing_language_raises(self):
+        with pytest.raises(ValueError, match='event_slug'):
+            parse_booth_id('pycon2026')
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError):
+            parse_booth_id('')
+
+    def test_three_letter_code_rejected(self):
+        with pytest.raises(ValueError):
+            parse_booth_id('pycon2026-eng')
+
+    def test_unrecognised_code_rejected(self):
+        with pytest.raises(ValueError):
+            parse_booth_id('pycon2026-zz')
+
+
+# ── booth_id_to_mediamtx_path ────────────────────────────────────────────────
+
+class TestBoothIdToMediamtxPath:
+    def test_basic(self):
+        assert booth_id_to_mediamtx_path('pycon2026-en') == 'pycon2026/en'
+
+    def test_slug_with_hyphens(self):
+        assert booth_id_to_mediamtx_path('my-great-event-fr') == 'my-great-event/fr'
+
+    def test_invalid_id_raises(self):
+        with pytest.raises(ValueError):
+            booth_id_to_mediamtx_path('invalid')
+
+
+# ── mediamtx_path_to_booth_id ────────────────────────────────────────────────
+
+class TestMediamtxPathToBoothId:
+    def test_basic(self):
+        assert mediamtx_path_to_booth_id('pycon2026/en') == 'pycon2026-en'
+
+    def test_with_hyphens(self):
+        assert mediamtx_path_to_booth_id('my-great-event/fr') == 'my-great-event-fr'
+
+    def test_strips_slashes(self):
+        assert mediamtx_path_to_booth_id('/pycon2026/en/') == 'pycon2026-en'
+
+    def test_too_many_segments_raises(self):
+        with pytest.raises(ValueError, match='exactly two segments'):
+            mediamtx_path_to_booth_id('a/b/c')
+
+    def test_single_segment_raises(self):
+        with pytest.raises(ValueError, match='exactly two segments'):
+            mediamtx_path_to_booth_id('pycon2026')
+
+    def test_invalid_slug_raises(self):
+        with pytest.raises(ValueError):
+            mediamtx_path_to_booth_id('-invalid/en')
+
+    def test_invalid_code_raises(self):
+        with pytest.raises(ValueError):
+            mediamtx_path_to_booth_id('pycon2026/xyz')
+
+
+# ── Bidirectional round-trip ──────────────────────────────────────────────────
+
+class TestRoundTrip:
+    @pytest.mark.parametrize('event_slug,lang_code', [
+        ('pycon2026', 'en'),
+        ('my-great-event', 'fr'),
+        ('fossasia2026', 'de'),
+        ('event1', 'zh'),
+    ])
+    def test_booth_id_roundtrip(self, event_slug, lang_code):
+        booth_id = make_booth_id(event_slug, lang_code)
+        path = booth_id_to_mediamtx_path(booth_id)
+        recovered_id = mediamtx_path_to_booth_id(path)
+        assert recovered_id == booth_id
+
+    @pytest.mark.parametrize('event_slug,lang_code', [
+        ('pycon2026', 'en'),
+        ('my-great-event', 'fr'),
+    ])
+    def test_mediamtx_path_roundtrip(self, event_slug, lang_code):
+        path = make_mediamtx_path(event_slug, lang_code)
+        booth_id = mediamtx_path_to_booth_id(path)
+        recovered_path = booth_id_to_mediamtx_path(booth_id)
+        assert recovered_path == path

--- a/tests/test_booth_state.py
+++ b/tests/test_booth_state.py
@@ -16,6 +16,18 @@ async def join(registry, name, role='interpreter'):
     return participant
 
 
+async def join_identity(registry, name, role='interpreter', booth_id='pycon2026-en'):
+    """Join helper using a booth ID that follows the new identity scheme."""
+    participant, _ = await registry.join_participant(
+        booth_id=booth_id,
+        display_name=name,
+        role=role,
+        language='English',
+        channel_id=f'{booth_id}-audio',
+    )
+    return participant
+
+
 @pytest.mark.anyio
 async def test_first_interpreter_becomes_active():
     registry = BoothRegistry()
@@ -105,3 +117,116 @@ async def test_coordinator_can_assign_active_interpreter():
     )
 
     assert state['active_interpreter_id'] == interpreter_b.participant_id
+
+
+# ── Booth identity scheme tests ───────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_booth_sets_identity_fields():
+    registry = BoothRegistry()
+    state = await registry.create_booth(
+        event_slug='pycon2026',
+        language_code='en',
+        language='English',
+    )
+
+    assert state['booth_id'] == 'pycon2026-en'
+    assert state['event_slug'] == 'pycon2026'
+    assert state['language_code'] == 'en'
+    assert state['instance'] == 'primary'
+    assert state['mediamtx_path'] == 'pycon2026/en'
+    assert state['channel_id'] == 'pycon2026-en-audio'
+
+
+@pytest.mark.anyio
+async def test_create_booth_custom_channel_and_instance():
+    registry = BoothRegistry()
+    state = await registry.create_booth(
+        event_slug='fossasia2026',
+        language_code='fr',
+        language='French',
+        channel_id='custom-channel',
+        instance='backup',
+    )
+
+    assert state['booth_id'] == 'fossasia2026-fr'
+    assert state['instance'] == 'backup'
+    assert state['channel_id'] == 'custom-channel'
+    assert state['mediamtx_path'] == 'fossasia2026/fr'
+
+
+@pytest.mark.anyio
+async def test_create_booth_rejects_duplicate():
+    registry = BoothRegistry()
+    await registry.create_booth(
+        event_slug='pycon2026', language_code='en', language='English',
+    )
+
+    with pytest.raises(ValueError, match='already exists'):
+        await registry.create_booth(
+            event_slug='pycon2026', language_code='en', language='English',
+        )
+
+
+@pytest.mark.anyio
+async def test_create_booth_rejects_invalid_slug():
+    registry = BoothRegistry()
+
+    with pytest.raises(ValueError):
+        await registry.create_booth(
+            event_slug='--bad--', language_code='en', language='English',
+        )
+
+
+@pytest.mark.anyio
+async def test_create_booth_rejects_invalid_language_code():
+    registry = BoothRegistry()
+
+    with pytest.raises(ValueError):
+        await registry.create_booth(
+            event_slug='pycon2026', language_code='xyz', language='English',
+        )
+
+
+@pytest.mark.anyio
+async def test_get_or_create_parses_identity_from_booth_id():
+    """When a booth is auto-created via snapshot with a valid ID, it should
+    have identity fields populated."""
+    registry = BoothRegistry()
+    state = await registry.snapshot('pycon2026-en', 'English', 'pycon2026-en-audio')
+
+    assert state['event_slug'] == 'pycon2026'
+    assert state['language_code'] == 'en'
+    assert state['mediamtx_path'] == 'pycon2026/en'
+
+
+@pytest.mark.anyio
+async def test_get_or_create_handles_legacy_booth_id():
+    """Legacy free-form booth IDs that don't match the identity scheme
+    should still work with empty identity fields."""
+    registry = BoothRegistry()
+    state = await registry.snapshot('hall-a-fr', 'French', 'hall-a-fr-audio')
+
+    assert state['booth_id'] == 'hall-a-fr'
+    # 'fr' is a valid ISO 639-1 code, so it should parse
+    assert state['event_slug'] == 'hall-a'
+    assert state['language_code'] == 'fr'
+
+
+@pytest.mark.anyio
+async def test_identity_booth_join_and_snapshot():
+    """Full flow: create booth via identity, join, verify snapshot."""
+    registry = BoothRegistry()
+    await registry.create_booth(
+        event_slug='pycon2026', language_code='de', language='German',
+    )
+
+    participant = await join_identity(
+        registry, 'Interpreter A', booth_id='pycon2026-de',
+    )
+    state = await registry.snapshot('pycon2026-de', 'German', 'pycon2026-de-audio')
+
+    assert state['active_interpreter_id'] == participant.participant_id
+    assert state['event_slug'] == 'pycon2026'
+    assert state['language_code'] == 'de'
+    assert len(state['participants']) == 1


### PR DESCRIPTION
…MTX path mapping

Define three-coordinate booth identity scheme per RFC #40 Section 5.1:
- Booth ID format: {event_slug}-{language_code} (e.g. pycon2026-en)
- MediaMTX path format: {event_slug}/{language_code} (e.g. pycon2026/en)
- Booth instance: primary or backup (only one publishes at a time)

New module portal/booth_identity.py:
- validate_event_slug: alphanumeric + hyphens, 1-64 chars, no consecutive hyphens
- validate_language_code: ISO 639-1 two-letter code against full code set
- validate_instance: primary or backup
- make_booth_id / make_mediamtx_path: construct from validated coordinates
- parse_booth_id: split booth ID into (event_slug, language_code)
- booth_id_to_mediamtx_path / mediamtx_path_to_booth_id: bidirectional conversion

Updated portal/booth_state.py:
- Booth dataclass gains event_slug, language_code, instance, mediamtx_path fields
- BoothRegistry.create_booth() for validated identity-based booth creation
- _get_or_create_booth() auto-parses valid IDs, gracefully handles legacy IDs

Tests: 60 new identity tests + 8 new registry tests, all 99 pass.
Documentation: ARCHITECTURE.md Section 6 documents the identity scheme.

Closes #53