### PR TITLE
feat: Add role model and permission helpers

### DIFF
--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -16,7 +16,13 @@ from portal.booth_identity import (
     validate_language_code,
 )
 
-ParticipantRole = Literal['interpreter', 'coordinator', 'listener']
+ParticipantRole = Literal[
+    'super_admin',
+    'event_admin',
+    'coordinator',
+    'interpreter',
+    'listener',
+]
 
 
 def utc_now_iso() -> str:

--- a/portal/roles.py
+++ b/portal/roles.py
@@ -1,0 +1,121 @@
+"""Role definitions and permission helpers for the interpretation portal.
+
+Mirrors the Eventyay backend ``core/permissions.py`` pattern:
+- ``Permission`` enum with ``SCOPE_ACTION`` naming.
+- ``ROLE_PERMISSIONS`` dict mapping each role to its granted permissions.
+- Standalone helper functions for use in FastAPI dependency injection.
+
+The interpretation portal defines five roles ordered by privilege:
+
+    super_admin > event_admin > coordinator > interpreter > listener
+
+Booth-level roles (coordinator, interpreter, listener) govern in-booth
+actions.  Admin roles (event_admin, super_admin) govern administrative
+operations and inherit coordinator permissions within booths.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from portal.booth_state import ParticipantRole
+
+# ---------------------------------------------------------------------------
+# Permission enum
+# ---------------------------------------------------------------------------
+
+
+class Permission(Enum):
+    """Granular permissions for the interpretation portal.
+
+    Naming convention follows Eventyay: ``SCOPE_ACTION`` in uppercase.
+    String values use ``scope.action`` dot notation.
+    """
+
+    # Booth-level permissions
+    BOOTH_GO_LIVE = 'booth.go_live'
+    BOOTH_SET_ACTIVE = 'booth.set_active'
+    BOOTH_CHAT_SEND = 'booth.chat_send'
+    BOOTH_VIEW = 'booth.view'
+
+    # Admin permissions
+    ADMIN_MANAGE_BOOTHS = 'admin.manage_booths'
+    ADMIN_MANAGE_EVENTS = 'admin.manage_events'
+
+
+# ---------------------------------------------------------------------------
+# Role → Permission mapping
+# ---------------------------------------------------------------------------
+
+ROLE_PERMISSIONS: dict[ParticipantRole, frozenset[Permission]] = {
+    'super_admin': frozenset(Permission),
+    'event_admin': frozenset({
+        Permission.BOOTH_GO_LIVE,
+        Permission.BOOTH_SET_ACTIVE,
+        Permission.BOOTH_CHAT_SEND,
+        Permission.BOOTH_VIEW,
+        Permission.ADMIN_MANAGE_BOOTHS,
+    }),
+    'coordinator': frozenset({
+        Permission.BOOTH_SET_ACTIVE,
+        Permission.BOOTH_CHAT_SEND,
+        Permission.BOOTH_VIEW,
+    }),
+    'interpreter': frozenset({
+        Permission.BOOTH_GO_LIVE,
+        Permission.BOOTH_CHAT_SEND,
+        Permission.BOOTH_VIEW,
+    }),
+    'listener': frozenset({
+        Permission.BOOTH_CHAT_SEND,
+        Permission.BOOTH_VIEW,
+    }),
+}
+
+# Roles considered administrative (mirrors Eventyay's ``ORGANIZER_ROLES``).
+ADMIN_ROLES: frozenset[ParticipantRole] = frozenset({'super_admin', 'event_admin'})
+
+# All valid role values as a frozenset for quick membership testing.
+ALL_ROLES: frozenset[ParticipantRole] = frozenset(ROLE_PERMISSIONS.keys())
+
+
+# ---------------------------------------------------------------------------
+# Permission helper functions
+# ---------------------------------------------------------------------------
+
+
+def has_permission(role: ParticipantRole, permission: Permission) -> bool:
+    """Return True if *role* is granted *permission*."""
+    perms = ROLE_PERMISSIONS.get(role)
+    if perms is None:
+        return False
+    return permission in perms
+
+
+def can_go_live(role: ParticipantRole) -> bool:
+    """True if *role* may publish audio (activate WHIP ingest).
+
+    Only interpreters can go live.  Admin roles have the permission in the
+    mapping for completeness, but in practice they do not hold microphones.
+    """
+    return has_permission(role, Permission.BOOTH_GO_LIVE)
+
+
+def can_set_active(role: ParticipantRole) -> bool:
+    """True if *role* may assign the active interpreter."""
+    return has_permission(role, Permission.BOOTH_SET_ACTIVE)
+
+
+def can_manage_booths(role: ParticipantRole) -> bool:
+    """True if *role* may create/delete booths and generate invite tokens."""
+    return has_permission(role, Permission.ADMIN_MANAGE_BOOTHS)
+
+
+def can_manage_events(role: ParticipantRole) -> bool:
+    """True if *role* may create/delete events."""
+    return has_permission(role, Permission.ADMIN_MANAGE_EVENTS)
+
+
+def is_admin_role(role: ParticipantRole) -> bool:
+    """True if *role* is an administrative role."""
+    return role in ADMIN_ROLES

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,223 @@
+"""Tests for portal.roles — permission helpers and role model.
+
+Mirrors the testing conventions in test_booth_state.py and
+test_booth_identity.py: flat functions grouped by topic, ``assert``
+statements, ``pytest.mark.parametrize`` for combinatorial coverage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from portal.booth_state import ParticipantRole
+from portal.roles import (
+    ADMIN_ROLES,
+    ALL_ROLES,
+    ROLE_PERMISSIONS,
+    Permission,
+    can_go_live,
+    can_manage_booths,
+    can_manage_events,
+    can_set_active,
+    has_permission,
+    is_admin_role,
+)
+
+
+# ── Role type completeness ──────────────────────────────────────────────
+
+
+def test_all_roles_has_five_entries():
+    assert len(ALL_ROLES) == 5
+
+
+def test_all_roles_values():
+    assert ALL_ROLES == frozenset({
+        'super_admin',
+        'event_admin',
+        'coordinator',
+        'interpreter',
+        'listener',
+    })
+
+
+def test_role_permissions_covers_all_roles():
+    """Every role in ALL_ROLES must have a ROLE_PERMISSIONS entry."""
+    assert set(ROLE_PERMISSIONS.keys()) == ALL_ROLES
+
+
+def test_admin_roles_subset_of_all_roles():
+    assert ADMIN_ROLES.issubset(ALL_ROLES)
+
+
+# ── Permission enum ─────────────────────────────────────────────────────
+
+
+def test_permission_enum_values_use_dot_notation():
+    for perm in Permission:
+        assert '.' in perm.value, f'{perm.name} value should use dot notation'
+
+
+def test_permission_enum_has_expected_members():
+    names = {p.name for p in Permission}
+    assert 'BOOTH_GO_LIVE' in names
+    assert 'BOOTH_SET_ACTIVE' in names
+    assert 'BOOTH_CHAT_SEND' in names
+    assert 'BOOTH_VIEW' in names
+    assert 'ADMIN_MANAGE_BOOTHS' in names
+    assert 'ADMIN_MANAGE_EVENTS' in names
+
+
+# ── has_permission (the primitive) ───────────────────────────────────────
+
+
+@pytest.mark.parametrize('role', list(ALL_ROLES))
+def test_has_permission_booth_view_all_roles(role: ParticipantRole):
+    """Every role can view a booth."""
+    assert has_permission(role, Permission.BOOTH_VIEW) is True
+
+
+@pytest.mark.parametrize('role', list(ALL_ROLES))
+def test_has_permission_booth_chat_all_roles(role: ParticipantRole):
+    """Every role can send chat messages."""
+    assert has_permission(role, Permission.BOOTH_CHAT_SEND) is True
+
+
+def test_has_permission_unknown_role_returns_false():
+    assert has_permission('unknown_role', Permission.BOOTH_VIEW) is False  # type: ignore[arg-type]
+
+
+# ── super_admin gets everything ──────────────────────────────────────────
+
+
+def test_super_admin_has_all_permissions():
+    for perm in Permission:
+        assert has_permission('super_admin', perm) is True
+
+
+# ── can_go_live ──────────────────────────────────────────────────────────
+
+
+ROLES_THAT_CAN_GO_LIVE = {'interpreter', 'event_admin', 'super_admin'}
+ROLES_THAT_CANNOT_GO_LIVE = {'coordinator', 'listener'}
+
+
+@pytest.mark.parametrize('role', list(ROLES_THAT_CAN_GO_LIVE))
+def test_can_go_live_granted(role: ParticipantRole):
+    assert can_go_live(role) is True
+
+
+@pytest.mark.parametrize('role', list(ROLES_THAT_CANNOT_GO_LIVE))
+def test_can_go_live_denied(role: ParticipantRole):
+    assert can_go_live(role) is False
+
+
+# ── can_set_active ───────────────────────────────────────────────────────
+
+
+ROLES_THAT_CAN_SET_ACTIVE = {'coordinator', 'event_admin', 'super_admin'}
+ROLES_THAT_CANNOT_SET_ACTIVE = {'interpreter', 'listener'}
+
+
+@pytest.mark.parametrize('role', list(ROLES_THAT_CAN_SET_ACTIVE))
+def test_can_set_active_granted(role: ParticipantRole):
+    assert can_set_active(role) is True
+
+
+@pytest.mark.parametrize('role', list(ROLES_THAT_CANNOT_SET_ACTIVE))
+def test_can_set_active_denied(role: ParticipantRole):
+    assert can_set_active(role) is False
+
+
+# ── can_manage_booths ────────────────────────────────────────────────────
+
+
+ROLES_THAT_CAN_MANAGE_BOOTHS = {'event_admin', 'super_admin'}
+ROLES_THAT_CANNOT_MANAGE_BOOTHS = {'coordinator', 'interpreter', 'listener'}
+
+
+@pytest.mark.parametrize('role', list(ROLES_THAT_CAN_MANAGE_BOOTHS))
+def test_can_manage_booths_granted(role: ParticipantRole):
+    assert can_manage_booths(role) is True
+
+
+@pytest.mark.parametrize('role', list(ROLES_THAT_CANNOT_MANAGE_BOOTHS))
+def test_can_manage_booths_denied(role: ParticipantRole):
+    assert can_manage_booths(role) is False
+
+
+# ── can_manage_events ────────────────────────────────────────────────────
+
+
+def test_can_manage_events_super_admin():
+    assert can_manage_events('super_admin') is True
+
+
+@pytest.mark.parametrize('role', ['event_admin', 'coordinator', 'interpreter', 'listener'])
+def test_can_manage_events_denied(role: ParticipantRole):
+    assert can_manage_events(role) is False
+
+
+# ── is_admin_role ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize('role', ['super_admin', 'event_admin'])
+def test_is_admin_role_true(role: ParticipantRole):
+    assert is_admin_role(role) is True
+
+
+@pytest.mark.parametrize('role', ['coordinator', 'interpreter', 'listener'])
+def test_is_admin_role_false(role: ParticipantRole):
+    assert is_admin_role(role) is False
+
+
+# ── ROLE_PERMISSIONS structure ───────────────────────────────────────────
+
+
+def test_role_permissions_are_frozensets():
+    for role, perms in ROLE_PERMISSIONS.items():
+        assert isinstance(perms, frozenset), f'{role} permissions should be frozenset'
+
+
+def test_privilege_escalation_hierarchy():
+    """Higher-privilege roles must be a superset of lower-privilege roles.
+
+    super_admin ⊇ event_admin ⊇ coordinator (for booth-level permissions).
+    """
+    sa = ROLE_PERMISSIONS['super_admin']
+    ea = ROLE_PERMISSIONS['event_admin']
+    coord = ROLE_PERMISSIONS['coordinator']
+    listener = ROLE_PERMISSIONS['listener']
+
+    assert listener.issubset(coord), 'listener perms must be subset of coordinator'
+    assert coord.issubset(ea), 'coordinator perms must be subset of event_admin'
+    assert ea.issubset(sa), 'event_admin perms must be subset of super_admin'
+
+
+def test_interpreter_is_not_subset_of_coordinator():
+    """Interpreter has BOOTH_GO_LIVE which coordinator lacks.
+
+    This verifies the intentional divergence: interpreters can go live
+    but cannot set active, while coordinators can set active but cannot
+    go live.
+    """
+    interp = ROLE_PERMISSIONS['interpreter']
+    coord = ROLE_PERMISSIONS['coordinator']
+    assert not interp.issubset(coord)
+    assert not coord.issubset(interp)
+
+
+# ── Backward compatibility with existing booth_state.py ──────────────────
+
+
+def test_existing_booth_roles_still_valid():
+    """The three original booth roles must remain valid ParticipantRole values."""
+    original_roles = ['interpreter', 'coordinator', 'listener']
+    for role in original_roles:
+        assert role in ALL_ROLES
+
+
+def test_new_admin_roles_are_valid():
+    """The two new admin roles must be valid ParticipantRole values."""
+    assert 'event_admin' in ALL_ROLES
+    assert 'super_admin' in ALL_ROLES


