### PR TITLE
Add room_id field to Booth, derive channel_id from MediaMTX path

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,6 +105,10 @@ A booth is identified by three coordinates:
 
 **MediaMTX path:** `{event_slug}/{language_code}` → `pycon2026/en` (one active stream per language per event)
 
+**Channel ID:** defaults to the MediaMTX path (`{event_slug}/{language_code}`) when created via `create_booth()`. Can be overridden with an explicit value.
+
+**Room ID:** optional integer FK to an Eventyay Room (`room_id: int | None`). Nullable — has no effect on booth identity. Exists to support future Eventyay integration for mapping booths to event rooms.
+
 ### Validation rules
 
 - **Event slug:** `^[a-z0-9]+(?:-[a-z0-9]+)*$`, 1–64 characters. Must start and end with alphanumeric. No consecutive hyphens, no underscores, no spaces.
@@ -161,7 +165,7 @@ Existing free-form booth IDs (e.g. `hall-a-fr`) that happen to end with a valid 
 `BoothRegistry` tracks:
 
 - booth identity (`booth_id`, `event_slug`, `language_code`, `instance`, `mediamtx_path`)
-- booth metadata (`language`, `channel_id`)
+- booth metadata (`language`, `channel_id`, `room_id`)
 - active interpreter id
 - participant roster and roles
 - per-participant connection, mic, and ingest state

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -301,11 +301,12 @@ async def booth_state_api(
     token: str = Query(''),
     language: str = 'English',
     channel: str | None = Query(None),
+    room: int | None = Query(None),
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> dict:
     _require_access(credentials, token)
     channel_id = channel or f'{booth_id}-audio'
-    return await booths.snapshot(booth_id, language, channel_id)
+    return await booths.snapshot(booth_id, language, channel_id, room_id=room)
 
 
 
@@ -327,6 +328,13 @@ async def _handle_join(ws: WebSocket, session: Session, data: dict) -> None:
     language = data.get('language', 'English')
     channel_id = data.get('channel_id', f'{session.booth_id}-audio')
     participant_id = data.get('participant_id')
+    room_id = data.get('room_id')
+    if room_id is not None:
+        try:
+            room_id = int(room_id)
+        except (TypeError, ValueError):
+            await ws.send_text(json.dumps({'type': 'booth:error', 'message': 'room_id must be an integer.'}))
+            return
     try:
         participant, state = await booths.join_participant(
             booth_id=session.booth_id,
@@ -335,6 +343,7 @@ async def _handle_join(ws: WebSocket, session: Session, data: dict) -> None:
             language=language,
             channel_id=channel_id,
             participant_id=participant_id,
+            room_id=room_id,
         )
     except (ValueError, PermissionError) as exc:
         await ws.send_text(json.dumps({'type': 'booth:error', 'message': str(exc)}))

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -55,6 +55,7 @@ class Booth:
     channel_id: str
     instance: BoothInstance = 'primary'
     mediamtx_path: str = ''
+    room_id: int | None = None
     active_interpreter_id: str | None = None
     handoff_state: str = 'idle'
     participants: dict[str, Participant] = field(default_factory=dict)
@@ -62,8 +63,11 @@ class Booth:
     ingest_status: str = 'disconnected'
 
     def __post_init__(self) -> None:
-        if not self.mediamtx_path and self.event_slug and self.language_code:
-            self.mediamtx_path = make_mediamtx_path(self.event_slug, self.language_code)
+        if self.event_slug and self.language_code:
+            if not self.mediamtx_path:
+                self.mediamtx_path = make_mediamtx_path(self.event_slug, self.language_code)
+            if not self.channel_id:
+                self.channel_id = self.mediamtx_path
 
     def as_public_dict(self) -> dict:
         return {
@@ -72,6 +76,7 @@ class Booth:
             'language_code': self.language_code,
             'instance': self.instance,
             'mediamtx_path': self.mediamtx_path,
+            'room_id': self.room_id,
             'language': self.language,
             'channel_id': self.channel_id,
             'active_interpreter_id': self.active_interpreter_id,
@@ -94,12 +99,19 @@ class BoothRegistry:
         self._booths: dict[str, Booth] = {}
         self._lock = asyncio.Lock()
 
-    def _get_or_create_booth(self, booth_id: str, language: str, channel_id: str) -> Booth:
+    def _get_or_create_booth(
+        self,
+        booth_id: str,
+        language: str,
+        channel_id: str,
+        room_id: int | None = None,
+    ) -> Booth:
         """Return existing booth or create one. Caller must hold self._lock.
 
-        ``language`` and ``channel_id`` are only used when *creating* the booth;
-        they are treated as immutable once set so that a later request from a
-        different client cannot silently change the booth's canonical values.
+        ``language``, ``channel_id``, and ``room_id`` are only used when
+        *creating* the booth; they are treated as immutable once set so that
+        a later request from a different client cannot silently change the
+        booth's canonical values.
 
         The ``booth_id`` is parsed into ``event_slug`` and ``language_code``
         using :func:`parse_booth_id`.  If parsing fails (legacy free-form ID),
@@ -119,6 +131,7 @@ class BoothRegistry:
                 language_code=language_code,
                 language=language,
                 channel_id=channel_id,
+                room_id=room_id,
             )
             self._booths[booth_id] = booth
         return booth
@@ -130,11 +143,18 @@ class BoothRegistry:
         language: str,
         channel_id: str = '',
         instance: BoothInstance = 'primary',
+        room_id: int | None = None,
     ) -> dict:
         """Create a booth using validated identity coordinates.
 
-        This is the preferred entry point for new code.  The booth ID and
-        MediaMTX path are derived automatically from the coordinates.
+        This is the preferred entry point for new code.  The booth ID,
+        MediaMTX path, and default ``channel_id`` are derived automatically
+        from the coordinates.  When no explicit ``channel_id`` is given it
+        defaults to the MediaMTX path (``{event_slug}/{language_code}``).
+
+        ``room_id`` is an optional foreign key to an Eventyay Room.  It is
+        nullable and has no effect on booth identity — it exists to support
+        future Eventyay integration.
 
         Raises ``ValueError`` if the slug or language code is invalid, or if
         a booth with the same ID already exists.
@@ -143,6 +163,7 @@ class BoothRegistry:
         code = validate_language_code(language_code)
         inst = validate_instance(instance)
         booth_id = make_booth_id(slug, code)
+        mtx_path = make_mediamtx_path(slug, code)
 
         async with self._lock:
             if booth_id in self._booths:
@@ -152,15 +173,22 @@ class BoothRegistry:
                 event_slug=slug,
                 language_code=code,
                 language=language,
-                channel_id=channel_id or f'{booth_id}-audio',
+                channel_id=channel_id or mtx_path,
                 instance=inst,
+                room_id=room_id,
             )
             self._booths[booth_id] = booth
             return booth.as_public_dict()
 
-    async def snapshot(self, booth_id: str, language: str, channel_id: str) -> dict:
+    async def snapshot(
+        self,
+        booth_id: str,
+        language: str,
+        channel_id: str,
+        room_id: int | None = None,
+    ) -> dict:
         async with self._lock:
-            return self._get_or_create_booth(booth_id, language, channel_id).as_public_dict()
+            return self._get_or_create_booth(booth_id, language, channel_id, room_id=room_id).as_public_dict()
 
     async def join_participant(
         self,
@@ -170,9 +198,10 @@ class BoothRegistry:
         language: str,
         channel_id: str,
         participant_id: str | None = None,
+        room_id: int | None = None,
     ) -> tuple[Participant, dict]:
         async with self._lock:
-            booth = self._get_or_create_booth(booth_id, language, channel_id)
+            booth = self._get_or_create_booth(booth_id, language, channel_id, room_id=room_id)
             participant = Participant(
                 participant_id=participant_id or uuid4().hex,
                 display_name=display_name.strip() or 'Interpreter',

--- a/tests/test_booth_state.py
+++ b/tests/test_booth_state.py
@@ -135,7 +135,8 @@ async def test_create_booth_sets_identity_fields():
     assert state['language_code'] == 'en'
     assert state['instance'] == 'primary'
     assert state['mediamtx_path'] == 'pycon2026/en'
-    assert state['channel_id'] == 'pycon2026-en-audio'
+    assert state['channel_id'] == 'pycon2026/en'
+    assert state['room_id'] is None
 
 
 @pytest.mark.anyio
@@ -230,3 +231,121 @@ async def test_identity_booth_join_and_snapshot():
     assert state['event_slug'] == 'pycon2026'
     assert state['language_code'] == 'de'
     assert len(state['participants']) == 1
+
+
+# ── Event and room field tests ────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_booth_with_room_id():
+    registry = BoothRegistry()
+    state = await registry.create_booth(
+        event_slug='pycon2026',
+        language_code='en',
+        language='English',
+        room_id=42,
+    )
+
+    assert state['room_id'] == 42
+    assert state['event_slug'] == 'pycon2026'
+    assert state['channel_id'] == 'pycon2026/en'
+
+
+@pytest.mark.anyio
+async def test_create_booth_room_id_defaults_to_none():
+    registry = BoothRegistry()
+    state = await registry.create_booth(
+        event_slug='fossasia2026',
+        language_code='fr',
+        language='French',
+    )
+
+    assert state['room_id'] is None
+
+
+@pytest.mark.anyio
+async def test_channel_id_defaults_to_mediamtx_path():
+    """When no explicit channel_id is given, it should equal the MediaMTX path."""
+    registry = BoothRegistry()
+    state = await registry.create_booth(
+        event_slug='pycon2026',
+        language_code='de',
+        language='German',
+    )
+
+    assert state['channel_id'] == 'pycon2026/de'
+    assert state['channel_id'] == state['mediamtx_path']
+
+
+@pytest.mark.anyio
+async def test_channel_id_explicit_overrides_default():
+    """An explicit channel_id should override the mediamtx_path default."""
+    registry = BoothRegistry()
+    state = await registry.create_booth(
+        event_slug='pycon2026',
+        language_code='es',
+        language='Spanish',
+        channel_id='custom-channel',
+    )
+
+    assert state['channel_id'] == 'custom-channel'
+    assert state['mediamtx_path'] == 'pycon2026/es'
+
+
+@pytest.mark.anyio
+async def test_snapshot_passes_room_id_on_creation():
+    """room_id passed via snapshot should be stored on initial booth creation."""
+    registry = BoothRegistry()
+    state = await registry.snapshot('pycon2026-en', 'English', 'pycon2026/en', room_id=7)
+
+    assert state['room_id'] == 7
+    assert state['event_slug'] == 'pycon2026'
+
+
+@pytest.mark.anyio
+async def test_snapshot_room_id_immutable_after_creation():
+    """room_id from a later snapshot call must not overwrite the original."""
+    registry = BoothRegistry()
+    await registry.snapshot('pycon2026-en', 'English', 'pycon2026/en', room_id=7)
+    state = await registry.snapshot('pycon2026-en', 'English', 'pycon2026/en', room_id=99)
+
+    assert state['room_id'] == 7
+
+
+@pytest.mark.anyio
+async def test_join_participant_passes_room_id():
+    """room_id passed via join_participant creates the booth with that room."""
+    registry = BoothRegistry()
+    _, state = await registry.join_participant(
+        booth_id='pycon2026-en',
+        display_name='Interpreter A',
+        role='interpreter',
+        language='English',
+        channel_id='pycon2026/en',
+        room_id=15,
+    )
+
+    assert state['room_id'] == 15
+
+
+@pytest.mark.anyio
+async def test_legacy_booth_has_no_room_id():
+    """Legacy booths auto-created without room_id should default to None."""
+    registry = BoothRegistry()
+    state = await registry.snapshot('hall-a-fr', 'French', 'hall-a-fr-audio')
+
+    assert state['room_id'] is None
+
+
+@pytest.mark.anyio
+async def test_as_public_dict_includes_room_id():
+    """as_public_dict must always include room_id in serialized output."""
+    registry = BoothRegistry()
+    state = await registry.create_booth(
+        event_slug='pycon2026',
+        language_code='ja',
+        language='Japanese',
+        room_id=100,
+    )
+
+    assert 'room_id' in state
+    assert state['room_id'] == 100


### PR DESCRIPTION
Add room_id: int | None to Booth dataclass as nullable FK placeholder for future Eventyay Room integration.

channel_id now defaults to the MediaMTX path ({event_slug}/{language_code}) when created via create_booth(), instead of {booth_id}-audio. Explicit channel_id still overrides the default.

Updated methods: _get_or_create_booth(), create_booth(), snapshot(), join_participant() all accept optional room_id. REST API booth state endpoint and WebSocket join handler pass room_id through.

as_public_dict() includes room_id in serialized output.

9 new tests covering room_id creation, immutability, channel_id derivation, and backward compatibility. All 108 tests pass.

Closes #59