### PR TITLE
Implement booth bootstrap flow (#61)

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -190,6 +190,13 @@ class TokenResponse(BaseModel):
     token_type: str = 'bearer'
 
 
+class CreateBoothRequest(BaseModel):
+    language_code: str
+    language: str = ''
+    room_id: int | None = None
+    instance: str = 'primary'
+
+
 # ── Auth endpoint ─────────────────────────────────────────────────────────────
 
 @app.post('/api/auth/token', response_model=TokenResponse)
@@ -214,6 +221,53 @@ async def healthz() -> dict:
         'server': 'fastapi',
         'mediamtx_ok': await _check_mediamtx(),
     }
+
+
+@app.get('/interpreter/{event_slug}/{language_code}')
+async def interpreter_booth_by_identity(
+    request: Request,
+    event_slug: str,
+    language_code: str,
+    token: str = '',
+    language: str = '',
+) -> Any:
+    """Booth page addressed by event_slug and language_code (preferred URL).
+
+    Derives booth_id, channel_id, WHIP URL, and WHEP URL from the identity
+    coordinates.  The MediaMTX path is created on first access.
+    """
+    from portal.booth_identity import make_booth_id, make_mediamtx_path
+
+    booth_id = make_booth_id(event_slug, language_code)
+    mediamtx_path = make_mediamtx_path(event_slug, language_code)
+    channel_id = mediamtx_path
+    display_language = language or language_code.upper()
+    await _ensure_mediamtx_path(channel_id)
+    whip_url = f'{settings.mediamtx_whip_base}/{mediamtx_path}/whip'
+    whep_url = f'{settings.mediamtx_whip_base}/{mediamtx_path}/whep'
+    return templates.TemplateResponse(
+        request,
+        'interpreter_booth.html',
+        {
+            'booth_id': booth_id,
+            'booth_token': token,
+            'booth_language': display_language,
+            'booth_channel_id': channel_id,
+            'event_slug': event_slug,
+            'language_code': language_code,
+            'whip_url': whip_url,
+            'whep_url': whep_url,
+            'default_jitsi_room': settings.default_jitsi_room,
+            'default_jitsi_url': _make_jitsi_url(
+                settings.effective_jitsi_base_url, settings.default_jitsi_room
+            ),
+            'jitsi_domain': settings.effective_jitsi_domain,
+            'jitsi_base_url': settings.effective_jitsi_base_url,
+            'mediamtx_whip_base': settings.mediamtx_whip_base,
+            'mediamtx_hls_base': settings.mediamtx_hls_base,
+            'js_version': _JS_CACHE_BUST,
+        },
+    )
 
 
 @app.get('/interpreter/{booth_id}')