### PR DESCRIPTION
## Summary

Implements Phase 3 Step 1: **Define role model and permissions** (closes #63).

Extends the interpretation portal's type system with two admin roles and adds a standalone permissions module mirroring Eventyay's `core/permissions.py` patterns.

## Changes

### `portal/booth_state.py`
- Extended `ParticipantRole` Literal type from 3 to 5 roles:
  `super_admin`, `event_admin`, `coordinator`, `interpreter`, `listener`
- Fully backward-compatible — all existing inline permission checks
  (string comparisons) continue to work unchanged.

### `portal/roles.py` (new)
- `Permission` enum with 6 granular permissions using `SCOPE_ACTION` naming
  and `scope.action` dot-notation values (matches Eventyay convention).
- `ROLE_PERMISSIONS` dict mapping each role to a `frozenset[Permission]`.
- `ADMIN_ROLES` and `ALL_ROLES` frozensets (mirrors Eventyay's `ORGANIZER_ROLES`).
- Standalone helper functions for FastAPI dependency injection:
  - `has_permission(role, permission)` — primitive check
  - `can_go_live(role)` — WHIP ingest permission
  - `can_set_active(role)` — assign active interpreter
  - `can_manage_booths(role)` — booth CRUD + invite tokens
  - `can_manage_events(role)` — event CRUD (super_admin only)
  - `is_admin_role(role)` — admin role check

### `tests/test_roles.py` (new)
- 48 tests covering:
  - Role type completeness and enum structure
  - Every permission function × every role (parametrized)
  - Privilege hierarchy validation (`super_admin ⊇ event_admin ⊇ coordinator ⊇ listener`)
  - Intentional interpreter/coordinator permission divergence
  - Backward compatibility assertions
  - Unknown role handling

## Privilege Hierarchy

| Permission | super_admin | event_admin | coordinator | interpreter | listener |
|---|---|---|---|---|---|
| `booth.view` | ✅ | ✅ | ✅ | ✅ | ✅ |
| `booth.chat_send` | ✅ | ✅ | ✅ | ✅ | ✅ |
| `booth.go_live` | ✅ | ✅ | ❌ | ✅ | ❌ |
| `booth.set_active` | ✅ | ✅ | ✅ | ❌ | ❌ |
| `admin.manage_booths` | ✅ | ✅ | ❌ | ❌ | ❌ |
| `admin.manage_events` | ✅ | ❌ | ❌ | ❌ | ❌ |

## Design Decisions

1. **Standalone functions over class methods** — enables clean FastAPI `Depends()` injection (Step 6, #68).
2. **No booth_state.py inline check updates yet** — existing `role == 'coordinator'` checks remain; they will be replaced with role helpers when route guards are added (#68).
3. **Interpreter ≠ coordinator** — interpreters can go live but cannot set active; coordinators can set active but cannot go live. This is intentional.
4. **super_admin gets all permissions** via `frozenset(Permission)`.

## Test Results

```
202 passed, 3 warnings in 1.01s
```

All 154 existing tests pass unchanged + 48 new role tests.

## Next Steps

- #64: Add `role` claim to JWT tokens
- #65: Event model with multi-language booth support
- #68: RBAC enforcement via route guards using these permission helpers