### PR TITLE
Add multi-event namespace isolation (#62)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -132,11 +132,11 @@ Existing free-form booth IDs (e.g. `hall-a-fr`) that happen to end with a valid 
 ## 7. Runtime components in this repository
 
 - `fastapi_app.py`
-  - FastAPI routes, WebSocket event handlers, JWT auth, Jinja2 templates, health checks
+  - FastAPI routes (legacy + event-scoped), WebSocket event handlers with cross-event validation, `_resolve_whip_url` shared helper, JWT auth, Jinja2 templates, health checks
 - `portal/booth_identity.py`
   - booth identity scheme: validation (event slug, ISO 639-1 language code, instance), booth ID generation, MediaMTX path mapping, bidirectional conversion
 - `portal/booth_state.py`
-  - async in-memory booth registry, participant role policy, active interpreter ownership, handoff state, chat history
+  - async in-memory booth registry, participant role policy, active interpreter ownership, handoff state, chat history, event-scoped queries (`get_booth`, `get_booth_for_event`, `validate_booth_event`)
 - `portal/auth.py`
   - JWT token creation and validation (PyJWT)
 - `portal/config.py`
@@ -209,6 +209,17 @@ Layer 1: booth_state  →  role + active-interpreter check  (PermissionError)
 Layer 2: /whip-url    →  gated WHIP URL endpoint          (HTTP 403)
 Layer 3: MediaMTX     →  overridePublisher: yes            (old publisher kicked)
 ```
+
+## 9.1 Multi-event namespace isolation
+
+Event-scoped API endpoints (`/api/events/{event_slug}/booths/...`) enforce strict
+namespace isolation:
+
+- `list_booths_for_event(event_slug)` filters the in-memory registry by event_slug.
+- `get_booth_for_event(event_slug, language_code)` returns `None` (not a new booth) if the combination doesn't exist.
+- `validate_booth_event(booth_id, expected_event)` raises `PermissionError` if the booth's parsed event_slug doesn't match — used by event-scoped WHIP URL endpoint and WebSocket join handler.
+- MediaMTX paths embed the event slug (`{event_slug}/{language_code}`), so audio streams are physically separated per event.
+- WebSocket join with a mismatched `event_slug` field is rejected before the participant is added to the booth.
 
 ## 10. Reconnect and teardown behavior
 

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -22,6 +22,7 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
 from portal.auth import create_token, decode_token, security, verify_ws_token
+from portal.booth_identity import make_booth_id, make_mediamtx_path
 from portal.booth_state import BoothRegistry
 from portal.config import settings
 
@@ -179,6 +180,24 @@ def _require_access(
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Invalid or missing auth token.')
 
 
+async def _resolve_whip_url(booth_id: str, participant_id: str, language: str, channel_id: str) -> dict:
+    """Check publish permission and return the WHIP URL payload.
+
+    Shared by both the legacy ``/api/booth/{id}/whip-url`` endpoint and the
+    event-scoped ``/api/events/{slug}/booths/{lang}/whip-url`` endpoint.
+    Raises :class:`HTTPException` on permission/lookup failures.
+    """
+    try:
+        await booths.check_publish_permission(booth_id, participant_id, language, channel_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except PermissionError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    await _ensure_mediamtx_path(channel_id)
+    whip_url = f'{settings.mediamtx_whip_base}/{channel_id}/whip'
+    return {'whip_url': whip_url, 'channel_id': channel_id, 'booth_id': booth_id}
+
+
 # ── Pydantic request models ───────────────────────────────────────────────────
 
 class TokenRequest(BaseModel):
@@ -236,8 +255,6 @@ async def interpreter_booth_by_identity(
     Derives booth_id, channel_id, WHIP URL, and WHEP URL from the identity
     coordinates.  The MediaMTX path is created on first access.
     """
-    from portal.booth_identity import make_booth_id, make_mediamtx_path
-
     booth_id = make_booth_id(event_slug, language_code)
     mediamtx_path = make_mediamtx_path(event_slug, language_code)
     channel_id = mediamtx_path
@@ -380,15 +397,7 @@ async def booth_whip_url(
     """
     _require_access(credentials, token)
     channel_id = channel or f'{booth_id}-audio'
-    try:
-        await booths.check_publish_permission(booth_id, participant_id, language, channel_id)
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except PermissionError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
-    await _ensure_mediamtx_path(channel_id)
-    whip_url = f'{settings.mediamtx_whip_base}/{channel_id}/whip'
-    return {'whip_url': whip_url, 'channel_id': channel_id, 'booth_id': booth_id}
+    return await _resolve_whip_url(booth_id, participant_id, language, channel_id)
 
 
 @app.post('/api/events/{event_slug}/booths', status_code=status.HTTP_201_CREATED)
@@ -438,6 +447,50 @@ async def list_event_booths(
     return {'event_slug': event_slug, 'booths': booth_list}
 
 
+@app.get('/api/events/{event_slug}/booths/{language_code}/state')
+async def event_booth_state(
+    event_slug: str,
+    language_code: str,
+    token: str = Query(''),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> dict:
+    """Event-scoped booth state — never auto-creates a booth.
+
+    Returns 404 if the booth does not exist for this event.
+    """
+    _require_access(credentials, token)
+    state = await booths.get_booth_for_event(event_slug, language_code)
+    if state is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No booth for language '{language_code}' in event '{event_slug}'.",
+        )
+    return state
+
+
+@app.get('/api/events/{event_slug}/booths/{language_code}/whip-url')
+async def event_booth_whip_url(
+    event_slug: str,
+    language_code: str,
+    participant_id: str = Query(...),
+    token: str = Query(''),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> dict:
+    """Event-scoped WHIP URL — validates event ownership before returning.
+
+    Combines event namespace isolation (booth must belong to event) with
+    Layer 2 active-interpreter enforcement.
+    """
+    _require_access(credentials, token)
+    booth_id = make_booth_id(event_slug, language_code)
+    channel_id = make_mediamtx_path(event_slug, language_code)
+    try:
+        await booths.validate_booth_event(booth_id, event_slug)
+    except PermissionError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    return await _resolve_whip_url(booth_id, participant_id, language_code.upper(), channel_id)
+
+
 @app.get('/api/interpreter/status/{channel_id}')
 async def ingest_status_api(channel_id: str) -> dict:
     """Returns MediaMTX reachability — used by the frontend preflight check."""
@@ -456,6 +509,14 @@ async def _handle_join(ws: WebSocket, session: Session, data: dict) -> None:
     language = data.get('language', 'English')
     channel_id = data.get('channel_id', f'{session.booth_id}-audio')
     participant_id = data.get('participant_id')
+    # Cross-event isolation: reject if client-supplied event_slug doesn't match
+    client_event = data.get('event_slug')
+    if client_event is not None:
+        try:
+            await booths.validate_booth_event(session.booth_id, client_event)
+        except PermissionError as exc:
+            await ws.send_text(json.dumps({'type': 'booth:error', 'message': str(exc)}))
+            return
     room_id = data.get('room_id')
     if room_id is not None:
         try:

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -356,6 +356,34 @@ class BoothRegistry:
                 if booth.event_slug == event_slug
             ]
 
+    async def get_booth(self, booth_id: str) -> dict | None:
+        """Return the public dict for an existing booth, or None."""
+        async with self._lock:
+            booth = self._booths.get(booth_id)
+            return booth.as_public_dict() if booth is not None else None
+
+    async def get_booth_for_event(self, event_slug: str, language_code: str) -> dict | None:
+        """Return the booth for a specific event + language, or None.
+
+        Unlike :meth:`snapshot`, this never auto-creates a booth.
+        """
+        booth_id = make_booth_id(event_slug, language_code)
+        return await self.get_booth(booth_id)
+
+    async def validate_booth_event(self, booth_id: str, expected_event: str) -> None:
+        """Raise PermissionError if *booth_id* does not belong to *expected_event*.
+
+        Used by event-scoped API endpoints to prevent cross-event access.
+        """
+        try:
+            event_slug, _ = parse_booth_id(booth_id)
+        except ValueError:
+            event_slug = ''
+        if event_slug != expected_event:
+            raise PermissionError(
+                f"Booth '{booth_id}' does not belong to event '{expected_event}'."
+            )
+
     async def set_ingest_status(self, booth_id: str, status: str, language: str, channel_id: str) -> dict:
         async with self._lock:
             booth = self._get_or_create_booth(booth_id, language, channel_id)

--- a/tests/test_booth_state.py
+++ b/tests/test_booth_state.py
@@ -479,3 +479,110 @@ async def test_list_booths_for_event_empty():
     result = await registry.list_booths_for_event('nonexistent')
 
     assert result == []
+
+
+# ── Namespace isolation (get_booth / get_booth_for_event / validate_booth_event) ──
+
+
+@pytest.mark.anyio
+async def test_get_booth_returns_existing():
+    registry = BoothRegistry()
+    await registry.create_booth(event_slug='pycon2026', language_code='en', language='English')
+    result = await registry.get_booth('pycon2026-en')
+    assert result is not None
+    assert result['booth_id'] == 'pycon2026-en'
+
+
+@pytest.mark.anyio
+async def test_get_booth_returns_none_for_missing():
+    registry = BoothRegistry()
+    result = await registry.get_booth('nonexistent-booth')
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_get_booth_for_event_returns_matching():
+    registry = BoothRegistry()
+    await registry.create_booth(event_slug='pycon2026', language_code='fr', language='French')
+    result = await registry.get_booth_for_event('pycon2026', 'fr')
+    assert result is not None
+    assert result['booth_id'] == 'pycon2026-fr'
+    assert result['event_slug'] == 'pycon2026'
+    assert result['language_code'] == 'fr'
+
+
+@pytest.mark.anyio
+async def test_get_booth_for_event_returns_none_wrong_event():
+    registry = BoothRegistry()
+    await registry.create_booth(event_slug='pycon2026', language_code='en', language='English')
+    result = await registry.get_booth_for_event('fossasia', 'en')
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_get_booth_for_event_returns_none_wrong_language():
+    registry = BoothRegistry()
+    await registry.create_booth(event_slug='pycon2026', language_code='en', language='English')
+    result = await registry.get_booth_for_event('pycon2026', 'de')
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_validate_booth_event_passes_for_correct_event():
+    registry = BoothRegistry()
+    # Should not raise
+    await registry.validate_booth_event('pycon2026-en', 'pycon2026')
+
+
+@pytest.mark.anyio
+async def test_validate_booth_event_rejects_wrong_event():
+    registry = BoothRegistry()
+    with pytest.raises(PermissionError, match="does not belong"):
+        await registry.validate_booth_event('pycon2026-en', 'fossasia')
+
+
+@pytest.mark.anyio
+async def test_validate_booth_event_rejects_malformed_id():
+    registry = BoothRegistry()
+    with pytest.raises(PermissionError, match="does not belong"):
+        await registry.validate_booth_event('bad', 'pycon2026')
+
+
+@pytest.mark.anyio
+async def test_cross_event_isolation_booths_invisible():
+    """Booths from event A must not appear in event B listings."""
+    registry = BoothRegistry()
+    await registry.create_booth(event_slug='eventa', language_code='en', language='English')
+    await registry.create_booth(event_slug='eventa', language_code='fr', language='French')
+    await registry.create_booth(event_slug='eventb', language_code='de', language='German')
+
+    a_booths = await registry.list_booths_for_event('eventa')
+    b_booths = await registry.list_booths_for_event('eventb')
+
+    assert len(a_booths) == 2
+    assert len(b_booths) == 1
+    assert all(b['event_slug'] == 'eventa' for b in a_booths)
+    assert all(b['event_slug'] == 'eventb' for b in b_booths)
+
+    # get_booth_for_event also isolates
+    assert await registry.get_booth_for_event('eventa', 'de') is None
+    assert await registry.get_booth_for_event('eventb', 'en') is None
+    assert (await registry.get_booth_for_event('eventb', 'de'))['booth_id'] == 'eventb-de'
+
+
+@pytest.mark.anyio
+async def test_cross_event_participants_isolated():
+    """Participants in event A booth must not appear in event B booth."""
+    registry = BoothRegistry()
+    await registry.create_booth(event_slug='eventa', language_code='en', language='English')
+    await registry.create_booth(event_slug='eventb', language_code='en', language='English')
+
+    await registry.join_participant(
+        booth_id='eventa-en', display_name='Alice', role='interpreter',
+        language='English', channel_id='eventa/en',
+    )
+
+    a_state = await registry.get_booth('eventa-en')
+    b_state = await registry.get_booth('eventb-en')
+    assert len(a_state['participants']) == 1
+    assert len(b_state['participants']) == 0

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -744,3 +744,190 @@ def test_full_bootstrap_flow():
         whep_url = whip_body['whip_url'].replace('/whip', '/whep')
         assert f'/{channel}/whep' in whep_url
 
+
+# ── Multi-event namespace isolation tests (#62) ──────────────────────────────
+
+
+def test_event_booth_state_returns_existing():
+    """Event-scoped state endpoint returns 200 for an existing booth."""
+    client.post('/api/events/statetest/booths', json={'language_code': 'en', 'language': 'English'})
+    res = client.get('/api/events/statetest/booths/en/state')
+    assert res.status_code == 200
+    body = res.json()
+    assert body['booth_id'] == 'statetest-en'
+    assert body['event_slug'] == 'statetest'
+    assert body['language_code'] == 'en'
+
+
+def test_event_booth_state_404_for_missing():
+    """Event-scoped state returns 404 when booth does not exist."""
+    res = client.get('/api/events/nosuchevent/booths/en/state')
+    assert res.status_code == 404
+    assert 'No booth' in res.json()['detail']
+
+
+def test_event_booth_state_404_wrong_language():
+    """Event-scoped state returns 404 when language not registered."""
+    client.post('/api/events/langtest/booths', json={'language_code': 'fr', 'language': 'French'})
+    res = client.get('/api/events/langtest/booths/de/state')
+    assert res.status_code == 404
+
+
+def test_event_booth_state_does_not_autocreate():
+    """Event-scoped state must not auto-create a booth."""
+    client.get('/api/events/autocreate/booths/en/state')
+    res = client.get('/api/events/autocreate/booths')
+    assert res.json()['booths'] == []
+
+
+def test_event_booth_whip_url_active_interpreter():
+    """Event-scoped WHIP URL returns URL for active interpreter."""
+    client.post('/api/events/whipevent/booths', json={'language_code': 'en', 'language': 'English'})
+    with client.websocket_connect('/ws/booth/whipevent-en') as ws:
+        ws.send_text(json.dumps({
+            'type': 'booth:join',
+            'display_name': 'Interp',
+            'role': 'interpreter',
+            'language': 'English',
+            'channel_id': 'whipevent/en',
+        }))
+        joined = json.loads(ws.receive_text())
+        if joined['type'] != 'booth:joined':
+            joined = json.loads(ws.receive_text())
+        pid = joined['participant_id']
+        ws.receive_text()  # drain booth:state
+
+        res = client.get(
+            '/api/events/whipevent/booths/en/whip-url',
+            params={'participant_id': pid},
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body['whip_url'].endswith('/whipevent/en/whip')
+        assert body['booth_id'] == 'whipevent-en'
+
+
+def test_event_booth_whip_url_standby_rejected():
+    """Event-scoped WHIP URL rejects standby interpreter."""
+    client.post('/api/events/whiprej/booths', json={'language_code': 'en', 'language': 'English'})
+    with client.websocket_connect('/ws/booth/whiprej-en') as ws:
+        # First interpreter joins (becomes active)
+        ws.send_text(json.dumps({
+            'type': 'booth:join', 'display_name': 'Active',
+            'role': 'interpreter', 'language': 'English', 'channel_id': 'whiprej/en',
+        }))
+        ws.receive_text()  # joined
+        ws.receive_text()  # state
+
+        # Second interpreter joins (becomes standby)
+        with client.websocket_connect('/ws/booth/whiprej-en') as ws2:
+            ws2.send_text(json.dumps({
+                'type': 'booth:join', 'display_name': 'Standby',
+                'role': 'interpreter', 'language': 'English', 'channel_id': 'whiprej/en',
+            }))
+            joined2 = json.loads(ws2.receive_text())
+            if joined2['type'] != 'booth:joined':
+                joined2 = json.loads(ws2.receive_text())
+            pid2 = joined2['participant_id']
+            ws2.receive_text()  # state
+
+            res = client.get(
+                '/api/events/whiprej/booths/en/whip-url',
+                params={'participant_id': pid2},
+            )
+            assert res.status_code == 403
+
+
+def test_cross_event_listing_isolation():
+    """Booths created under event A must not appear in event B listing."""
+    client.post('/api/events/isolatea/booths', json={'language_code': 'en', 'language': 'English'})
+    client.post('/api/events/isolatea/booths', json={'language_code': 'fr', 'language': 'French'})
+    client.post('/api/events/isolateb/booths', json={'language_code': 'de', 'language': 'German'})
+
+    a_res = client.get('/api/events/isolatea/booths')
+    b_res = client.get('/api/events/isolateb/booths')
+
+    assert len(a_res.json()['booths']) == 2
+    assert len(b_res.json()['booths']) == 1
+    assert all(b['event_slug'] == 'isolatea' for b in a_res.json()['booths'])
+    assert all(b['event_slug'] == 'isolateb' for b in b_res.json()['booths'])
+
+
+def test_cross_event_state_isolation():
+    """Event-scoped state endpoint must not leak booths across events."""
+    client.post('/api/events/eventx/booths', json={'language_code': 'en', 'language': 'English'})
+    # eventx-en exists, but asking eventy for 'en' must return 404
+    res = client.get('/api/events/eventy/booths/en/state')
+    assert res.status_code == 404
+
+
+def test_cross_event_mediamtx_path_isolation():
+    """Two events with the same language must get separate MediaMTX paths."""
+    r1 = client.post('/api/events/confa/booths', json={'language_code': 'en', 'language': 'English'})
+    r2 = client.post('/api/events/confb/booths', json={'language_code': 'en', 'language': 'English'})
+
+    assert r1.json()['mediamtx_path'] == 'confa/en'
+    assert r2.json()['mediamtx_path'] == 'confb/en'
+    assert r1.json()['booth_id'] != r2.json()['booth_id']
+
+
+def test_ws_cross_event_join_rejected():
+    """WebSocket join with mismatched event_slug must be rejected."""
+    client.post('/api/events/evtreal/booths', json={'language_code': 'en', 'language': 'English'})
+    with client.websocket_connect('/ws/booth/evtreal-en') as ws:
+        ws.send_text(json.dumps({
+            'type': 'booth:join',
+            'display_name': 'Attacker',
+            'role': 'interpreter',
+            'language': 'English',
+            'channel_id': 'evtreal/en',
+            'event_slug': 'wrongevent',  # mismatch!
+        }))
+        resp = json.loads(ws.receive_text())
+        assert resp['type'] == 'booth:error'
+        assert 'does not belong' in resp['message']
+
+
+def test_ws_cross_event_join_accepted_with_correct_slug():
+    """WebSocket join with matching event_slug must succeed."""
+    client.post('/api/events/evtok/booths', json={'language_code': 'en', 'language': 'English'})
+    with client.websocket_connect('/ws/booth/evtok-en') as ws:
+        ws.send_text(json.dumps({
+            'type': 'booth:join',
+            'display_name': 'Good Interpreter',
+            'role': 'interpreter',
+            'language': 'English',
+            'channel_id': 'evtok/en',
+            'event_slug': 'evtok',  # correct
+        }))
+        resp = json.loads(ws.receive_text())
+        assert resp['type'] == 'booth:joined'
+
+
+def test_full_isolation_flow():
+    """End-to-end: two separate events share no state."""
+    # Create booths for two events with the same language
+    client.post('/api/events/fest1/booths', json={'language_code': 'en', 'language': 'English'})
+    client.post('/api/events/fest2/booths', json={'language_code': 'en', 'language': 'English'})
+
+    # Join fest1 booth
+    with client.websocket_connect('/ws/booth/fest1-en') as ws:
+        ws.send_text(json.dumps({
+            'type': 'booth:join', 'display_name': 'Alice',
+            'role': 'interpreter', 'language': 'English', 'channel_id': 'fest1/en',
+        }))
+        joined = json.loads(ws.receive_text())
+        if joined['type'] != 'booth:joined':
+            joined = json.loads(ws.receive_text())
+        ws.receive_text()  # state
+
+        # fest1 has 1 participant; fest2 has 0
+        state1 = client.get('/api/events/fest1/booths/en/state').json()
+        state2 = client.get('/api/events/fest2/booths/en/state').json()
+        assert len(state1['participants']) == 1
+        assert len(state2['participants']) == 0
+
+        # fest2 listing must not show fest1 booths
+        listing2 = client.get('/api/events/fest2/booths').json()
+        assert all(b['event_slug'] == 'fest2' for b in listing2['booths'])
+


### PR DESCRIPTION
Event-scoped booth state and WHIP URL endpoints:
- GET /api/events/{slug}/booths/{lang}/state (never auto-creates)
- GET /api/events/{slug}/booths/{lang}/whip-url (namespace + role check)

BoothRegistry additions:
- get_booth() non-creating lookup
- get_booth_for_event() event+language lookup
- validate_booth_event() cross-event guard

Cross-event isolation:
- WebSocket join validates event_slug when client provides it
- Event-scoped endpoints filter by event_slug
- MediaMTX paths embed event slug for stream separation

Optimization:
- Extract _resolve_whip_url() shared helper (DRY)
- Move inline booth_identity import to module top

Documentation:
- ARCHITECTURE.md: namespace isolation section, updated component list
- explainer.md: Section 22 with full Phase 2 reference (identity scheme, data model, all endpoints, enforcement layers, isolation, bootstrap flow)

Tests: 154 passed (22 new isolation + event-scoped tests)


closes #62 