### PR TITLE
Add multi-layer active-interpreter enforcement (#60)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -175,16 +175,40 @@ Existing free-form booth IDs (e.g. `hall-a-fr`) that happen to end with a valid 
 
 The browser keeps only local UI/session state: joined participant id, mic stream, peer connection, current booth snapshot, and current chat messages. Server state remains the source of truth for who is active.
 
-## 9. Active interpreter enforcement
+## 9. Active interpreter enforcement — three-layer model
+
+Three independent layers prevent unauthorized audio publishing. Each layer is tested independently so a failure in one layer does not compromise the others.
+
+### Layer 1 — Application state (booth_state.py)
+
+`BoothRegistry.update_participant_state()` rejects any attempt to set `mic_active=True` or `ingest_connected=True` unless:
+
+1. The participant's role is `interpreter` (coordinators and listeners are rejected).
+2. The participant is the booth's current `active_interpreter_id`.
+
+`BoothRegistry.check_publish_permission()` encapsulates the same two checks for reuse by Layer 2.
 
 Enforcement rules:
 
 1. Start WHIP ingest only when local participant is active for the channel.
 2. Only the active interpreter can click "Go Live" to publish audio.
 3. Active interpreter handoff via `booth:set-active` clears the previous publisher's mic and ingest state.
-4. MediaMTX enforces single-publisher per path (`overridePublisher: yes`).
-5. Coordinator role can override active ownership.
+5. Coordinator role can override active ownership (but cannot publish).
 6. Non-interpreter roles cannot become active publishers.
+
+### Layer 2 — WHIP URL gating (fastapi_app.py)
+
+`GET /api/booth/{booth_id}/whip-url?participant_id=...` returns the MediaMTX WHIP ingest URL **only** to the active interpreter. Non-active interpreters and non-interpreter roles receive HTTP 403 and never learn the URL. The browser must call this endpoint before starting a WHIP session.
+
+### Layer 3 — Media server enforcement (mediamtx.yml)
+
+MediaMTX runs with `overridePublisher: yes` on all paths. If a rogue or stale WHIP session bypasses Layers 1 and 2, MediaMTX itself ensures only one publisher is live per path at any time — the old publisher is disconnected immediately when a new one arrives.
+
+```
+Layer 1: booth_state  →  role + active-interpreter check  (PermissionError)
+Layer 2: /whip-url    →  gated WHIP URL endpoint          (HTTP 403)
+Layer 3: MediaMTX     →  overridePublisher: yes            (old publisher kicked)
+```
 
 ## 10. Reconnect and teardown behavior
 

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -309,6 +309,34 @@ async def booth_state_api(
     return await booths.snapshot(booth_id, language, channel_id, room_id=room)
 
 
+@app.get('/api/booth/{booth_id}/whip-url')
+async def booth_whip_url(
+    booth_id: str,
+    participant_id: str = Query(...),
+    token: str = Query(''),
+    language: str = 'English',
+    channel: str | None = Query(None),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> dict:
+    """Return the WHIP ingest URL only if the caller is the active interpreter.
+
+    Layer 2 enforcement: the browser must call this endpoint before starting
+    a WHIP session. Non-active interpreters and non-interpreter roles receive
+    a 403 response and never learn the WHIP URL.
+    """
+    _require_access(credentials, token)
+    channel_id = channel or f'{booth_id}-audio'
+    try:
+        await booths.check_publish_permission(booth_id, participant_id, language, channel_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except PermissionError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    await _ensure_mediamtx_path(channel_id)
+    whip_url = f'{settings.mediamtx_whip_base}/{channel_id}/whip'
+    return {'whip_url': whip_url, 'channel_id': channel_id, 'booth_id': booth_id}
+
+
 
 @app.get('/api/interpreter/status/{channel_id}')
 async def ingest_status_api(channel_id: str) -> dict:

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -103,6 +103,13 @@ apiAddress: :9997
 #
 # overridePublisher: when a new WHIP publisher connects to a path that already
 # has one, MediaMTX kicks the old publisher and accepts the new one.
+#
+# ENFORCEMENT LAYER 3 — Media-level single-publisher guarantee:
+# If a rogue or stale WHIP session bypasses the application-level checks
+# (Layer 1: booth_state role + active-interpreter validation, Layer 2:
+# /api/booth/{booth_id}/whip-url gated endpoint), MediaMTX itself ensures
+# only one publisher is live per path at any time. The old publisher is
+# disconnected immediately when a new one arrives.
 pathDefaults:
   record: no             # disable on-disk recording for local dev
   overridePublisher: yes

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -303,6 +303,8 @@ class BoothRegistry:
             if participant is None:
                 raise ValueError('Participant does not exist in booth.')
             wants_publisher_state = mic_active is True or ingest_connected is True
+            if wants_publisher_state and participant.role != 'interpreter':
+                raise PermissionError('Only interpreter role can publish audio.')
             if wants_publisher_state and booth.active_interpreter_id != participant_id:
                 raise PermissionError('Only the active interpreter can mark mic or ingest active.')
             if mic_active is not None:
@@ -316,6 +318,29 @@ class BoothRegistry:
                 'connected' if any(p.ingest_connected for p in booth.participants.values()) else 'disconnected'
             )
             return booth.as_public_dict()
+
+    async def check_publish_permission(
+        self,
+        booth_id: str,
+        participant_id: str,
+        language: str,
+        channel_id: str,
+    ) -> None:
+        """Raise PermissionError if participant may not publish audio.
+
+        Checks two conditions (Layer 1 enforcement):
+        1. Participant must have the ``interpreter`` role.
+        2. Participant must be the booth's active interpreter.
+        """
+        async with self._lock:
+            booth = self._get_or_create_booth(booth_id, language, channel_id)
+            participant = booth.participants.get(participant_id)
+            if participant is None:
+                raise ValueError('Participant does not exist in booth.')
+            if participant.role != 'interpreter':
+                raise PermissionError('Only interpreter role can publish audio.')
+            if booth.active_interpreter_id != participant_id:
+                raise PermissionError('Only the active interpreter can publish audio.')
 
     async def is_active_interpreter(self, booth_id: str, participant_id: str, language: str, channel_id: str) -> bool:
         async with self._lock:

--- a/tests/test_booth_state.py
+++ b/tests/test_booth_state.py
@@ -349,3 +349,107 @@ async def test_as_public_dict_includes_room_id():
 
     assert 'room_id' in state
     assert state['room_id'] == 100
+
+
+# ── Layer 1: active-interpreter enforcement tests ─────────────────────────────
+
+@pytest.mark.anyio
+async def test_coordinator_cannot_set_mic_active():
+    """Coordinator role must not be allowed to mark mic or ingest active."""
+    registry = BoothRegistry()
+    await join(registry, 'Interpreter A')
+    coordinator = await join(registry, 'Coordinator', role='coordinator')
+
+    with pytest.raises(PermissionError, match='Only interpreter role'):
+        await registry.update_participant_state(
+            'hall-a-fr',
+            coordinator.participant_id,
+            'French',
+            'hall-a-fr-audio',
+            mic_active=True,
+        )
+
+
+@pytest.mark.anyio
+async def test_listener_cannot_set_ingest_connected():
+    """Listener role must not be allowed to mark ingest connected."""
+    registry = BoothRegistry()
+    await join(registry, 'Interpreter A')
+    listener = await join(registry, 'Listener', role='listener')
+
+    with pytest.raises(PermissionError, match='Only interpreter role'):
+        await registry.update_participant_state(
+            'hall-a-fr',
+            listener.participant_id,
+            'French',
+            'hall-a-fr-audio',
+            ingest_connected=True,
+        )
+
+
+@pytest.mark.anyio
+async def test_check_publish_permission_active_interpreter_passes():
+    """Active interpreter passes the publish permission check."""
+    registry = BoothRegistry()
+    interpreter = await join(registry, 'Interpreter A')
+
+    # Should not raise
+    await registry.check_publish_permission(
+        'hall-a-fr', interpreter.participant_id, 'French', 'hall-a-fr-audio',
+    )
+
+
+@pytest.mark.anyio
+async def test_check_publish_permission_standby_interpreter_rejected():
+    """Standby interpreter fails the publish permission check."""
+    registry = BoothRegistry()
+    await join(registry, 'Interpreter A')
+    interpreter_b = await join(registry, 'Interpreter B')
+
+    with pytest.raises(PermissionError, match='active interpreter'):
+        await registry.check_publish_permission(
+            'hall-a-fr', interpreter_b.participant_id, 'French', 'hall-a-fr-audio',
+        )
+
+
+@pytest.mark.anyio
+async def test_check_publish_permission_coordinator_rejected():
+    """Coordinator role fails the publish permission check."""
+    registry = BoothRegistry()
+    coordinator = await join(registry, 'Coordinator', role='coordinator')
+
+    with pytest.raises(PermissionError, match='Only interpreter role'):
+        await registry.check_publish_permission(
+            'hall-a-fr', coordinator.participant_id, 'French', 'hall-a-fr-audio',
+        )
+
+
+@pytest.mark.anyio
+async def test_check_publish_permission_unknown_participant():
+    """Unknown participant_id raises ValueError."""
+    registry = BoothRegistry()
+    await join(registry, 'Interpreter A')
+
+    with pytest.raises(ValueError, match='does not exist'):
+        await registry.check_publish_permission(
+            'hall-a-fr', 'unknown-id', 'French', 'hall-a-fr-audio',
+        )
+
+
+@pytest.mark.anyio
+async def test_active_interpreter_can_turn_off_mic():
+    """Active interpreter can set mic_active=False (non-publisher state)."""
+    registry = BoothRegistry()
+    interpreter = await join(registry, 'Interpreter A')
+
+    await registry.update_participant_state(
+        'hall-a-fr', interpreter.participant_id, 'French', 'hall-a-fr-audio',
+        mic_active=True,
+    )
+    state = await registry.update_participant_state(
+        'hall-a-fr', interpreter.participant_id, 'French', 'hall-a-fr-audio',
+        mic_active=False,
+    )
+
+    participants = {p['participant_id']: p for p in state['participants']}
+    assert participants[interpreter.participant_id]['mic_active'] is False

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -491,3 +491,109 @@ def test_ws_coordinator_can_switch_active_interpreter():
     assert state_msg is not None, 'Expected a booth:state after set-active'
     assert state_msg['state']['active_interpreter_id'] == pid_a
 
+
+# ── Layer 2: WHIP URL gated endpoint tests ────────────────────────────────────
+
+def test_whip_url_active_interpreter_gets_url():
+    """Active interpreter receives a WHIP URL from the gated endpoint."""
+    booth = 'whip-gate-booth'
+    channel = f'{booth}-audio'
+    with client.websocket_connect(f'/ws/booth/{booth}') as ws:
+        ws.send_text(json.dumps({
+            'type': 'booth:join', 'display_name': 'Active',
+            'role': 'interpreter', 'language': 'English', 'channel_id': channel,
+        }))
+        joined = json.loads(ws.receive_text())
+        if joined['type'] != 'booth:joined':
+            joined = json.loads(ws.receive_text())
+        pid = joined['participant_id']
+        ws.receive_text()  # drain booth:state
+
+        res = client.get(
+            f'/api/booth/{booth}/whip-url',
+            params={'participant_id': pid, 'language': 'English', 'channel': channel},
+        )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert 'whip_url' in body
+    assert body['channel_id'] == channel
+    assert body['booth_id'] == booth
+    assert body['whip_url'].endswith(f'/{channel}/whip')
+
+
+def test_whip_url_standby_interpreter_rejected():
+    """Standby interpreter receives 403 from the WHIP URL endpoint."""
+    booth = 'whip-standby-booth'
+    channel = f'{booth}-audio'
+    with client.websocket_connect(f'/ws/booth/{booth}') as ws_a, \
+         client.websocket_connect(f'/ws/booth/{booth}') as ws_b:
+
+        # IntA joins first → becomes active
+        ws_a.send_text(json.dumps({
+            'type': 'booth:join', 'display_name': 'IntA',
+            'role': 'interpreter', 'language': 'English', 'channel_id': channel,
+        }))
+        ws_a.receive_text()  # booth:joined
+        ws_a.receive_text()  # booth:state
+        ws_b.receive_text()  # booth:state broadcast
+
+        # IntB joins → standby
+        ws_b.send_text(json.dumps({
+            'type': 'booth:join', 'display_name': 'IntB',
+            'role': 'interpreter', 'language': 'English', 'channel_id': channel,
+        }))
+        joined_b = json.loads(ws_b.receive_text())
+        if joined_b['type'] != 'booth:joined':
+            joined_b = json.loads(ws_b.receive_text())
+        pid_b = joined_b['participant_id']
+        ws_b.receive_text()  # drain booth:state
+        ws_a.receive_text()  # drain broadcast to ws_a
+
+        res = client.get(
+            f'/api/booth/{booth}/whip-url',
+            params={'participant_id': pid_b, 'language': 'English', 'channel': channel},
+        )
+
+    assert res.status_code == 403
+    assert 'active interpreter' in res.json()['detail'].lower()
+
+
+def test_whip_url_coordinator_rejected():
+    """Coordinator role receives 403 from the WHIP URL endpoint."""
+    booth = 'whip-coord-booth'
+    channel = f'{booth}-audio'
+    with client.websocket_connect(f'/ws/booth/{booth}') as ws:
+        ws.send_text(json.dumps({
+            'type': 'booth:join', 'display_name': 'Coord',
+            'role': 'coordinator', 'language': 'English', 'channel_id': channel,
+        }))
+        joined = json.loads(ws.receive_text())
+        if joined['type'] != 'booth:joined':
+            joined = json.loads(ws.receive_text())
+        pid = joined['participant_id']
+        ws.receive_text()  # drain booth:state
+
+        res = client.get(
+            f'/api/booth/{booth}/whip-url',
+            params={'participant_id': pid, 'language': 'English', 'channel': channel},
+        )
+
+    assert res.status_code == 403
+    assert 'interpreter role' in res.json()['detail'].lower()
+
+
+def test_whip_url_unknown_participant_returns_404():
+    """Unknown participant_id returns 404."""
+    res = client.get(
+        '/api/booth/whip-404-booth/whip-url',
+        params={'participant_id': 'nonexistent', 'language': 'English'},
+    )
+    assert res.status_code == 404
+
+
+def test_whip_url_missing_participant_id_returns_422():
+    """Missing required participant_id query param returns 422."""
+    res = client.get('/api/booth/whip-missing-booth/whip-url')
+    assert res.status_code == 422
+


### PR DESCRIPTION
Layer 1 (booth_state.py):
- Add role check in update_participant_state: non-interpreter roles (coordinator, listener) are rejected before the active-interpreter check.
- Add check_publish_permission() method for reusable two-step validation (role + active status) used by Layer 2.

Layer 2 (fastapi_app.py):
- Add GET /api/booth/{booth_id}/whip-url gated endpoint. Returns the MediaMTX WHIP ingest URL only to the active interpreter; returns 403 for standby interpreters and non-interpreter roles, 404 for unknown participants, 422 for missing participant_id.

Layer 3 (mediamtx.yml):
- Document overridePublisher: yes as enforcement Layer 3 — MediaMTX kicks stale publishers if they bypass application-level checks.

Tests: 12 new tests (7 unit + 5 integration), 120 total, all passing.
ARCHITECTURE.md: rewrite section 9 with three-layer enforcement model.