### PR TITLE
Feat: Implement invite-token authentication flow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -138,7 +138,7 @@ Existing free-form booth IDs (e.g. `hall-a-fr`) that happen to end with a valid 
 - `portal/booth_state.py`
   - async in-memory booth registry, participant role policy, active interpreter ownership, handoff state, chat history, event-scoped queries (`get_booth`, `get_booth_for_event`, `validate_booth_event`)
 - `portal/auth.py`
-  - JWT token creation and validation (PyJWT)
+  - JWT token creation and validation (PyJWT), participant token issuance with role claims
 - `portal/config.py`
   - pydantic-settings configuration loaded from environment variables / `.env`
 - `portal/roles.py`
@@ -344,6 +344,58 @@ namespace isolation:
 - `validate_booth_event(booth_id, expected_event)` raises `PermissionError` if the booth's parsed event_slug doesn't match — used by event-scoped WHIP URL endpoint and WebSocket join handler.
 - MediaMTX paths embed the event slug (`{event_slug}/{language_code}`), so audio streams are physically separated per event.
 - WebSocket join with a mismatched `event_slug` field is rejected before the participant is added to the booth.
+
+## 9.2 Invite-token authentication flow
+
+Invite tokens provide a single-use, shareable URL for joining a specific booth with a pre-assigned role.
+
+### Flow
+
+```mermaid
+sequenceDiagram
+  participant Admin as Event Admin
+  participant DB as Database
+  participant User as Participant Browser
+  participant Portal as FastAPI Portal
+
+  Admin->>DB: create_invite_token(booth_id, role, label, expires_at)
+  DB-->>Admin: token (64-char hex)
+  Admin->>User: Share link: /join/{token}
+  User->>Portal: GET /join/{token}
+  Portal->>DB: get_invite_token(token) + joinedload(booth→event)
+  alt Token not found
+    Portal-->>User: 404 Invalid invite token
+  else Token expired
+    Portal-->>User: 403 Token has expired
+  else Token already used
+    Portal-->>User: 403 Token has already been used
+  else Valid
+    Portal->>DB: redeem_invite_token(token) → sets used_at
+    Portal->>Portal: create_participant_token(booth_id, role, event_slug, language_code)
+    Portal-->>User: 303 Redirect to /interpreter/{event_slug}/{language_code}
+    Note over Portal,User: Set-Cookie: session_token (JWT, HttpOnly, SameSite=lax)
+  end
+```
+
+### JWT cookie claims
+
+| Claim | Type | Description |
+|-------|------|-------------|
+| `sub` | UUID string | Unique participant identifier (generated per redemption) |
+| `booth_id` | int | Database ID of the assigned booth |
+| `role` | string | One of: `interpreter`, `coordinator`, `listener`, `event_admin`, `super_admin` |
+| `event_slug` | string | Slug of the event the booth belongs to |
+| `language_code` | string | ISO 639-1 language code of the booth |
+| `iat` | int | Issued-at timestamp |
+| `exp` | int | Expiry timestamp (configurable via `JWT_EXPIRY_SECONDS`) |
+
+### Security properties
+
+- Tokens are 64-character cryptographically random hex strings (`secrets.token_hex(32)`).
+- Each token can only be used once (`used_at` is set on redemption).
+- Optional expiry (`expires_at`) allows time-limited invitations.
+- The JWT cookie is `HttpOnly` and `SameSite=lax` to prevent XSS and CSRF.
+- Token lookup uses `joinedload` to eagerly load booth and event data in a single query.
 
 ## 10. Reconnect and teardown behavior
 

--- a/agents.md
+++ b/agents.md
@@ -5,6 +5,8 @@ This file defines implementation guardrails for contributors and coding agents w
 Read this file in full before making changes. The constraints here are non-negotiable.
 
 ---
+Follow Eventyay backend patterns wherever applicable. Reuse naming conventions, validation style, dataclass/model structure, route organization, API response patterns, testing conventions, and documentation style. Do not directly couple the interpretation portal to Eventyay yet. Only mirror architectural patterns to maintain consistency for future integration.
+---
 
 ## Product intent
 