@@ -336,6 +390,52 @@ async def booth_whip_url(
     whip_url = f'{settings.mediamtx_whip_base}/{channel_id}/whip'
     return {'whip_url': whip_url, 'channel_id': channel_id, 'booth_id': booth_id}
 
+
+@app.post('/api/events/{event_slug}/booths', status_code=status.HTTP_201_CREATED)
+async def create_event_booth(
+    event_slug: str,
+    body: CreateBoothRequest,
+    token: str = Query(''),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> dict:
+    """Create a booth for an event.
+
+    Returns the booth state including derived booth_id, MediaMTX path,
+    WHIP URL, and WHEP URL.
+    """
+    _require_access(credentials, token)
+    try:
+        state = await booths.create_booth(
+            event_slug=event_slug,
+            language_code=body.language_code,
+            language=body.language or body.language_code.upper(),
+            instance=body.instance,
+            room_id=body.room_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    mediamtx_path = state['mediamtx_path']
+    await _ensure_mediamtx_path(mediamtx_path)
+    state['whip_url'] = f'{settings.mediamtx_whip_base}/{mediamtx_path}/whip'
+    state['whep_url'] = f'{settings.mediamtx_whip_base}/{mediamtx_path}/whep'
+    return state
+
+
+@app.get('/api/events/{event_slug}/booths')
+async def list_event_booths(
+    event_slug: str,
+    token: str = Query(''),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> dict:
+    """List all booths for an event."""
+    _require_access(credentials, token)
+    booth_list = await booths.list_booths_for_event(event_slug)
+    for b in booth_list:
+        mtx = b.get('mediamtx_path', '')
+        if mtx:
+            b['whip_url'] = f'{settings.mediamtx_whip_base}/{mtx}/whip'
+            b['whep_url'] = f'{settings.mediamtx_whip_base}/{mtx}/whep'
+    return {'event_slug': event_slug, 'booths': booth_list}
 
 
 @app.get('/api/interpreter/status/{channel_id}')

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -347,6 +347,15 @@ class BoothRegistry:
             booth = self._get_or_create_booth(booth_id, language, channel_id)
             return booth.active_interpreter_id == participant_id
 
+    async def list_booths_for_event(self, event_slug: str) -> list[dict]:
+        """Return public snapshots of all booths belonging to *event_slug*."""
+        async with self._lock:
+            return [
+                booth.as_public_dict()
+                for booth in self._booths.values()
+                if booth.event_slug == event_slug
+            ]
+
     async def set_ingest_status(self, booth_id: str, status: str, language: str, channel_id: str) -> dict:
         async with self._lock:
             booth = self._get_or_create_booth(booth_id, language, channel_id)

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -14,6 +14,10 @@
   data-jitsi-domain='{{ jitsi_domain }}'
   data-whip-base='{{ mediamtx_whip_base }}'
   data-hls-base='{{ mediamtx_hls_base }}'
+  data-event-slug='{{ event_slug | default("") }}'
+  data-language-code='{{ language_code | default("") }}'
+  data-whip-url='{{ whip_url | default("") }}'
+  data-whep-url='{{ whep_url | default("") }}'
 >
   <section class='panel'>
     <header class='panel-header'>
@@ -196,9 +200,9 @@
         <div><dt>Mic state</dt><dd id='mic-state'>Inactive</dd></div>
         <div><dt>Ingest reachable</dt><dd id='ingest-reachable'>Unknown</dd></div>
         <div><dt>Active interpreter</dt><dd id='active-name'>Unassigned</dd></div>
-        <div><dt>HLS stream</dt><dd><span id='hls-validation-status' class='status-badge'>Not started</span></dd></div>
+        <div><dt>WHEP stream</dt><dd><span id='hls-validation-status' class='status-badge'>Not started</span></dd></div>
         <div id='hls-url-row' class='hidden'>
-          <dt>HLS stream (VLC / browser)</dt>
+          <dt>Listener URL (WHEP)</dt>
           <dd class='hls-url-cell'><code id='hls-url-display'></code><button id='copy-hls-url' type='button' class='btn btn-xs'>Copy</button></dd>
         </div>
       </dl>

--- a/tests/test_booth_state.py
+++ b/tests/test_booth_state.py
@@ -453,3 +453,29 @@ async def test_active_interpreter_can_turn_off_mic():
 
     participants = {p['participant_id']: p for p in state['participants']}
     assert participants[interpreter.participant_id]['mic_active'] is False
+
+
+# ── Booth listing tests ───────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_booths_for_event_returns_matching():
+    registry = BoothRegistry()
+    await registry.create_booth(event_slug='pycon2026', language_code='en', language='English')
+    await registry.create_booth(event_slug='pycon2026', language_code='fr', language='French')
+    await registry.create_booth(event_slug='fossasia', language_code='en', language='English')
+
+    result = await registry.list_booths_for_event('pycon2026')
+
+    assert len(result) == 2
+    slugs = {b['language_code'] for b in result}
+    assert slugs == {'en', 'fr'}
+
+
+@pytest.mark.anyio
+async def test_list_booths_for_event_empty():
+    registry = BoothRegistry()
+    await registry.create_booth(event_slug='pycon2026', language_code='en', language='English')
+
+    result = await registry.list_booths_for_event('nonexistent')
+
+    assert result == []

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -597,3 +597,150 @@ def test_whip_url_missing_participant_id_returns_422():
     res = client.get('/api/booth/whip-missing-booth/whip-url')
     assert res.status_code == 422
 
+
+# ── Booth bootstrap flow tests (Issue #61) ────────────────────────────────────
+
+def test_create_event_booth():
+    """POST /api/events/{slug}/booths creates a booth and returns WHIP/WHEP URLs."""
+    res = client.post('/api/events/pycon2026/booths', json={
+        'language_code': 'en',
+        'language': 'English',
+        'room_id': 42,
+    })
+    assert res.status_code == 201
+    body = res.json()
+    assert body['booth_id'] == 'pycon2026-en'
+    assert body['event_slug'] == 'pycon2026'
+    assert body['language_code'] == 'en'
+    assert body['mediamtx_path'] == 'pycon2026/en'
+    assert body['room_id'] == 42
+    assert body['whip_url'].endswith('/pycon2026/en/whip')
+    assert body['whep_url'].endswith('/pycon2026/en/whep')
+
+
+def test_create_event_booth_duplicate_returns_400():
+    """Creating the same booth twice returns 400."""
+    client.post('/api/events/duptest/booths', json={'language_code': 'fr', 'language': 'French'})
+    res = client.post('/api/events/duptest/booths', json={'language_code': 'fr', 'language': 'French'})
+    assert res.status_code == 400
+    assert 'already exists' in res.json()['detail']
+
+
+def test_create_event_booth_invalid_language_code():
+    """Invalid language code returns 400."""
+    res = client.post('/api/events/pycon2026/booths', json={
+        'language_code': 'xyz',
+        'language': 'Unknown',
+    })
+    assert res.status_code == 400
+
+
+def test_create_event_booth_invalid_event_slug():
+    """Invalid event slug returns 400."""
+    res = client.post('/api/events/--bad--/booths', json={
+        'language_code': 'en',
+        'language': 'English',
+    })
+    assert res.status_code == 400
+
+
+def test_list_event_booths():
+    """GET /api/events/{slug}/booths lists booths for the event."""
+    client.post('/api/events/listtest/booths', json={'language_code': 'en', 'language': 'English'})
+    client.post('/api/events/listtest/booths', json={'language_code': 'de', 'language': 'German'})
+    client.post('/api/events/other/booths', json={'language_code': 'ja', 'language': 'Japanese'})
+
+    res = client.get('/api/events/listtest/booths')
+    assert res.status_code == 200
+    body = res.json()
+    assert body['event_slug'] == 'listtest'
+    assert len(body['booths']) == 2
+    codes = {b['language_code'] for b in body['booths']}
+    assert codes == {'en', 'de'}
+    # Each booth should have WHEP/WHIP URLs
+    for b in body['booths']:
+        assert 'whip_url' in b
+        assert 'whep_url' in b
+
+
+def test_list_event_booths_empty():
+    """Listing booths for a non-existent event returns empty list."""
+    res = client.get('/api/events/nonexistent/booths')
+    assert res.status_code == 200
+    assert res.json()['booths'] == []
+
+
+def test_interpreter_booth_by_identity_page():
+    """GET /interpreter/{event_slug}/{language_code} renders the booth page."""
+    res = client.get('/interpreter/myevent/en')
+    assert res.status_code == 200
+    assert b'myevent-en' in res.content
+    assert b"data-event-slug='myevent'" in res.content
+    assert b"data-language-code='en'" in res.content
+    assert b'data-whip-url=' in res.content
+    assert b'data-whep-url=' in res.content
+
+
+def test_interpreter_booth_by_identity_whip_whep_urls():
+    """The identity-based booth page has correct WHIP and WHEP URLs."""
+    res = client.get('/interpreter/fossasia/fr')
+    assert res.status_code == 200
+    content = res.content.decode()
+    assert 'fossasia/fr/whip' in content
+    assert 'fossasia/fr/whep' in content
+
+
+def test_legacy_interpreter_booth_still_works():
+    """The old /interpreter/{booth_id} route still works for backward compat."""
+    res = client.get('/interpreter/demo-booth')
+    assert res.status_code == 200
+    assert b'demo-booth' in res.content
+
+
+def test_full_bootstrap_flow():
+    """End-to-end: create booth → access page → join → go live (get WHIP URL)."""
+    # 1. Organiser creates booth via API
+    create_res = client.post('/api/events/bootstrap/booths', json={
+        'language_code': 'es',
+        'language': 'Spanish',
+        'room_id': 5,
+    })
+    assert create_res.status_code == 201
+    booth = create_res.json()
+    booth_id = booth['booth_id']
+    assert booth_id == 'bootstrap-es'
+
+    # 2. Interpreter accesses booth page
+    page_res = client.get('/interpreter/bootstrap/es')
+    assert page_res.status_code == 200
+    assert b'bootstrap-es' in page_res.content
+
+    # 3. Interpreter joins via WebSocket
+    channel = booth['mediamtx_path']
+    with client.websocket_connect(f'/ws/booth/{booth_id}') as ws:
+        ws.send_text(json.dumps({
+            'type': 'booth:join',
+            'display_name': 'Interpreter A',
+            'role': 'interpreter',
+            'language': 'Spanish',
+            'channel_id': channel,
+        }))
+        joined = json.loads(ws.receive_text())
+        if joined['type'] != 'booth:joined':
+            joined = json.loads(ws.receive_text())
+        pid = joined['participant_id']
+        ws.receive_text()  # drain booth:state
+
+        # 4. Active interpreter requests WHIP URL (Go Live)
+        whip_res = client.get(
+            f'/api/booth/{booth_id}/whip-url',
+            params={'participant_id': pid, 'language': 'Spanish', 'channel': channel},
+        )
+        assert whip_res.status_code == 200
+        whip_body = whip_res.json()
+        assert whip_body['whip_url'].endswith(f'/{channel}/whip')
+
+        # 5. Verify WHEP URL is derivable from the same path
+        whep_url = whip_body['whip_url'].replace('/whip', '/whep')
+        assert f'/{channel}/whep' in whep_url
+


### PR DESCRIPTION
Add end-to-end flow: organiser creates booth → interpreter joins via URL → coordinator assigns active → interpreter goes live via WHIP → WHEP output available.

API endpoints:
- POST /api/events/{event_slug}/booths: create booth with language_code, language, room_id, instance. Returns booth state with WHIP/WHEP URLs.
- GET /api/events/{event_slug}/booths: list all booths for an event with WHIP/WHEP URLs attached.

Page routes:
- GET /interpreter/{event_slug}/{language_code}: identity-based booth page. Derives booth_id, channel_id, WHIP URL, WHEP URL from coordinates. Ensures MediaMTX path exists on first access.
- Old GET /interpreter/{booth_id} route preserved for backward compat.

booth_state.py:
- Add list_booths_for_event() method to BoothRegistry.

Template:
- Add data-event-slug, data-language-code, data-whip-url, data-whep-url attributes to interpreter_booth.html.
- Update Audio Status section to reference WHEP (not HLS).

Tests: 12 new tests (2 unit + 10 integration), 132 total, all passing. Full bootstrap flow tested end-to-end.

closes #61