@@ -61,7 +63,7 @@ Enforcement rules:
 |---|---|
 | `fastapi_app.py` | FastAPI routes, WebSocket handler, JWT auth, Jinja2 templates |
 | `portal/booth_state.py` | In-memory booth registry, participant roles, handoff policy, chat |
-| `portal/auth.py` | JWT token creation and validation |
+| `portal/auth.py` | JWT token creation and validation, participant token issuance with role claims |
 | `portal/config.py` | pydantic-settings (env vars / .env) |
 | `templates/` | Server-rendered HTML (base shell, booth page, WHEP listener page, HLS listener page) |
 | `static/js/interpreter-booth.js` | Plain browser JS — WebRTC/WHIP, WebSocket, mic controls, Jitsi embed |
@@ -95,6 +97,15 @@ Open booth URL → monitor participant grid → assign active interpreter
 ```
 Open /listener-webrtc/{booth_id} → WHEP WebRTC connects → sub-second audio (primary)
 Open /listen/{booth_id} → hls.js loads HLS stream → auto-recovers on handoff (fallback)
+```
+
+### Invite-token join flow
+
+```
+Receive invite link → GET /join/{token} → validate & redeem → JWT cookie → redirect to booth
+     │                                         │
+     ▼                                         ▼
+Token invalid/expired/used → 4xx error    /interpreter/{event_slug}/{language_code}
 ```
 
 ---
@@ -170,3 +181,5 @@ When changing architecture or behavior, update:
 - `README.md` for operational usage and setup
 - `ARCHITECTURE.md` for system design
 - `agents.md` (this file) for guardrails
+
+**Every PR that adds, removes, or changes a feature must update the relevant documentation files above as part of the same commit.** Do not defer documentation to a follow-up PR.

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -21,7 +21,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
-from portal.auth import create_token, decode_token, security, verify_ws_token
+from portal.auth import create_participant_token, create_token, decode_token, security, verify_ws_token
 from portal.booth_identity import make_booth_id, make_mediamtx_path
 from portal.booth_state import BoothRegistry
 from portal.config import settings
@@ -224,6 +224,49 @@ async def get_token(body: Annotated[TokenRequest | None, Body()] = None) -> Toke
     if settings.booth_access_token and provided != settings.booth_access_token:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid access token.')
     return TokenResponse(access_token=create_token())
+
+
+# ── Invite-token join flow ────────────────────────────────────────────────────
+
+@app.get('/join/{token}')
+async def join_via_invite(token: str) -> RedirectResponse:
+    """Validate an invite token, issue a JWT cookie, and redirect to the booth.
+
+    Flow:
+    1. Look up the token in the database
+    2. Validate: not expired, not already used
+    3. Mark the token as used (``used_at = now``)
+    4. Issue a signed JWT cookie with role claims
+    5. Redirect to ``/interpreter/{event_slug}/{language_code}``
+    """
+    from portal.database import get_session, redeem_invite_token
+
+    async with get_session() as session:
+        try:
+            tok = await redeem_invite_token(session, token)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+
+    if tok is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Invalid invite token.')
+
+    jwt_token = create_participant_token(
+        booth_id=tok.booth_id,
+        role=tok.role,
+        event_slug=tok.booth.event.slug,
+        language_code=tok.booth.language_code,
+    )
+
+    redirect_url = f'/interpreter/{tok.booth.event.slug}/{tok.booth.language_code}'
+    response = RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
+    response.set_cookie(
+        key='session_token',
+        value=jwt_token,
+        httponly=True,
+        samesite='lax',
+        max_age=settings.jwt_expiry_seconds,
+    )
+    return response
 
 
 # ── Page routes ───────────────────────────────────────────────────────────────

--- a/portal/auth.py
+++ b/portal/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import jwt
@@ -14,6 +15,27 @@ security = HTTPBearer(auto_error=False)
 def create_token() -> str:
     now = datetime.now(timezone.utc)
     payload = {
+        'iat': now,
+        'exp': now + timedelta(seconds=settings.jwt_expiry_seconds),
+    }
+    return jwt.encode(payload, settings.effective_jwt_secret, algorithm='HS256')
+
+
+def create_participant_token(
+    *,
+    booth_id: int,
+    role: str,
+    event_slug: str,
+    language_code: str,
+) -> str:
+    """Create a JWT with role claims for a participant who joined via invite link."""
+    now = datetime.now(timezone.utc)
+    payload = {
+        'sub': str(uuid.uuid4()),
+        'booth_id': booth_id,
+        'role': role,
+        'event_slug': event_slug,
+        'language_code': language_code,
         'iat': now,
         'exp': now + timedelta(seconds=settings.jwt_expiry_seconds),
     }

--- a/tests/test_join_flow.py
+++ b/tests/test_join_flow.py
@@ -1,0 +1,402 @@
+"""Tests for the invite-token join flow (GET /join/{token}).
+
+Covers:
+- Happy path: valid token → JWT cookie + redirect
+- Error paths: expired, already-used, invalid tokens
+- JWT cookie contents (role, event_slug, language_code, booth_id)
+- create_participant_token() in portal/auth.py
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ['BOOTH_ACCESS_TOKEN'] = ''
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from portal.auth import create_participant_token, decode_token
+from portal.database import (
+    create_booth,
+    create_event,
+    create_invite_token,
+    create_room,
+    get_invite_token,
+    redeem_invite_token,
+)
+from portal.models import Base, utc_now
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db():
+    """Yield an async session backed by an in-memory SQLite database."""
+    engine = create_async_engine('sqlite+aiosqlite://', echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        async with session.begin():
+            yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture
+async def sample_booth(db):
+    """Create an event → room → booth and return (booth, event) tuple."""
+    event = await create_event(db, slug='testcon2026', display_name='TestCon 2026')
+    room = await create_room(db, event_id=event.id, display_name='Main Hall')
+    booth = await create_booth(
+        db, event_id=event.id, room_id=room.id,
+        language_code='fr', language_name='French',
+    )
+    return booth, event
+
+
+# ---------------------------------------------------------------------------
+# create_participant_token() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateParticipantToken:
+    def test_creates_valid_jwt(self):
+        token = create_participant_token(
+            booth_id=1, role='interpreter',
+            event_slug='pycon2026', language_code='en',
+        )
+        payload = decode_token(token)
+        assert payload['booth_id'] == 1
+        assert payload['role'] == 'interpreter'
+        assert payload['event_slug'] == 'pycon2026'
+        assert payload['language_code'] == 'en'
+        assert 'sub' in payload
+        assert 'exp' in payload
+        assert 'iat' in payload
+
+    def test_sub_is_uuid(self):
+        import uuid
+        token = create_participant_token(
+            booth_id=1, role='listener',
+            event_slug='ev', language_code='de',
+        )
+        payload = decode_token(token)
+        uuid.UUID(payload['sub'])  # raises if not a valid UUID
+
+    def test_different_calls_produce_different_subs(self):
+        t1 = create_participant_token(
+            booth_id=1, role='interpreter',
+            event_slug='ev', language_code='en',
+        )
+        t2 = create_participant_token(
+            booth_id=1, role='interpreter',
+            event_slug='ev', language_code='en',
+        )
+        assert decode_token(t1)['sub'] != decode_token(t2)['sub']
+
+    @pytest.mark.parametrize('role', [
+        'interpreter', 'coordinator', 'listener', 'event_admin', 'super_admin',
+    ])
+    def test_all_roles_accepted(self, role):
+        token = create_participant_token(
+            booth_id=42, role=role,
+            event_slug='test', language_code='zh',
+        )
+        assert decode_token(token)['role'] == role
+
+
+# ---------------------------------------------------------------------------
+# Token redemption + join flow (database-level)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenRedemption:
+    @pytest.mark.anyio
+    async def test_redeem_valid_token(self, db, sample_booth):
+        booth, event = sample_booth
+        tok = await create_invite_token(db, booth_id=booth.id, role='interpreter', label='Alice')
+        redeemed = await redeem_invite_token(db, tok.token)
+        assert redeemed is not None
+        assert redeemed.is_used is True
+        assert redeemed.used_at is not None
+
+    @pytest.mark.anyio
+    async def test_redeem_sets_used_at(self, db, sample_booth):
+        booth, _ = sample_booth
+        tok = await create_invite_token(db, booth_id=booth.id, role='listener')
+        before = utc_now()
+        redeemed = await redeem_invite_token(db, tok.token)
+        assert redeemed.used_at is not None
+
+    @pytest.mark.anyio
+    async def test_redeem_already_used_raises(self, db, sample_booth):
+        booth, _ = sample_booth
+        tok = await create_invite_token(db, booth_id=booth.id, role='interpreter')
+        await redeem_invite_token(db, tok.token)
+        with pytest.raises(ValueError, match='already been used'):
+            await redeem_invite_token(db, tok.token)
+
+    @pytest.mark.anyio
+    async def test_redeem_expired_token_raises(self, db, sample_booth):
+        booth, _ = sample_booth
+        past = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        tok = await create_invite_token(
+            db, booth_id=booth.id, role='interpreter', expires_at=past,
+        )
+        with pytest.raises(ValueError, match='expired'):
+            await redeem_invite_token(db, tok.token)
+
+    @pytest.mark.anyio
+    async def test_redeem_nonexistent_returns_none(self, db):
+        result = await redeem_invite_token(db, 'a' * 64)
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_redeemed_token_has_booth_and_event_loaded(self, db, sample_booth):
+        booth, event = sample_booth
+        tok = await create_invite_token(db, booth_id=booth.id, role='coordinator')
+        redeemed = await redeem_invite_token(db, tok.token)
+        assert redeemed.booth.event.slug == 'testcon2026'
+        assert redeemed.booth.language_code == 'fr'
+
+    @pytest.mark.anyio
+    async def test_future_expiry_is_valid(self, db, sample_booth):
+        booth, _ = sample_booth
+        future = datetime.now(tz=timezone.utc) + timedelta(hours=24)
+        tok = await create_invite_token(
+            db, booth_id=booth.id, role='listener', expires_at=future,
+        )
+        redeemed = await redeem_invite_token(db, tok.token)
+        assert redeemed is not None
+        assert redeemed.is_used is True
+
+
+# ---------------------------------------------------------------------------
+# GET /join/{token} integration tests (FastAPI TestClient)
+# ---------------------------------------------------------------------------
+
+
+class TestJoinRoute:
+    """Test the /join/{token} endpoint via the FastAPI test client.
+
+    These tests need a real database. We configure portal.database to use
+    an in-memory SQLite before importing the app.
+    """
+
+    @pytest.fixture(autouse=True)
+    async def setup_db(self):
+        """Set up an in-memory database for the FastAPI app."""
+        from portal.database import configure, dispose, init_db
+        configure('sqlite+aiosqlite://')
+        await init_db()
+        yield
+        await dispose()
+
+    @pytest.fixture
+    async def _seed(self):
+        """Seed the database with an event, room, and booth."""
+        from portal.database import (
+            create_booth,
+            create_event,
+            create_invite_token,
+            create_room,
+            get_session,
+        )
+        async with get_session() as s:
+            event = await create_event(s, slug='pycon2026', display_name='PyCon 2026')
+            room = await create_room(s, event_id=event.id, display_name='Main Hall')
+            booth = await create_booth(
+                s, event_id=event.id, room_id=room.id,
+                language_code='en', language_name='English',
+            )
+        return event, room, booth
+
+    async def _make_token(self, booth_id, role='interpreter', **kwargs):
+        from portal.database import create_invite_token, get_session
+        async with get_session() as s:
+            tok = await create_invite_token(s, booth_id=booth_id, role=role, **kwargs)
+        return tok.token
+
+    @pytest.mark.anyio
+    async def test_valid_token_redirects(self, _seed):
+        event, _, booth = _seed
+        token_str = await self._make_token(booth.id)
+
+        from httpx import ASGITransport, AsyncClient
+        from fastapi_app import app
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url='http://test',
+        ) as client:
+            resp = await client.get(f'/join/{token_str}', follow_redirects=False)
+        assert resp.status_code == 303
+        assert resp.headers['location'] == '/interpreter/pycon2026/en'
+
+    @pytest.mark.anyio
+    async def test_valid_token_sets_cookie(self, _seed):
+        event, _, booth = _seed
+        token_str = await self._make_token(booth.id, role='coordinator')
+
+        from httpx import ASGITransport, AsyncClient
+        from fastapi_app import app
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url='http://test',
+        ) as client:
+            resp = await client.get(f'/join/{token_str}', follow_redirects=False)
+
+        cookie = resp.cookies.get('session_token')
+        assert cookie is not None
+
+        payload = decode_token(cookie)
+        assert payload['role'] == 'coordinator'
+        assert payload['event_slug'] == 'pycon2026'
+        assert payload['language_code'] == 'en'
+        assert payload['booth_id'] == booth.id
+
+    @pytest.mark.anyio
+    async def test_invalid_token_returns_404(self, _seed):
+        from httpx import ASGITransport, AsyncClient
+        from fastapi_app import app
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url='http://test',
+        ) as client:
+            resp = await client.get('/join/' + 'a' * 64, follow_redirects=False)
+        assert resp.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_expired_token_returns_403(self, _seed):
+        _, _, booth = _seed
+        past = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        token_str = await self._make_token(booth.id, expires_at=past)
+
+        from httpx import ASGITransport, AsyncClient
+        from fastapi_app import app
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url='http://test',
+        ) as client:
+            resp = await client.get(f'/join/{token_str}', follow_redirects=False)
+        assert resp.status_code == 403
+        assert 'expired' in resp.json()['detail'].lower()
+
+    @pytest.mark.anyio
+    async def test_used_token_returns_403(self, _seed):
+        _, _, booth = _seed
+        token_str = await self._make_token(booth.id)
+
+        from httpx import ASGITransport, AsyncClient
+        from fastapi_app import app
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url='http://test',
+        ) as client:
+            # First use — success
+            resp1 = await client.get(f'/join/{token_str}', follow_redirects=False)
+            assert resp1.status_code == 303
+
+            # Second use — rejected
+            resp2 = await client.get(f'/join/{token_str}', follow_redirects=False)
+            assert resp2.status_code == 403
+            assert 'already been used' in resp2.json()['detail'].lower()
+
+    @pytest.mark.anyio
+    async def test_token_with_different_roles(self, _seed):
+        _, _, booth = _seed
+        for role in ['interpreter', 'coordinator', 'listener', 'event_admin', 'super_admin']:
+            token_str = await self._make_token(booth.id, role=role)
+
+            from httpx import ASGITransport, AsyncClient
+            from fastapi_app import app
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url='http://test',
+            ) as client:
+                resp = await client.get(f'/join/{token_str}', follow_redirects=False)
+            assert resp.status_code == 303
+            cookie = resp.cookies.get('session_token')
+            payload = decode_token(cookie)
+            assert payload['role'] == role
+
+    @pytest.mark.anyio
+    async def test_token_with_future_expiry_works(self, _seed):
+        _, _, booth = _seed
+        future = datetime.now(tz=timezone.utc) + timedelta(hours=24)
+        token_str = await self._make_token(booth.id, expires_at=future)
+
+        from httpx import ASGITransport, AsyncClient
+        from fastapi_app import app
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url='http://test',
+        ) as client:
+            resp = await client.get(f'/join/{token_str}', follow_redirects=False)
+        assert resp.status_code == 303
+
+    @pytest.mark.anyio
+    async def test_redirect_url_uses_event_slug_and_language(self, _seed):
+        """Ensure redirect uses /interpreter/{event_slug}/{language_code} pattern."""
+        _, _, booth = _seed
+        token_str = await self._make_token(booth.id)
+
+        from httpx import ASGITransport, AsyncClient
+        from fastapi_app import app
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url='http://test',
+        ) as client:
+            resp = await client.get(f'/join/{token_str}', follow_redirects=False)
+        loc = resp.headers['location']
+        assert loc.startswith('/interpreter/')
+        parts = loc.split('/')
+        assert parts[2] == 'pycon2026'  # event_slug
+        assert parts[3] == 'en'         # language_code
+
+    @pytest.mark.anyio
+    async def test_multiple_booths_redirect_correctly(self):
+        """Tokens for different booths redirect to their respective URLs."""
+        from portal.database import (
+            create_booth,
+            create_event,
+            create_invite_token,
+            create_room,
+            get_session,
+        )
+
+        async with get_session() as s:
+            event = await create_event(s, slug='multi-event', display_name='Multi')
+            room = await create_room(s, event_id=event.id, display_name='Room')
+            booth_en = await create_booth(
+                s, event_id=event.id, room_id=room.id,
+                language_code='en', language_name='English',
+            )
+            booth_fr = await create_booth(
+                s, event_id=event.id, room_id=room.id,
+                language_code='fr', language_name='French',
+            )
+
+        tok_en = await self._make_token(booth_en.id)
+        tok_fr = await self._make_token(booth_fr.id)
+
+        from httpx import ASGITransport, AsyncClient
+        from fastapi_app import app
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url='http://test',
+        ) as client:
+            resp_en = await client.get(f'/join/{tok_en}', follow_redirects=False)
+            assert resp_en.headers['location'] == '/interpreter/multi-event/en'
+
+            resp_fr = await client.get(f'/join/{tok_fr}', follow_redirects=False)
+            assert resp_fr.headers['location'] == '/interpreter/multi-event/fr'


### PR DESCRIPTION
## Summary

Implements the invite-token authentication flow (`GET /join/{token}`) as specified in #65 (Phase 3, Step 3).

When an event admin creates an invite token for a booth, they get a shareable link like `/join/{token}`. When a participant clicks that link, the portal:

1. **Validates** the token (exists? expired? already used?)
2. **Redeems** it (sets `used_at` so it can't be reused)
3. **Issues a JWT cookie** (`session_token`) with role claims
4. **Redirects** to `/interpreter/{event_slug}/{language_code}`

## Changes

### `portal/auth.py`
- Added `create_participant_token()` — creates a JWT with claims: `sub` (UUID), `booth_id`, `role`, `event_slug`, `language_code`, `iat`, `exp`

### `fastapi_app.py`
- Added `GET /join/{token}` route with full validation:
  - Invalid token → **404**
  - Expired token → **403** (`Token has expired.`)
  - Already-used token → **403** (`Token has already been used.`)
  - Valid token → redeem → JWT cookie → **303** redirect

### `tests/test_join_flow.py` (new — 24 tests)
- **Unit tests:** `create_participant_token()` JWT structure, UUID sub, all roles
- **DB-level tests:** redeem valid/expired/used/nonexistent tokens, eager-loaded relationships
- **Integration tests:** full HTTP flow via `httpx.AsyncClient` — redirect, cookie, error codes, multi-booth, role variations

### `ARCHITECTURE.md`
- Added Section 9.2: invite-token authentication flow with Mermaid sequence diagram
- Documented JWT cookie claims table and security properties

### `agents.md`
- Added invite-token join flow to the flow summary section
- Updated module ownership for `portal/auth.py`
- Added mandatory documentation rule: every feature PR must update docs in the same commit

## E2E Verification (Docker)

Verified end-to-end inside the running Docker container:

| Test | Method | Result |
|------|--------|--------|
| Valid token (interpreter) | `curl /join/{token}` | ✅ 303 → `/interpreter/pycon2026/en` + JWT cookie |
| JWT claims | Decoded cookie | ✅ role=interpreter, event_slug=pycon2026, language_code=en, booth_id=1 |
| Expired token | `curl /join/{expired}` | ✅ 403 `Token has expired.` |
| Invalid token | `curl /join/{garbage}` | ✅ 404 `Invalid invite token.` |
| Double-use token | `curl /join/{token}` twice | ✅ 303 first, 403 second |
| French booth | `curl /join/{fr-token}` | ✅ 303 → `/interpreter/pycon2026/fr` |
| Future-expiry token | `curl /join/{future}` | ✅ 303 redirect |
| DB state after redemptions | SQL query | ✅ used_at set correctly on all redeemed tokens |

## Test Results

```
295 passed, 0 failures
```

Closes #65