### PR TITLE
Add event-scoped roles, token management UI, and membership for admin 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ MEDIAMTX_HLS_BASE=http://localhost:8888
 # MEDIAMTX_INTERNAL_BASE=
 
 # Admin panel — password for /admin/login. Empty = admin login disabled.
-ADMIN_PASSWORD=ADMIN
+ADMIN_PASSWORD=
 
 # Database — SQLite for development, PostgreSQL for production.
 # The default stores a SQLite file in the project root.

--- a/.env.example
+++ b/.env.example
@@ -7,32 +7,47 @@ BOOTH_ACCESS_TOKEN=
 JWT_SECRET=
 JWT_EXPIRY_SECONDS=86400
 
-# Jitsi Meet — self-hosted by default (docker-compose.yml runs jitsi-web)
-# HTTP :8080 for local dev (no self-signed cert issues with iframes)
-# HTTPS :8443 also available if you prefer
-# For public Jitsi instead, set JITSI_DOMAIN=meet.jit.si
+# ── Jitsi Meet ────────────────────────────────────────────────────────────────
+# Self-hosted Jitsi runs in Docker alongside the portal.
+# Local dev: use http://localhost:8080 (Jitsi HTTP port)
+# Production (voxbento.com): Caddy proxies jitsi.voxbento.com → localhost:8080
+#   JITSI_DOMAIN=jitsi.voxbento.com
+#   JITSI_BASE_URL=https://jitsi.voxbento.com
+#   JITSI_PUBLIC_URL=https://jitsi.voxbento.com
 DEFAULT_JITSI_ROOM=eventyay-stage-room
 JITSI_DOMAIN=localhost:8080
-# Full Jitsi base URL including scheme. When empty, defaults to http://{JITSI_DOMAIN}.
-# For production HTTPS: JITSI_BASE_URL=https://jitsi.your-domain.com
 JITSI_BASE_URL=
+JITSI_PUBLIC_URL=http://localhost:8080
 
-# Jitsi internal auth (change in production)
+# Jitsi internal auth (change in production — use long random passwords)
 JVB_AUTH_PASSWORD=changeme
 JICOFO_AUTH_PASSWORD=changeme
 
-# DOCKER_HOST_ADDRESS — required for Jitsi video/audio to work in Docker.
-# Set to your machine's LAN IP so JVB can advertise reachable ICE candidates.
+# DOCKER_HOST_ADDRESS — required for Jitsi JVB and MediaMTX WebRTC ICE.
+# Set to your server's public IP so WebRTC ICE candidates are reachable.
 # macOS:  ipconfig getifaddr en0
 # Linux:  hostname -I | awk '{print $1}'
 DOCKER_HOST_ADDRESS=
 
-# MediaMTX — used for WebRTC/WHIP ingest and HLS output
-# These are the URLs the BROWSER uses (must be accessible from outside Docker).
+# ── MediaMTX — WebRTC/WHIP ingest + HLS output ────────────────────────────────
+# These are the URLs the BROWSER uses (must be reachable from outside Docker).
+#
+# Local dev:
+#   MEDIAMTX_WHIP_BASE=http://localhost:8889
+#   MEDIAMTX_HLS_BASE=http://localhost:8888
+#
+# Production (voxbento.com) — Caddy proxies:
+#   /hls/*          → localhost:8888  (HLS; Caddy strips /hls prefix)
+#   */{path}/whip   → localhost:8889  (WHIP ingest)
+#   */{path}/whep   → localhost:8889  (WHEP playback)
+#
+#   MEDIAMTX_WHIP_BASE=https://voxbento.com
+#   MEDIAMTX_HLS_BASE=https://voxbento.com/hls
+#
 MEDIAMTX_WHIP_BASE=http://localhost:8889
 MEDIAMTX_HLS_BASE=http://localhost:8888
 # Optional: internal URL for Python health checks (leave empty for native dev).
-# In Docker, docker-compose.yml sets this to http://mediamtx:8888 automatically.
+# docker-compose.yml sets this to http://mediamtx:8888 automatically.
 # MEDIAMTX_INTERNAL_BASE=
 
 # Admin panel — password for /admin/login. Empty = admin login disabled.
@@ -42,4 +57,3 @@ ADMIN_PASSWORD=
 # The default stores a SQLite file in the project root.
 # For PostgreSQL: DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/interpretation
 DATABASE_URL=sqlite+aiosqlite:///./interpretation.db
-

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,9 @@ MEDIAMTX_HLS_BASE=http://localhost:8888
 # In Docker, docker-compose.yml sets this to http://mediamtx:8888 automatically.
 # MEDIAMTX_INTERNAL_BASE=
 
+# Admin panel — password for /admin/login. Empty = admin login disabled.
+ADMIN_PASSWORD=
+
 # Database — SQLite for development, PostgreSQL for production.
 # The default stores a SQLite file in the project root.
 # For PostgreSQL: DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/interpretation

--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ MEDIAMTX_HLS_BASE=http://localhost:8888
 # MEDIAMTX_INTERNAL_BASE=
 
 # Admin panel — password for /admin/login. Empty = admin login disabled.
-ADMIN_PASSWORD=
+ADMIN_PASSWORD=ADMIN
 
 # Database — SQLite for development, PostgreSQL for production.
 # The default stores a SQLite file in the project root.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           node --check static/js/interpreter-booth.js
           node --check static/js/whep-listener.js
+          node --check static/js/admin.js
 
       - name: Run unit tests
         run: uv run pytest tests/ -v
@@ -185,6 +186,95 @@ jobs:
           source /tmp/ci-helpers.sh
           assert_http "http://${CI_HOST}:${PORTAL_PORT}/static/js/interpreter-booth.js" "interpreter-booth.js"
           assert_http "http://${CI_HOST}:${PORTAL_PORT}/static/js/whep-listener.js"     "whep-listener.js"
+          assert_http "http://${CI_HOST}:${PORTAL_PORT}/static/js/admin.js"             "admin.js"
+          assert_http "http://${CI_HOST}:${PORTAL_PORT}/static/css/admin.css"           "admin.css"
+
+      # ── Auth & admin panel smoke tests ──────────────────────
+      - name: Home page, login, register render
+        run: |
+          source /tmp/ci-helpers.sh
+          assert_http "http://${CI_HOST}:${PORTAL_PORT}/"         "GET /"
+          assert_http "http://${CI_HOST}:${PORTAL_PORT}/login"    "GET /login"
+          assert_http "http://${CI_HOST}:${PORTAL_PORT}/register" "GET /register"
+
+      - name: Admin panel login and CRUD smoke test
+        env:
+          ADMIN_PASSWORD: admin
+        run: |
+          BASE="http://${CI_HOST}:${PORTAL_PORT}"
+
+          # Admin login page renders
+          code=$(curl -s -o /dev/null -w '%{http_code}' "${BASE}/admin/login")
+          echo "GET /admin/login → $code"
+          [ "$code" = "200" ] || { echo "FAIL"; exit 1; }
+
+          # Admin login with correct password → redirect + cookie
+          resp=$(curl -s -D - -o /dev/null -X POST "${BASE}/admin/login" -d "password=admin")
+          echo "$resp" | head -5
+          echo "$resp" | grep -qi "set-cookie.*admin_token" || { echo "FAIL: no admin_token cookie"; exit 1; }
+
+          # Extract the admin_token cookie
+          ADMIN_COOKIE=$(echo "$resp" | grep -i 'set-cookie.*admin_token' | sed 's/.*admin_token=\([^;]*\).*/\1/')
+          echo "Admin token: ${ADMIN_COOKIE:0:20}..."
+
+          # Dashboard loads
+          code=$(curl -s -o /dev/null -w '%{http_code}' -b "admin_token=${ADMIN_COOKIE}" "${BASE}/admin/")
+          echo "GET /admin/ → $code"
+          [ "$code" = "200" ] || { echo "FAIL"; exit 1; }
+
+          # Create event
+          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST -b "admin_token=${ADMIN_COOKIE}" \
+            -d "slug=ci-smoke&display_name=CI+Smoke+Test" "${BASE}/admin/events/")
+          echo "POST /admin/events/ → $code"
+          [ "$code" = "303" ] || { echo "FAIL"; exit 1; }
+
+          # Events list renders
+          code=$(curl -s -o /dev/null -w '%{http_code}' -b "admin_token=${ADMIN_COOKIE}" "${BASE}/admin/events/")
+          echo "GET /admin/events/ → $code"
+          [ "$code" = "200" ] || { echo "FAIL"; exit 1; }
+
+          # Users list renders
+          code=$(curl -s -o /dev/null -w '%{http_code}' -b "admin_token=${ADMIN_COOKIE}" "${BASE}/admin/users/")
+          echo "GET /admin/users/ → $code"
+          [ "$code" = "200" ] || { echo "FAIL"; exit 1; }
+
+          # Admin without cookie → 403
+          code=$(curl -s -o /dev/null -w '%{http_code}' "${BASE}/admin/")
+          echo "GET /admin/ (no cookie) → $code"
+          [ "$code" = "403" ] || { echo "FAIL: expected 403"; exit 1; }
+
+      - name: User registration and login smoke test
+        run: |
+          BASE="http://${CI_HOST}:${PORTAL_PORT}"
+
+          # Register a new user
+          resp=$(curl -s -D - -o /dev/null -X POST "${BASE}/register" \
+            -d "email=ci-test@example.com&display_name=CI+User&password=securepass123&password_confirm=securepass123")
+          echo "$resp" | head -5
+          echo "$resp" | grep -qi "set-cookie.*user_token" || { echo "FAIL: no user_token after register"; exit 1; }
+
+          # Login with the registered user
+          resp=$(curl -s -D - -o /dev/null -X POST "${BASE}/login" \
+            -d "email=ci-test@example.com&password=securepass123")
+          echo "$resp" | head -5
+          echo "$resp" | grep -qi "set-cookie.*user_token" || { echo "FAIL: no user_token after login"; exit 1; }
+
+          # Extract user token and check account page
+          USER_COOKIE=$(echo "$resp" | grep -i 'set-cookie.*user_token' | sed 's/.*user_token=\([^;]*\).*/\1/')
+          code=$(curl -s -o /dev/null -w '%{http_code}' -b "user_token=${USER_COOKIE}" "${BASE}/account")
+          echo "GET /account → $code"
+          [ "$code" = "200" ] || { echo "FAIL"; exit 1; }
+
+          # Login with wrong password → 403
+          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "${BASE}/login" \
+            -d "email=ci-test@example.com&password=wrong")
+          echo "POST /login (wrong pw) → $code"
+          [ "$code" = "403" ] || { echo "FAIL: expected 403"; exit 1; }
+
+          # Account without cookie → redirect to login
+          code=$(curl -s -o /dev/null -w '%{http_code}' "${BASE}/account")
+          echo "GET /account (no cookie) → $code"
+          [ "$code" = "303" ] || { echo "FAIL: expected 303 redirect"; exit 1; }
 
       # ── Collect logs on failure ─────────────────────────────
       - name: Dump logs on failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,7 @@ jobs:
       MEDIAMTX_WHIP_BASE: http://localhost:8889
       MEDIAMTX_HLS_BASE: http://localhost:8888
       MEDIAMTX_API_BASE: http://mediamtx:9997
+      ADMIN_PASSWORD: ci-admin-pass
 
     steps:
       - name: Checkout repository
@@ -198,8 +199,6 @@ jobs:
           assert_http "http://${CI_HOST}:${PORTAL_PORT}/register" "GET /register"
 
       - name: Admin panel login and CRUD smoke test
-        env:
-          ADMIN_PASSWORD: admin
         run: |
           BASE="http://${CI_HOST}:${PORTAL_PORT}"
 
@@ -209,7 +208,7 @@ jobs:
           [ "$code" = "200" ] || { echo "FAIL"; exit 1; }
 
           # Admin login with correct password → redirect + cookie
-          resp=$(curl -s -D - -o /dev/null -X POST "${BASE}/admin/login" -d "password=admin")
+          resp=$(curl -s -D - -o /dev/null -X POST "${BASE}/admin/login" -d "password=ci-admin-pass")
           echo "$resp" | head -5
           echo "$resp" | grep -qi "set-cookie.*admin_token" || { echo "FAIL: no admin_token cookie"; exit 1; }
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,12 +163,13 @@ jobs:
       - name: Portal page endpoints
         run: |
           source /tmp/ci-helpers.sh
-          assert_http "http://${CI_HOST}:${PORTAL_PORT}/interpreter/ci-booth?token=ci-test-token" \
-                      "GET /interpreter/ci-booth"
+          # Booth pages now require auth — unauthenticated requests redirect to /login
+          assert_http "http://${CI_HOST}:${PORTAL_PORT}/interpreter/ci-event/en" \
+                      "GET /interpreter/ci-event/en (no auth → 303)" "303"
           assert_http "http://${CI_HOST}:${PORTAL_PORT}/listener-webrtc/ci-booth" \
-                      "GET /listener-webrtc/ci-booth"
+                      "GET /listener-webrtc/ci-booth (no auth → 303)" "303"
           assert_http "http://${CI_HOST}:${PORTAL_PORT}/listen/ci-booth" \
-                      "GET /listen/ci-booth"
+                      "GET /listen/ci-booth (no auth → 303)" "303"
 
       - name: Portal ingest-status API
         run: |
@@ -274,6 +275,23 @@ jobs:
           code=$(curl -s -o /dev/null -w '%{http_code}' "${BASE}/account")
           echo "GET /account (no cookie) → $code"
           [ "$code" = "303" ] || { echo "FAIL: expected 303 redirect"; exit 1; }
+
+          # Listener / WebRTC pages redirect unauthenticated users
+          code=$(curl -s -o /dev/null -w '%{http_code}' "${BASE}/listen/ci-booth")
+          echo "GET /listen/ci-booth (no cookie) → $code"
+          [ "$code" = "303" ] || { echo "FAIL: expected 303"; exit 1; }
+
+          # With a valid user_token but no event membership → 403 on interpreter page
+          code=$(curl -s -o /dev/null -w '%{http_code}' -b "user_token=${USER_COOKIE}" \
+            "${BASE}/interpreter/ci-smoke/en")
+          echo "GET /interpreter/ci-smoke/en (user, no membership) → $code"
+          [ "$code" = "403" ] || { echo "FAIL: expected 403 without membership"; exit 1; }
+
+          # With user_token, listener pages (no event scope) should pass through
+          code=$(curl -s -o /dev/null -w '%{http_code}' -b "user_token=${USER_COOKIE}" \
+            "${BASE}/listen/ci-booth")
+          echo "GET /listen/ci-booth (user_token) → $code"
+          [ "$code" = "200" ] || { echo "FAIL: expected 200"; exit 1; }
 
       # ── Collect logs on failure ─────────────────────────────
       - name: Dump logs on failure

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,9 +144,9 @@ Existing free-form booth IDs (e.g. `hall-a-fr`) that happen to end with a valid 
 - `portal/roles.py`
   - Permission enum, role-permission mapping, standalone permission helpers (mirrors Eventyay `core/permissions.py`)
 - `portal/models.py`
-  - SQLAlchemy 2.0 declarative models: Event, Room, DBBooth, InviteToken, User
+  - SQLAlchemy 2.0 declarative models: Event, Room, DBBooth, InviteToken, User, EventMembership
 - `portal/database.py`
-  - async engine lifecycle, session factory, CRUD helpers for all models (including user management)
+  - async engine lifecycle, session factory, CRUD helpers for all models (including user management, event memberships, and token revocation)
 - `alembic/`
   - database migration framework (async-aware env.py, version-controlled migration scripts)
 - `templates/base.html`
@@ -172,9 +172,11 @@ Existing free-form booth IDs (e.g. `hall-a-fr`) that happen to end with a valid 
 - `templates/login.html`
   - user login form (email, password)
 - `templates/account.html`
-  - user account page showing role, status, permissions
+  - user account page showing event memberships and account status
 - `templates/admin/`
-  - admin panel templates: dashboard, event/room/booth CRUD, user management, login
+  - admin panel templates: dashboard, event/room/booth CRUD, user management, event members, login
+- `static/js/admin.js`
+  - admin panel client-side utilities (clipboard copy for invite links)
 - `mediamtx.yml`
   - MediaMTX configuration (WHIP ingest, WHEP playback, HLS fallback, Control API, overridePublisher for handoff)
 - `docker-compose.yml`
@@ -212,8 +214,10 @@ The persistent database stores configuration that must survive restarts (which e
 erDiagram
     Event ||--o{ Room : "has rooms"
     Event ||--o{ DBBooth : "has booths"
+    Event ||--o{ EventMembership : "has members"
     Room  ||--o{ DBBooth : "contains booths"
     DBBooth ||--o{ InviteToken : "has tokens"
+    User  ||--o{ EventMembership : "has memberships"
 
     Event {
         int id PK
@@ -251,8 +255,15 @@ erDiagram
         string email UK
         string display_name
         string password_hash
-        string role "default: listener"
+        bool is_admin "default: false"
         bool is_active "default: true"
+        datetime created_at
+    }
+    EventMembership {
+        int id PK
+        int user_id FK
+        int event_id FK
+        string role
         datetime created_at
     }
 ```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -138,15 +138,15 @@ Existing free-form booth IDs (e.g. `hall-a-fr`) that happen to end with a valid 
 - `portal/booth_state.py`
   - async in-memory booth registry, participant role policy, active interpreter ownership, handoff state, chat history, event-scoped queries (`get_booth`, `get_booth_for_event`, `validate_booth_event`)
 - `portal/auth.py`
-  - JWT token creation and validation (PyJWT), participant token issuance with role claims
+  - JWT token creation and validation (PyJWT), participant token issuance with role claims, user authentication (bcrypt password hashing, user session tokens), admin token guard
 - `portal/config.py`
   - pydantic-settings configuration loaded from environment variables / `.env`
 - `portal/roles.py`
   - Permission enum, role-permission mapping, standalone permission helpers (mirrors Eventyay `core/permissions.py`)
 - `portal/models.py`
-  - SQLAlchemy 2.0 declarative models: Event, Room, DBBooth, InviteToken
+  - SQLAlchemy 2.0 declarative models: Event, Room, DBBooth, InviteToken, User
 - `portal/database.py`
-  - async engine lifecycle, session factory, CRUD helpers for all models
+  - async engine lifecycle, session factory, CRUD helpers for all models (including user management)
 - `alembic/`
   - database migration framework (async-aware env.py, version-controlled migration scripts)
 - `templates/base.html`
@@ -163,6 +163,18 @@ Existing free-form booth IDs (e.g. `hall-a-fr`) that happen to end with a valid 
   - WHEP WebRTC listener client — connects to MediaMTX WHEP endpoint for low-latency playback
 - `static/css/interpreter.css`
   - lightweight Eventyay-aligned styles
+- `static/css/admin.css`
+  - admin panel, login/register, account, and home page styles
+- `templates/home.html`
+  - public home page with event list, listener links, auth-aware header
+- `templates/register.html`
+  - user registration form (email, display name, password)
+- `templates/login.html`
+  - user login form (email, password)
+- `templates/account.html`
+  - user account page showing role, status, permissions
+- `templates/admin/`
+  - admin panel templates: dashboard, event/room/booth CRUD, user management, login
 - `mediamtx.yml`
   - MediaMTX configuration (WHIP ingest, WHEP playback, HLS fallback, Control API, overridePublisher for handoff)
 - `docker-compose.yml`
@@ -232,6 +244,15 @@ erDiagram
         datetime expires_at "nullable"
         datetime used_at "nullable"
         string created_by
+        datetime created_at
+    }
+    User {
+        int id PK
+        string email UK
+        string display_name
+        string password_hash
+        string role "default: listener"
+        bool is_active "default: true"
         datetime created_at
     }
 ```
@@ -442,7 +463,71 @@ Ingest responsibilities:
 - in Docker, `portal-data` volume persists the SQLite database across container restarts
 - in Docker, `DOCKER_HOST_ADDRESS` must be set to the host's LAN IP for JVB ICE to work
 
-## 13. Reliability and operational constraints
+## 13. User registration and authentication
+
+The portal supports self-service user registration and admin-managed role promotion.
+
+### Registration flow
+
+```mermaid
+sequenceDiagram
+    participant U as User Browser
+    participant P as Portal (FastAPI)
+    participant DB as Database
+
+    U->>P: GET /register
+    P->>U: Registration form
+    U->>P: POST /register (email, name, password)
+    P->>P: Validate input + hash password (bcrypt)
+    P->>DB: INSERT user (role=listener)
+    P->>P: Create JWT (user_token cookie)
+    P->>U: 303 → /account
+```
+
+### Key design decisions
+
+- **Default role is `listener`** — no role selection at registration. Users cannot self-assign admin, interpreter, or coordinator roles.
+- **Password hashing uses bcrypt** (`bcrypt.hashpw` with auto-generated salt). Plaintext passwords are never stored.
+- **User sessions use JWT cookies** (`user_token`, HttpOnly, SameSite=lax) — same pattern as admin tokens.
+- **Admins manage roles** from `/admin/users/` — dropdown to change any user's role, toggle active/inactive, delete.
+- **Deactivated accounts** cannot log in but are not deleted (preserving audit trail).
+
+### Admin user management
+
+The admin panel at `/admin/users/` allows:
+
+| Action | Route | Effect |
+|--------|-------|--------|
+| View all users | `GET /admin/users/` | Table with email, name, role, status, join date |
+| Change role | `POST /admin/users/{id}/role` | Promote/demote between listener, interpreter, coordinator, event_admin, super_admin |
+| Toggle active | `POST /admin/users/{id}/toggle-active` | Enable/disable login without deleting |
+| Delete user | `POST /admin/users/{id}/delete` | Permanent removal |
+
+## 14. Admin panel
+
+The admin panel (`/admin/`) provides a server-rendered management UI guarded by the `ADMIN_PASSWORD` env var.
+
+### Route structure
+
+| Route | Purpose |
+|-------|--------|
+| `GET /admin/login` | Admin login form |
+| `POST /admin/login` | Validate password, set `admin_token` cookie |
+| `GET /admin/logout` | Clear cookie, redirect to login |
+| `GET /admin/` | Dashboard with event cards, live status, MediaMTX health |
+| `GET /admin/events/` | Event list + create form |
+| `GET /admin/events/{id}/` | Event detail: rooms, booths, interpreter page links |
+| `GET /admin/events/{id}/rooms/` | Room list + create form |
+| `GET /admin/events/{id}/rooms/{id}/` | Room detail: schedule table, live status |
+| `GET /admin/events/{id}/rooms/{id}/booths/` | Booth list + create form |
+| `GET /admin/events/{id}/rooms/{id}/booths/{id}/` | Booth detail: WHEP URL, participants, invite tokens |
+| `GET /admin/users/` | User management: role assignment, activate/deactivate |
+
+### Auth guard
+
+Admin routes use `Depends(require_admin)` which checks for a valid `admin_token` JWT cookie with `admin=True` claim. Returns HTTP 403 if missing or invalid.
+
+## 15. Reliability and operational constraints
 
 - recommend headphones-first operation to reduce feedback risk
 - prevent local audio loopback in mic capture path

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -500,19 +500,29 @@ sequenceDiagram
 - **Default role is `listener`** — no role selection at registration. Users cannot self-assign admin, interpreter, or coordinator roles.
 - **Password hashing uses bcrypt** (`bcrypt.hashpw` with auto-generated salt). Plaintext passwords are never stored.
 - **User sessions use JWT cookies** (`user_token`, HttpOnly, SameSite=lax) — same pattern as admin tokens.
-- **Admins manage roles** from `/admin/users/` — dropdown to change any user's role, toggle active/inactive, delete.
+- **Roles are per-event** — admins assign roles at `/admin/events/{id}/members/` via `EventMembership`. There is no global role field on the user.
+- **`is_admin` flag** on `User` grants access to the admin panel; it is toggled from `/admin/users/`.
 - **Deactivated accounts** cannot log in but are not deleted (preserving audit trail).
 
 ### Admin user management
 
-The admin panel at `/admin/users/` allows:
+The admin panel provides two layers of user management:
+
+**Site-wide** (`/admin/users/`):
 
 | Action | Route | Effect |
 |--------|-------|--------|
-| View all users | `GET /admin/users/` | Table with email, name, role, status, join date |
-| Change role | `POST /admin/users/{id}/role` | Promote/demote between listener, interpreter, coordinator, event_admin, super_admin |
+| View all users | `GET /admin/users/` | Table with email, name, admin status, join date |
 | Toggle active | `POST /admin/users/{id}/toggle-active` | Enable/disable login without deleting |
 | Delete user | `POST /admin/users/{id}/delete` | Permanent removal |
+
+**Per-event** (`/admin/events/{id}/members/`):
+
+| Action | Route | Effect |
+|--------|-------|--------|
+| View all users + memberships | `GET /admin/events/{id}/members/` | Table with inline role dropdown for every user |
+| Assign / change role | `POST /admin/events/{id}/members/` | Create or update `EventMembership` (roles: `listener`, `interpreter`, `coordinator`, `event_admin`) |
+| Remove membership | `POST /admin/events/{id}/members/{mid}/delete` | Delete `EventMembership` row |
 
 ## 14. Admin panel
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,7 +144,7 @@ Existing free-form booth IDs (e.g. `hall-a-fr`) that happen to end with a valid 
 - `portal/roles.py`
   - Permission enum, role-permission mapping, standalone permission helpers (mirrors Eventyay `core/permissions.py`)
 - `portal/models.py`
-  - SQLAlchemy 2.0 declarative models: Event, Room, DBBooth, InviteToken, User, EventMembership
+  - SQLAlchemy 2.0 declarative models: Event, Room, DBBooth, InviteToken, User, EventMembership, BoothMembership
 - `portal/database.py`
   - async engine lifecycle, session factory, CRUD helpers for all models (including user management, event memberships, and token revocation)
 - `alembic/`
@@ -217,7 +217,9 @@ erDiagram
     Event ||--o{ EventMembership : "has members"
     Room  ||--o{ DBBooth : "contains booths"
     DBBooth ||--o{ InviteToken : "has tokens"
-    User  ||--o{ EventMembership : "has memberships"
+    DBBooth ||--o{ BoothMembership : "has members"
+    User  ||--o{ EventMembership : "has event memberships"
+    User  ||--o{ BoothMembership : "has booth memberships"
 
     Event {
         int id PK
@@ -263,6 +265,13 @@ erDiagram
         int id PK
         int user_id FK
         int event_id FK
+        string role
+        datetime created_at
+    }
+    BoothMembership {
+        int id PK
+        int user_id FK
+        int booth_id FK
         string role
         datetime created_at
     }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,71 @@
+# Caddyfile — voxbento.com production
+#
+# Deploy:
+#   sudo cp Caddyfile /etc/caddy/Caddyfile
+#   sudo systemctl reload caddy
+#
+# DNS requirements:
+#   A  voxbento.com       → 100.56.6.172
+#   A  jitsi.voxbento.com → 100.56.6.172
+#
+# Caddy handles TLS automatically via Let's Encrypt.
+#
+# Port layout (all Docker-exposed, bound to 0.0.0.0 on host):
+#   8000  FastAPI interpretation portal
+#   8888  MediaMTX HLS
+#   8889  MediaMTX WHIP/WHEP (WebRTC ingest + playback)
+#   8080  Jitsi web (HTTP)
+#   8189  MediaMTX WebRTC ICE/UDP  ← NOT proxied by Caddy (UDP)
+#
+# URL structure (as seen by browsers):
+#   https://voxbento.com/{channel}/whip         → MediaMTX WHIP ingest
+#   https://voxbento.com/{channel}/whep         → MediaMTX WHEP playback
+#   https://voxbento.com/hls/{channel}/...      → MediaMTX HLS segments
+#   https://jitsi.voxbento.com/...              → Jitsi Meet (monitoring feed)
+#   https://voxbento.com/*                      → FastAPI portal
+
+# ── Interpretation Portal ─────────────────────────────────────────────────────
+voxbento.com {
+
+    # ── HLS streaming ─────────────────────────────────────────────────────────
+    # Browser requests: https://voxbento.com/hls/{channel}/index.m3u8
+    # MediaMTX serves:  http://localhost:8888/{channel}/index.m3u8
+    # Strip /hls prefix before forwarding.
+    handle /hls/* {
+        uri strip_prefix /hls
+        reverse_proxy localhost:8888
+    }
+
+    # ── WebRTC WHIP ingest + WHEP playback ────────────────────────────────────
+    # Browser requests: https://voxbento.com/{channel}/whip  (POST SDP offer)
+    # Browser requests: https://voxbento.com/{channel}/whep  (POST SDP offer)
+    # MediaMTX serves:  http://localhost:8889/{channel}/whip|whep
+    # Match any path that ends with /whip or /whep (channel IDs use / separators
+    # which Caddy normalises from %2F, e.g. fossasia-2027/de/whip).
+    @whip_whep {
+        path_regexp whip_whep /(whip|whep)$
+    }
+    handle @whip_whep {
+        reverse_proxy localhost:8889
+    }
+
+    # ── FastAPI portal (catch-all) ────────────────────────────────────────────
+    reverse_proxy localhost:8000
+}
+
+# ── Jitsi Meet monitoring feed ────────────────────────────────────────────────
+# Interpreters use this embedded iframe to monitor the speaker.
+# Jitsi web runs in Docker on host port 8080 (HTTP).
+# Caddy provides HTTPS termination so the iframe loads securely inside the portal.
+#
+# Required: DNS A record jitsi.voxbento.com → 100.56.6.172
+# Note: JVB media (UDP 10000) connects DIRECTLY to the server, not via Caddy.
+jitsi.voxbento.com {
+    # Forward all requests including WebSocket (BOSH, Colibri) to Jitsi web.
+    reverse_proxy localhost:8080 {
+        header_up Host {host}
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto {scheme}
+    }
+}

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ docker compose up --build
 Open http://localhost:8000. That is it.
 
 **Admin panel:** Go to http://localhost:8000/admin/login and enter your `ADMIN_PASSWORD`.
-From there you can create events, rooms, booths, and manage users.
+From there you can create events, rooms, booths, manage users, and assign per-event roles.
 
 **User registration:** Anyone can register at http://localhost:8000/register.
-New accounts get `listener` access by default. Admins can promote users to interpreter,
-coordinator, or event_admin from `/admin/users/`.
+New accounts are non-admin by default. Admins assign event-scoped roles
+(listener, interpreter, coordinator, event_admin) from each event's **Members** page.
 
 | Service | Port | Purpose |
 |---------|------|---------|

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ uv run uvicorn fastapi_app:app --host 127.0.0.1 --port 8000 --reload
 
 ### User registration and role management
 
-1. Users register at `/register` — they get a **listener** account by default
-2. Admins go to `/admin/users/` to manage registered users
-3. Change a user's role via the dropdown (listener → interpreter → coordinator → event_admin → super_admin)
+1. Users register at `/register` — new accounts are non-admin with no event roles
+2. Admins manage site-wide access (the `is_admin` flag) and activation status at `/admin/users/`
+3. Per-event roles (`listener`, `interpreter`, `coordinator`, `event_admin`) are assigned from each event's **Members** page at `/admin/events/{id}/members/` — inline dropdowns let admins assign or remove roles per user
 4. Deactivate users to prevent login without deleting their account

--- a/README.md
+++ b/README.md
@@ -42,10 +42,21 @@ Everything starts with one command. No Python, MediaMTX, or manual config needed
 ```bash
 git clone https://github.com/fossasia/eventyay-interpretation-portal.git
 cd eventyay-interpretation-portal
+
+# Set admin password (required for admin panel access)
+echo 'ADMIN_PASSWORD=my-secure-admin-pass' >> .env
+
 docker compose up --build
 ```
 
 Open http://localhost:8000. That is it.
+
+**Admin panel:** Go to http://localhost:8000/admin/login and enter your `ADMIN_PASSWORD`.
+From there you can create events, rooms, booths, and manage users.
+
+**User registration:** Anyone can register at http://localhost:8000/register.
+New accounts get `listener` access by default. Admins can promote users to interpreter,
+coordinator, or event_admin from `/admin/users/`.
 
 | Service | Port | Purpose |
 |---------|------|---------|
@@ -84,6 +95,9 @@ chmod +x mediamtx
 
 **Terminal 2 — FastAPI:**
 ```bash
+# Set admin password for admin panel access
+export ADMIN_PASSWORD='my-secure-admin-pass'
+
 uv run uvicorn fastapi_app:app --host 127.0.0.1 --port 8000 --reload
 ```
 
@@ -120,6 +134,7 @@ Copy `.env.example` → `.env` and adjust as needed:
 | `MEDIAMTX_HLS_BASE` | `http://localhost:8888` | Browser-facing HLS URL |
 | `MEDIAMTX_INTERNAL_BASE` | *(empty)* | Python→MediaMTX URL (Docker: `http://mediamtx:8888`) |
 | `MEDIAMTX_API_BASE` | `http://localhost:9997` | MediaMTX Control API for dynamic path management |
+| `ADMIN_PASSWORD` | *(empty)* | Admin panel login password |
 | `DATABASE_URL` | `sqlite+aiosqlite:///./interpretation.db` | Database connection string (PostgreSQL for production) |
 | `JVB_AUTH_PASSWORD` | `changeme` | Jitsi JVB auth (change in production) |
 | `JICOFO_AUTH_PASSWORD` | `changeme` | Jitsi Jicofo auth (change in production) |
@@ -130,7 +145,13 @@ Copy `.env.example` → `.env` and adjust as needed:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET`  | `/` | Redirect to demo booth |
+| `GET`  | `/` | Home page with event list and listener links |
+| `GET`  | `/register` | User registration page |
+| `POST` | `/register` | Create listener account |
+| `GET`  | `/login` | User login page |
+| `POST` | `/login` | Authenticate and set session cookie |
+| `GET`  | `/logout` | Clear session cookie |
+| `GET`  | `/account` | User account page (role, status) |
 | `GET`  | `/interpreter/{booth_id}` | Interpreter booth UI |
 | `GET`  | `/listener-webrtc/{booth_id}` | Attendee WHEP listener (WebRTC, primary) |
 | `GET`  | `/listen/{booth_id}` | Attendee HLS listener (hls.js, fallback) |
@@ -139,6 +160,21 @@ Copy `.env.example` → `.env` and adjust as needed:
 | `GET`  | `/api/interpreter/status/{channel_id}` | MediaMTX reachability |
 | `GET`  | `/healthz` | Health check |
 | `WS`   | `/ws/booth/{booth_id}` | Booth coordination WebSocket |
+
+### Admin panel routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET`  | `/admin/login` | Admin login page |
+| `POST` | `/admin/login` | Validate admin password |
+| `GET`  | `/admin/` | Dashboard with event cards and live status |
+| `GET`  | `/admin/events/` | Event list + create form |
+| `GET`  | `/admin/events/{id}/` | Event detail with rooms and booths |
+| `GET`  | `/admin/events/{id}/rooms/` | Room list + create form |
+| `GET`  | `/admin/events/{id}/rooms/{id}/` | Room detail with interpreter URLs |
+| `GET`  | `/admin/events/{id}/rooms/{id}/booths/` | Booth list + create form |
+| `GET`  | `/admin/events/{id}/rooms/{id}/booths/{id}/` | Booth detail: WHEP URL, participants, tokens |
+| `GET`  | `/admin/users/` | User management: roles, activate/deactivate |
 
 ### WebSocket messages (client → server)
 
@@ -195,19 +231,25 @@ portal/
   booth_state.py              # async in-memory booth registry
   booth_identity.py           # booth ID ↔ MediaMTX path mapping
   roles.py                    # Permission enum, role-permission mapping
-  models.py                   # SQLAlchemy declarative models (Event, Room, DBBooth, InviteToken)
+  models.py                   # SQLAlchemy declarative models (Event, Room, DBBooth, InviteToken, User)
   database.py                 # async engine, session factory, CRUD helpers
 alembic/
   env.py                      # async-aware Alembic environment
   versions/                   # migration scripts (committed to version control)
 templates/
+  home.html                   # public home page with event list
+  register.html               # user registration form
+  login.html                  # user login form
+  account.html                # user account page
   interpreter_booth.html      # Jinja2 interpreter booth page
   listener.html               # Jinja2 attendee page (hls.js fallback)
   listener-webrtc.html        # Jinja2 attendee page (WHEP WebRTC, primary)
+  admin/                      # admin panel templates (dashboard, CRUD, users)
 static/
   js/interpreter-booth.js     # Plain browser JS — WebRTC/WHIP + WebSocket
   js/whep-listener.js         # WHEP WebRTC listener client
   css/interpreter.css
+  css/admin.css               # admin panel and auth page styles
 mediamtx.yml                  # MediaMTX config (WHIP ingest, WHEP playback, HLS fallback, Control API)
 docker-compose.yml            # portal + mediamtx + jitsi services
 Dockerfile                    # FastAPI container (uv, Python 3.13-slim)
@@ -217,4 +259,37 @@ tests/
   test_booth_identity.py      # booth identity scheme tests
   test_roles.py               # permission model tests
   test_database.py            # database model + CRUD tests
+  test_admin_panel.py         # admin panel route tests
+  test_user_auth.py           # registration, login, account, user management tests
+  test_join_flow.py           # invite-token join flow tests
 ```
+
+### Admin panel setup
+
+```bash
+# Set the admin password (required for admin access)
+export ADMIN_PASSWORD='your-secure-password'
+
+# Start the server
+uv run uvicorn fastapi_app:app --host 127.0.0.1 --port 8000 --reload
+
+# Visit http://localhost:8000/admin/login and enter the password
+```
+
+### Creating events, rooms, and booths
+
+1. Log in to the admin panel at `/admin/login`
+2. Go to **Events** → create an event (slug + display name)
+3. Open the event → go to **Rooms** → create a room
+4. Open the room → go to **Booths** → create a booth (language code + name)
+5. The booth detail page shows:
+   - Interpreter page URL (share with interpreters)
+   - WHEP listener URL (for attendees)
+   - Invite token management
+
+### User registration and role management
+
+1. Users register at `/register` — they get a **listener** account by default
+2. Admins go to `/admin/users/` to manage registered users
+3. Change a user's role via the dropdown (listener → interpreter → coordinator → event_admin → super_admin)
+4. Deactivate users to prevent login without deleting their account

--- a/README.md
+++ b/README.md
@@ -35,43 +35,45 @@ longer gap (~10–15 s).
 
 ## Setup
 
-### Option 1 — Docker Compose (recommended)
+### Prerequisites
 
-Everything starts with one command. No Python, MediaMTX, or manual config needed.
+| Dependency | Version | Purpose |
+|-----------|---------|---------|
+| Python | 3.13+ | FastAPI portal |
+| [uv](https://github.com/astral-sh/uv) | latest | Python package manager |
+| [MediaMTX](https://github.com/bluenviron/mediamtx/releases) | 1.x | WebRTC/HLS audio server |
+| Docker & Docker Compose | latest | Jitsi stack (or full Docker setup) |
+
+### Option 1 — Docker Compose (everything in containers)
+
+All services (portal, MediaMTX, Jitsi) start with one command:
 
 ```bash
 git clone https://github.com/fossasia/eventyay-interpretation-portal.git
 cd eventyay-interpretation-portal
 
-# Set admin password (required for admin panel access)
+# Configure environment
+cp .env.example .env
+
+# Required: set your admin password
 echo 'ADMIN_PASSWORD=my-secure-admin-pass' >> .env
+
+# Required for Jitsi video: set your machine's LAN IP
+# macOS:  ipconfig getifaddr en0
+# Linux:  hostname -I | awk '{print $1}'
+echo 'DOCKER_HOST_ADDRESS=192.168.1.x' >> .env
 
 docker compose up --build
 ```
 
-Open http://localhost:8000. That is it.
+Open http://localhost:8000 — all services are running.
 
-**Admin panel:** Go to http://localhost:8000/admin/login and enter your `ADMIN_PASSWORD`.
-From there you can create events, rooms, booths, manage users, and assign per-event roles.
+### Option 2 — Native setup (recommended for development)
 
-**User registration:** Anyone can register at http://localhost:8000/register.
-New accounts are non-admin by default. Admins assign event-scoped roles
-(listener, interpreter, coordinator, event_admin) from each event's **Members** page.
+Run the portal and MediaMTX natively for fast iteration with hot-reload. Jitsi runs
+in Docker since it requires four interconnected Java/Lua services.
 
-| Service | Port | Purpose |
-|---------|------|---------|
-| FastAPI portal | 8000 | Web UI, REST API, WebSocket |
-| MediaMTX WHEP/WHIP | 8889 | WebRTC playback (WHEP) and ingest (WHIP) |
-| MediaMTX HLS | 8888 | HLS fallback stream for attendees |
-| MediaMTX Control API | 9997 | Dynamic path management (alwaysAvailable) |
-| Jitsi Web | 8443 | Self-hosted video conferencing (interpreter monitors speaker) |
-| Jitsi JVB | 10000/udp | Jitsi media traffic |
-
-To stop: `Ctrl+C` or `docker compose down`.
-
-### Option 2 — Native (two terminals)
-
-**Requirements**: Python 3.13+, [uv](https://github.com/astral-sh/uv), [MediaMTX](https://github.com/bluenviron/mediamtx/releases)
+#### Step 1: Clone and install dependencies
 
 ```bash
 git clone https://github.com/fossasia/eventyay-interpretation-portal.git
@@ -79,46 +81,156 @@ cd eventyay-interpretation-portal
 uv sync                      # install Python dependencies
 ```
 
-Download MediaMTX for your platform from [releases](https://github.com/bluenviron/mediamtx/releases):
+#### Step 2: Configure environment
 
 ```bash
-# macOS ARM64 example
+cp .env.example .env
+```
+
+Edit `.env` and set at minimum:
+
+```ini
+ADMIN_PASSWORD=my-secure-admin-pass
+DOCKER_HOST_ADDRESS=192.168.1.x   # your LAN IP (for Jitsi)
+```
+
+#### Step 3: Download MediaMTX
+
+Download the binary for your platform from [MediaMTX releases](https://github.com/bluenviron/mediamtx/releases):
+
+**macOS (Apple Silicon):**
+```bash
 curl -sL https://github.com/bluenviron/mediamtx/releases/download/v1.12.3/mediamtx_v1.12.3_darwin_arm64.tar.gz \
   | tar xzf - mediamtx
+```
+
+**macOS (Intel):**
+```bash
+curl -sL https://github.com/bluenviron/mediamtx/releases/download/v1.12.3/mediamtx_v1.12.3_darwin_amd64.tar.gz \
+  | tar xzf - mediamtx
+```
+
+**Linux (x86_64):**
+```bash
+curl -sL https://github.com/bluenviron/mediamtx/releases/download/v1.12.3/mediamtx_v1.12.3_linux_amd64.tar.gz \
+  | tar xzf - mediamtx
+```
+
+```bash
 chmod +x mediamtx
 ```
 
-**Terminal 1 — MediaMTX:**
+#### Step 4: Start Jitsi (Docker)
+
+Jitsi requires four services (web, prosody, jicofo, jvb). The easiest way to run it
+is via the project's Docker Compose file with only the Jitsi services:
+
+```bash
+docker compose up -d jitsi-web jitsi-prosody jitsi-jicofo jitsi-jvb
+```
+
+Wait ~15 seconds for all services to start. Verify Jitsi is running:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/
+# Should return 200 or 301
+```
+
+> **Note:** Jitsi is used by interpreters to monitor the speaker's live video/audio.
+> If you don't need the speaker monitoring feature, you can skip this step — the
+> portal will work without it, but the Jitsi iframe on the interpreter page will
+> show a connection error.
+
+#### Step 5: Run database migrations
+
+```bash
+uv run alembic upgrade head
+```
+
+This creates the SQLite database (`interpretation.db`) and applies all migrations
+(users, events, rooms, booths, invite tokens, event memberships).
+
+#### Step 6: Start MediaMTX
+
+**Terminal 1:**
 ```bash
 ./mediamtx mediamtx.yml
 ```
 
-**Terminal 2 — FastAPI:**
-```bash
-# Set admin password for admin panel access
-export ADMIN_PASSWORD='my-secure-admin-pass'
+You should see:
+```
+INF MediaMTX v1.12.3
+INF [WebRTC] listener opened on :8889 (TCP), :8189 (UDP)
+INF [HLS] listener opened on :8888
+INF [API] listener opened on :9997
+```
 
+#### Step 7: Start the portal
+
+**Terminal 2:**
+```bash
 uv run uvicorn fastapi_app:app --host 127.0.0.1 --port 8000 --reload
 ```
 
-Open http://localhost:8000.
+You should see:
+```
+INFO:     Uvicorn running on http://127.0.0.1:8000
+INFO:     Started reloader process
+```
 
-### Verify it works
+### Verify the setup
+
+Run these checks to confirm everything is connected:
 
 ```bash
+# 1. Portal health (checks MediaMTX connectivity too)
 curl http://localhost:8000/healthz
 # {"ok": true, "server": "fastapi", "mediamtx_ok": true}
+
+# 2. MediaMTX API
+curl http://localhost:9997/v3/paths/list
+# {"items": [], ...}
+
+# 3. Jitsi web (if running)
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/
+# 200
+
+# 4. Admin panel
+open http://localhost:8000/admin/login
+# Log in with your ADMIN_PASSWORD
 ```
 
 ### Test audio end-to-end
 
-1. Open http://localhost:8000/interpreter/demo-booth
-2. Enter a name, select **Interpreter**, click **Join Booth**
-3. Click **Go Live** — allow microphone when prompted
-4. Open http://localhost:8000/listener-webrtc/demo-booth in another tab (WHEP WebRTC listener, sub-second latency)
-   — or http://localhost:8000/listen/demo-booth for the HLS fallback (hls.js, ~3 s delay)
-   — or use VLC: File → Open Network → `http://localhost:8888/demo-booth-audio/index.m3u8`
-5. Speak — you should hear yourself with <1 s delay on the WHEP listener
+1. Log in to admin panel → create an **Event** → **Room** → **Booth**
+2. Open the booth detail page → generate an **invite token** with role "interpreter"
+3. Copy the invite link (`/join/<token>`) and open it in a new browser tab
+4. You'll be redirected to the interpreter booth — click **Go Live** and allow microphone
+5. Open `http://localhost:8000/listener-webrtc/<booth-slug>` in another tab
+   - This is the WHEP WebRTC listener — sub-second latency
+6. Or open `http://localhost:8000/listen/<booth-slug>` for HLS fallback (~3 s delay)
+7. Speak — you should hear yourself
+
+**Quick test without admin panel:**
+```bash
+# Direct interpreter booth (for development/testing only)
+open http://localhost:8000/interpreter/demo-booth
+# Enter a name → select Interpreter → Join Booth → Go Live
+# Then open http://localhost:8000/listener-webrtc/demo-booth in another tab
+```
+
+### Services and ports
+
+| Service | Port | Protocol | Purpose |
+|---------|------|----------|---------|
+| FastAPI portal | 8000 | HTTP | Web UI, REST API, WebSocket |
+| MediaMTX WHIP/WHEP | 8889 | HTTP+UDP | WebRTC ingest (WHIP) and playback (WHEP) |
+| MediaMTX HLS | 8888 | HTTP | HLS fallback stream |
+| MediaMTX ICE | 8189/udp | UDP | WebRTC media traffic |
+| MediaMTX API | 9997 | HTTP | Dynamic path management |
+| Jitsi Web | 8080 | HTTP | Speaker monitoring (interpreter iframe) |
+| Jitsi Web (HTTPS) | 8443 | HTTPS | Speaker monitoring (production) |
+| Jitsi JVB | 10000/udp | UDP | Jitsi video bridge media |
 
 ### Environment variables
 
@@ -126,20 +238,31 @@ Copy `.env.example` → `.env` and adjust as needed:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
+| `ADMIN_PASSWORD` | *(empty)* | Admin panel login password (**required**) |
 | `SECRET_KEY` | `change-me` | JWT signing key |
 | `BOOTH_ACCESS_TOKEN` | *(empty)* | Booth password (empty = open access) |
-| `JITSI_DOMAIN` | `localhost:8443` | Jitsi Meet domain (self-hosted via Docker) |
-| `DEFAULT_JITSI_ROOM` | `eventyay-stage-room` | Default Jitsi room for interpreter monitoring |
-| `MEDIAMTX_WHIP_BASE` | `http://localhost:8889` | Browser-facing WHIP URL |
+| `DOCKER_HOST_ADDRESS` | *(empty)* | Host LAN IP for Jitsi JVB ICE candidates |
+| `JITSI_DOMAIN` | `localhost:8080` | Jitsi Meet domain |
+| `DEFAULT_JITSI_ROOM` | `eventyay-stage-room` | Default Jitsi room name |
+| `JITSI_BASE_URL` | *(empty)* | Full Jitsi URL with scheme (empty = `http://{JITSI_DOMAIN}`) |
+| `MEDIAMTX_WHIP_BASE` | `http://localhost:8889` | Browser-facing WHIP/WHEP URL |
 | `MEDIAMTX_HLS_BASE` | `http://localhost:8888` | Browser-facing HLS URL |
 | `MEDIAMTX_INTERNAL_BASE` | *(empty)* | Python→MediaMTX URL (Docker: `http://mediamtx:8888`) |
-| `MEDIAMTX_API_BASE` | `http://localhost:9997` | MediaMTX Control API for dynamic path management |
-| `ADMIN_PASSWORD` | *(empty)* | Admin panel login password |
-| `DATABASE_URL` | `sqlite+aiosqlite:///./interpretation.db` | Database connection string (PostgreSQL for production) |
+| `MEDIAMTX_API_BASE` | `http://localhost:9997` | MediaMTX Control API |
+| `DATABASE_URL` | `sqlite+aiosqlite:///./interpretation.db` | Database (PostgreSQL for production) |
 | `JVB_AUTH_PASSWORD` | `changeme` | Jitsi JVB auth (change in production) |
 | `JICOFO_AUTH_PASSWORD` | `changeme` | Jitsi Jicofo auth (change in production) |
 
----
+### Stopping services
+
+```bash
+# Stop portal: Ctrl+C in Terminal 2
+# Stop MediaMTX: Ctrl+C in Terminal 1
+# Stop Jitsi:
+docker compose down jitsi-web jitsi-prosody jitsi-jicofo jitsi-jvb
+# Or stop everything:
+docker compose down
+```
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/
 #### Step 5: Run database migrations
 
 ```bash
+# Natively
 uv run alembic upgrade head
+
+# In Docker
+docker compose exec portal uv run alembic upgrade head
 ```
 
 This creates the SQLite database (`interpretation.db`) and applies all migrations

--- a/alembic/versions/002_add_users.py
+++ b/alembic/versions/002_add_users.py
@@ -1,0 +1,33 @@
+"""Add users table for registered user accounts.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-06-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '002'
+down_revision = '001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('email', sa.String(320), nullable=False, unique=True),
+        sa.Column('display_name', sa.String(200), nullable=False),
+        sa.Column('password_hash', sa.String(200), nullable=False),
+        sa.Column('role', sa.String(20), nullable=False, server_default='listener'),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('1')),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index('ix_users_email', 'users', ['email'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_users_email', table_name='users')
+    op.drop_table('users')

--- a/alembic/versions/003_event_memberships.py
+++ b/alembic/versions/003_event_memberships.py
@@ -1,0 +1,46 @@
+"""Replace global User.role with per-event memberships.
+
+- Drop User.role column, add User.is_admin boolean
+- Create event_memberships table (user_id, event_id, role)
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-06-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '003'
+down_revision = '002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create event_memberships table
+    op.create_table(
+        'event_memberships',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('event_id', sa.Integer(), sa.ForeignKey('events.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('role', sa.String(20), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index('ix_membership_user_event', 'event_memberships', ['user_id', 'event_id'], unique=True)
+
+    # Add is_admin to users
+    op.add_column('users', sa.Column('is_admin', sa.Boolean(), nullable=False, server_default=sa.text('0')))
+
+    # Drop role from users (SQLite doesn't support DROP COLUMN before 3.35)
+    # Use batch mode for SQLite compatibility
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.drop_column('role')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.add_column(sa.Column('role', sa.String(20), nullable=False, server_default='listener'))
+        batch_op.drop_column('is_admin')
+    op.drop_index('ix_membership_user_event', table_name='event_memberships')
+    op.drop_table('event_memberships')

--- a/alembic/versions/004_booth_memberships.py
+++ b/alembic/versions/004_booth_memberships.py
@@ -1,0 +1,34 @@
+"""Add booth_memberships table.
+
+- Create booth_memberships table (user_id, booth_id, role)
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-06-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '004'
+down_revision = '003'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create booth_memberships table
+    op.create_table(
+        'booth_memberships',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('booth_id', sa.Integer(), sa.ForeignKey('booths.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('role', sa.String(20), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index('ix_membership_user_booth', 'booth_memberships', ['user_id', 'booth_id'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_membership_user_booth', table_name='booth_memberships')
+    op.drop_table('booth_memberships')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       PORT: "8000"
       SECRET_KEY: "${SECRET_KEY:-change-me}"
       BOOTH_ACCESS_TOKEN: "${BOOTH_ACCESS_TOKEN:-}"
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD:-}"
       JWT_SECRET: "${JWT_SECRET:-}"
       JWT_EXPIRY_SECONDS: "${JWT_EXPIRY_SECONDS:-86400}"
       DEFAULT_JITSI_ROOM: "${DEFAULT_JITSI_ROOM:-eventyay-stage-room}"

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -1,0 +1,174 @@
+# Admin & User Guide — Eventyay Interpretation Portal
+
+## Quick Start
+
+### 1. Set the admin password
+
+```bash
+# In .env or as environment variable
+ADMIN_PASSWORD=your-secure-password
+```
+
+### 2. Start the portal
+
+```bash
+# Docker (recommended)
+docker compose up --build
+
+# Or native
+uv run uvicorn fastapi_app:app --host 127.0.0.1 --port 8000 --reload
+```
+
+### 3. Access the admin panel
+
+1. Open http://localhost:8000/admin/login
+2. Enter the `ADMIN_PASSWORD` you set
+3. You're in the dashboard
+
+---
+
+## Admin Panel Guide
+
+### Dashboard (`/admin/`)
+
+Shows all events with live booth status and MediaMTX health indicator.
+
+### Creating an Event
+
+1. Go to **Events** → fill in slug (URL-safe, e.g. `pycon2026`) and display name
+2. Click **Create Event**
+3. Open the event to add rooms and booths
+
+### Creating Rooms
+
+1. Open an event → click **Rooms**
+2. Enter room name → **Add Room**
+
+### Creating Booths
+
+1. Open a room → click **Booths**
+2. Enter language code (2-letter ISO 639-1, e.g. `en`, `fr`, `es`) and language name
+3. Click **Add Booth**
+
+### Booth Detail Page
+
+Each booth detail page shows:
+- **Interpreter Page URL** — share this with interpreters
+- **WHEP Listener URL** — for attendees (copy button provided)
+- **MediaMTX Stream Path** — internal MediaMTX identifier
+- **Live Status** — whether an interpreter is currently broadcasting
+- **Active Interpreter** — who is currently live
+- **Participant Roster** — all connected users with roles
+- **Invite Tokens** — manage booth access tokens
+
+---
+
+## User Registration
+
+### How users register
+
+1. Visit http://localhost:8000/register
+2. Fill in email, display name, password (min 8 characters)
+3. Account is created with **listener** role
+4. Redirected to account page
+
+### What listeners can do
+
+- Browse events on the home page
+- Listen to live interpretation streams via WebRTC (WHEP)
+- View their account info at `/account`
+
+### What listeners cannot do
+
+- Access the admin panel
+- Go live as an interpreter
+- Manage booths or events
+- Self-assign higher roles
+
+---
+
+## Role Management
+
+### Available roles (ordered by privilege)
+
+| Role | Permissions |
+|------|-------------|
+| `listener` | View booths, listen to streams, send chat messages |
+| `interpreter` | All listener permissions + go live (publish audio via WHIP) |
+| `coordinator` | All listener permissions + assign active interpreter, manage handoffs |
+| `event_admin` | All coordinator permissions + manage booths and generate invite tokens |
+| `super_admin` | Full access to everything |
+
+### Promoting a user
+
+1. Log in to admin panel → go to **Users** (`/admin/users/`)
+2. Find the user in the table
+3. Use the **Role** dropdown to select the new role → auto-saves
+4. The user's permissions update on their next page load
+
+### Deactivating a user
+
+1. Go to `/admin/users/`
+2. Click **Deactivate** next to the user
+3. The user can no longer log in
+4. Click **Activate** to re-enable
+
+### Deleting a user
+
+1. Go to `/admin/users/`
+2. Click **Delete** → confirm in the dialog
+3. This is permanent and cannot be undone
+
+---
+
+## Typical Workflow for an Event
+
+### Before the event
+
+1. **Admin** creates event, rooms, and booths in the admin panel
+2. **Admin** promotes registered users to `interpreter` or `coordinator` roles
+3. **Admin** optionally generates invite tokens for booth access
+4. **Admin** shares interpreter page URLs with interpreters
+
+### During the event
+
+1. **Interpreters** open their booth URL, join, and go live
+2. **Listeners** visit the home page, find their event, and click "Listen"
+3. **Coordinators** manage interpreter handoffs within booths
+4. **Admin** monitors live status from the dashboard
+
+### After the event
+
+1. Booths stop automatically when interpreters disconnect
+2. Admin can delete events/rooms/booths to clean up
+3. User accounts persist for future events
+
+---
+
+## Environment Variables Reference
+
+| Variable | Default | Required | Purpose |
+|----------|---------|----------|---------|
+| `ADMIN_PASSWORD` | *(empty)* | Yes (for admin access) | Password for admin panel login |
+| `SECRET_KEY` | `change-me` | Yes (production) | JWT signing key — use 64+ random chars |
+| `DATABASE_URL` | `sqlite+aiosqlite:///./interpretation.db` | No | Database connection string |
+| `MEDIAMTX_WHIP_BASE` | `http://localhost:8889` | No | Browser-facing WHIP/WHEP URL |
+| `MEDIAMTX_HLS_BASE` | `http://localhost:8888` | No | Browser-facing HLS URL |
+| `JITSI_DOMAIN` | `localhost:8080` | No | Jitsi Meet domain |
+
+---
+
+## Database Commands
+
+```bash
+# Apply all migrations (creates tables)
+alembic upgrade head
+
+# Check current migration version
+alembic current
+
+# After adding/changing models, generate a new migration
+alembic revision --autogenerate -m "describe the change"
+```
+
+In Docker, migrations run automatically on container startup.

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -59,7 +59,24 @@ Each booth detail page shows:
 - **Live Status** — whether an interpreter is currently broadcasting
 - **Active Interpreter** — who is currently live
 - **Participant Roster** — all connected users with roles
-- **Invite Tokens** — manage booth access tokens
+- **Invite Tokens** — generate, copy, and revoke booth access tokens
+
+### Token Management (on Booth Detail Page)
+
+1. Open a booth detail page
+2. In the **Invite Tokens** section, fill in:
+   - **Role** — listener, interpreter, or coordinator
+   - **Label** — a human-readable label (e.g. "Alice — Spanish interpreter")
+   - **Expires in (hours)** — optional; leave empty for tokens that never expire
+3. Click **Generate Token**
+4. The new token appears in the table below with a **Copy Link** button
+5. Share the invite link with the intended participant
+
+#### Revoking a token
+
+- Click **Revoke** next to any active token
+- Revoked tokens are marked and cannot be used to join the booth
+- This action cannot be undone
 
 ---
 
@@ -69,55 +86,56 @@ Each booth detail page shows:
 
 1. Visit http://localhost:8000/register
 2. Fill in email, display name, password (min 8 characters)
-3. Account is created with **listener** role
+3. Account is created (non-admin, active)
 4. Redirected to account page
 
-### What listeners can do
+### What new users can do
 
 - Browse events on the home page
-- Listen to live interpretation streams via WebRTC (WHEP)
 - View their account info at `/account`
+- See which events they have roles for
 
-### What listeners cannot do
+### What new users cannot do
 
 - Access the admin panel
-- Go live as an interpreter
+- Go live as an interpreter (until assigned an interpreter role for an event)
 - Manage booths or events
-- Self-assign higher roles
 
 ---
 
 ## Role Management
 
-### Available roles (ordered by privilege)
+### Event-scoped roles
 
-| Role | Permissions |
-|------|-------------|
-| `listener` | View booths, listen to streams, send chat messages |
-| `interpreter` | All listener permissions + go live (publish audio via WHIP) |
-| `coordinator` | All listener permissions + assign active interpreter, manage handoffs |
-| `event_admin` | All coordinator permissions + manage booths and generate invite tokens |
-| `super_admin` | Full access to everything |
+Roles are assigned **per event**, not globally. A user can be an `interpreter` for one event and a `listener` for another.
 
-### Promoting a user
+| Role | Scope | Permissions |
+|------|-------|-------------|
+| `listener` | Event | View booths, listen to streams, send chat messages |
+| `interpreter` | Event | All listener permissions + go live (publish audio via WHIP) |
+| `coordinator` | Event | All listener permissions + assign active interpreter, manage handoffs |
+| `event_admin` | Event | All coordinator permissions + manage booths and generate invite tokens |
 
-1. Log in to admin panel → go to **Users** (`/admin/users/`)
-2. Find the user in the table
-3. Use the **Role** dropdown to select the new role → auto-saves
-4. The user's permissions update on their next page load
+### Assigning event roles
 
-### Deactivating a user
+1. Log in to admin panel → open an **Event** detail page
+2. Click **Manage Members**
+3. Select a registered user from the dropdown
+4. Choose a role → click **Assign Role**
+5. If the user already has a role for this event, it is updated
 
-1. Go to `/admin/users/`
-2. Click **Deactivate** next to the user
-3. The user can no longer log in
-4. Click **Activate** to re-enable
+### Removing an event role
 
-### Deleting a user
+1. Go to the event's **Members** page
+2. Click **Remove** next to the membership
 
-1. Go to `/admin/users/`
-2. Click **Delete** → confirm in the dialog
-3. This is permanent and cannot be undone
+### User admin flags
+
+The **Users** page (`/admin/users/`) shows all registered users with:
+- **Admin** badge — whether the user has site-wide admin access
+- **Status** — active or deactivated
+- **Deactivate/Activate** — toggle login access
+- **Delete** — permanently remove the account
 
 ---
 
@@ -126,8 +144,8 @@ Each booth detail page shows:
 ### Before the event
 
 1. **Admin** creates event, rooms, and booths in the admin panel
-2. **Admin** promotes registered users to `interpreter` or `coordinator` roles
-3. **Admin** optionally generates invite tokens for booth access
+2. **Admin** assigns per-event roles from the event's **Members** page (e.g. interpreter, coordinator)
+3. **Admin** generates invite tokens on each booth detail page and shares links
 4. **Admin** shares interpreter page URLs with interpreters
 
 ### During the event

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -120,9 +120,9 @@ Roles are assigned **per event**, not globally. A user can be an `interpreter` f
 
 1. Log in to admin panel → open an **Event** detail page
 2. Click **Manage Members**
-3. Select a registered user from the dropdown
-4. Choose a role → click **Assign Role**
-5. If the user already has a role for this event, it is updated
+3. Find the user in the table
+4. Choose a role from the **Event Role** dropdown (auto-saves on change)
+5. Select "— none —" to remove the role
 
 ### Removing an event role
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -121,9 +121,8 @@ Roles are assigned **per event**, not globally. A user can be an `interpreter` f
 
 1. Log in to admin panel → open an **Event** detail page
 2. Click **Manage Members**
-3. Find the user in the table
-4. Choose a role from the **Event Role** dropdown (auto-saves on change)
-5. Select "— none —" to remove the role
+3. Enter the user's registered email address in the **Assign Event Admin** form
+4. Click **Assign Role**
 
 ### Assigning booth roles (Interpreter assignments)
 
@@ -131,13 +130,15 @@ For stricter access control, you can assign an interpreter to a *specific booth*
 
 1. Go to an event's **Rooms** → **Booths** and open a specific booth
 2. Scroll to **Assigned Members**
-3. Select `interpreter` next to the user's name
-4. When the interpreter logs in, they will see an "Open Booth" button on their home dashboard directly to this booth
+3. Under **Assign Member**, enter the user's registered email address
+4. Select `interpreter` from the Role dropdown
+5. Click **Assign Member**
+6. When the interpreter logs in, they will see an "Open Booth" button on their home dashboard directly to this booth
 
 ### Removing a role
 
 1. Go to the event's or booth's **Members** section
-2. Click **Remove** next to the membership
+2. Click **Remove** next to the user's name
 
 ### User admin flags
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -59,6 +59,7 @@ Each booth detail page shows:
 - **Live Status** — whether an interpreter is currently broadcasting
 - **Active Interpreter** — who is currently live
 - **Participant Roster** — all connected users with roles
+- **Assigned Members** — assign registered users directly to this booth
 - **Invite Tokens** — generate, copy, and revoke booth access tokens
 
 ### Token Management (on Booth Detail Page)
@@ -111,9 +112,9 @@ Roles are assigned **per event**, not globally. A user can be an `interpreter` f
 
 | Role | Scope | Permissions |
 |------|-------|-------------|
-| `listener` | Event | View booths, listen to streams, send chat messages |
-| `interpreter` | Event | All listener permissions + go live (publish audio via WHIP) |
-| `coordinator` | Event | All listener permissions + assign active interpreter, manage handoffs |
+| `listener` | Booth / Event | View booths, listen to streams, send chat messages |
+| `interpreter` | Booth / Event | All listener permissions + go live (publish audio via WHIP) |
+| `coordinator` | Booth / Event | All listener permissions + assign active interpreter, manage handoffs + go live |
 | `event_admin` | Event | All coordinator permissions + manage booths and generate invite tokens |
 
 ### Assigning event roles
@@ -124,9 +125,18 @@ Roles are assigned **per event**, not globally. A user can be an `interpreter` f
 4. Choose a role from the **Event Role** dropdown (auto-saves on change)
 5. Select "— none —" to remove the role
 
-### Removing an event role
+### Assigning booth roles (Interpreter assignments)
 
-1. Go to the event's **Members** page
+For stricter access control, you can assign an interpreter to a *specific booth* rather than the whole event:
+
+1. Go to an event's **Rooms** → **Booths** and open a specific booth
+2. Scroll to **Assigned Members**
+3. Select `interpreter` next to the user's name
+4. When the interpreter logs in, they will see an "Open Booth" button on their home dashboard directly to this booth
+
+### Removing a role
+
+1. Go to the event's or booth's **Members** section
 2. Click **Remove** next to the membership
 
 ### User admin flags

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -57,6 +57,8 @@ class Session:
     participant_id: str | None
     language: str
     channel_id: str
+    # Role derived from the bearer cookie at WS connection time — never from client data.
+    granted_role: str | None = None
 
 
 class ConnectionManager:
@@ -642,14 +644,12 @@ async def _handle_join(ws: WebSocket, session: Session, data: dict) -> None:
     channel_id = data.get('channel_id', f'{session.booth_id}-audio')
     participant_id = data.get('participant_id')
 
-    # Role enforcement: the client supplies what role they want, but we check
-    # their granted_role from the JWT (passed through the page data-attribute
-    # and echoed back here). If they try to claim a higher role, reject it.
-    granted_role = data.get('granted_role')
-    if granted_role is not None and not can_perform_role(granted_role, role):
+    # Role enforcement: use the server-derived granted_role stored on the session
+    # (populated from cookies at WS connect time). Never trust data['granted_role'].
+    if session.granted_role is not None and not can_perform_role(session.granted_role, role):
         await ws.send_text(json.dumps({
             'type': 'booth:error',
-            'message': f'Your assigned role ({granted_role}) does not permit joining as {role}.',
+            'message': f'Your assigned role ({session.granted_role}) does not permit joining as {role}.',
         }))
         return
 
@@ -1372,12 +1372,31 @@ async def ws_booth(websocket: WebSocket, booth_id: str) -> None:
     except ValueError:
         return
 
+    # Derive granted_role from cookies at connect time — never trust client data.
+    ws_cookies = websocket.cookies
+    ws_session_payload: dict | None = None
+    for cookie_name in ('session_token', 'user_token'):
+        raw = ws_cookies.get(cookie_name, '')
+        if not raw:
+            continue
+        try:
+            import jwt as _pyjwt
+            ws_session_payload = _pyjwt.decode(
+                raw, settings.effective_jwt_secret, algorithms=['HS256'],
+            )
+            break
+        except Exception:
+            continue
+
+    ws_granted_role = resolve_booth_role(ws_session_payload)
+
     await websocket.accept()
     session = Session(
         booth_id=booth_id,
         participant_id=None,
         language='English',
         channel_id=f'{booth_id}-audio',
+        granted_role=ws_granted_role,
     )
     manager.add(websocket, session)
 

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -21,7 +21,11 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
-from portal.auth import create_participant_token, create_token, decode_token, security, verify_ws_token
+from portal.auth import (
+    create_admin_token, create_participant_token, create_token, create_user_token,
+    decode_token, get_current_user, hash_password, require_admin, require_user,
+    security, verify_password, verify_ws_token,
+)
 from portal.booth_identity import make_booth_id, make_mediamtx_path
 from portal.booth_state import BoothRegistry
 from portal.config import settings
@@ -272,8 +276,33 @@ async def join_via_invite(token: str) -> RedirectResponse:
 # ── Page routes ───────────────────────────────────────────────────────────────
 
 @app.get('/')
-async def home() -> RedirectResponse:
-    return RedirectResponse('/interpreter/demo-booth')
+async def home(request: Request):
+    from portal.database import get_session, list_events, list_booths_for_event
+
+    try:
+        async with get_session() as session:
+            events = await list_events(session)
+            event_data = []
+            for ev in events:
+                db_booths = await list_booths_for_event(session, ev.id)
+                booth_statuses = []
+                for b in db_booths:
+                    bid = make_booth_id(ev.slug, b.language_code)
+                    mem_booth = booths.get_booth_sync(bid)
+                    is_live = mem_booth is not None and mem_booth.ingest_status == 'connected'
+                    booth_statuses.append({'db': b, 'booth_id': bid, 'is_live': is_live})
+                event_data.append({
+                    'event': ev,
+                    'booths': booth_statuses,
+                    'live_count': sum(1 for bs in booth_statuses if bs['is_live']),
+                })
+    except Exception:
+        event_data = []
+
+    return templates.TemplateResponse(request, 'home.html', {
+        'events': event_data,
+        'current_user': await get_current_user(request),
+    })
 
 
 @app.get('/healthz')
@@ -656,6 +685,507 @@ async def _handle_update_state(ws: WebSocket, session: Session, data: dict) -> N
         await ws.send_text(json.dumps({'type': 'booth:error', 'message': str(exc)}))
         return
     await manager.broadcast(session.booth_id, {'type': 'booth:state', 'state': state})
+
+
+# ── User registration & login routes ─────────────────────────────────────────
+
+
+@app.get('/register')
+async def register_page(request: Request):
+    current_user = await get_current_user(request)
+    if current_user:
+        return RedirectResponse(url='/account', status_code=status.HTTP_303_SEE_OTHER)
+    return templates.TemplateResponse(request, 'register.html', {})
+
+
+@app.post('/register')
+async def register_submit(request: Request):
+    from portal.database import create_user, get_session, get_user_by_email
+
+    form = await request.form()
+    email = form.get('email', '').strip().lower()
+    display_name = form.get('display_name', '').strip()
+    password = form.get('password', '')
+    password_confirm = form.get('password_confirm', '')
+
+    errors = []
+    if not email or '@' not in email:
+        errors.append('Valid email is required.')
+    if not display_name:
+        errors.append('Display name is required.')
+    if len(password) < 8:
+        errors.append('Password must be at least 8 characters.')
+    if password != password_confirm:
+        errors.append('Passwords do not match.')
+
+    if not errors:
+        async with get_session() as session:
+            existing = await get_user_by_email(session, email)
+            if existing:
+                errors.append('An account with this email already exists.')
+            else:
+                pw_hash = hash_password(password)
+                user = await create_user(
+                    session, email=email, display_name=display_name,
+                    password_hash=pw_hash,
+                )
+                token = create_user_token(user_id=user.id, email=user.email, role=user.role)
+                response = RedirectResponse(url='/account', status_code=status.HTTP_303_SEE_OTHER)
+                response.set_cookie(
+                    key='user_token', value=token,
+                    httponly=True, samesite='lax', max_age=settings.jwt_expiry_seconds,
+                )
+                return response
+
+    return templates.TemplateResponse(
+        request, 'register.html',
+        {'errors': errors, 'email': email, 'display_name': display_name},
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+    )
+
+
+@app.get('/login')
+async def user_login_page(request: Request):
+    current_user = await get_current_user(request)
+    if current_user:
+        return RedirectResponse(url='/account', status_code=status.HTTP_303_SEE_OTHER)
+    return templates.TemplateResponse(request, 'login.html', {})
+
+
+@app.post('/login')
+async def user_login_submit(request: Request):
+    from portal.database import get_session, get_user_by_email
+
+    form = await request.form()
+    email = form.get('email', '').strip().lower()
+    password = form.get('password', '')
+
+    async with get_session() as session:
+        user = await get_user_by_email(session, email)
+
+    if user is None or not verify_password(password, user.password_hash):
+        return templates.TemplateResponse(
+            request, 'login.html',
+            {'error': 'Invalid email or password.', 'email': email},
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+    if not user.is_active:
+        return templates.TemplateResponse(
+            request, 'login.html',
+            {'error': 'Your account has been deactivated. Contact an admin.', 'email': email},
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+
+    token = create_user_token(user_id=user.id, email=user.email, role=user.role)
+    response = RedirectResponse(url='/account', status_code=status.HTTP_303_SEE_OTHER)
+    response.set_cookie(
+        key='user_token', value=token,
+        httponly=True, samesite='lax', max_age=settings.jwt_expiry_seconds,
+    )
+    return response
+
+
+@app.get('/logout')
+async def user_logout(request: Request):
+    response = RedirectResponse(url='/', status_code=status.HTTP_303_SEE_OTHER)
+    response.delete_cookie('user_token')
+    return response
+
+
+@app.get('/account')
+async def account_page(request: Request):
+    from portal.database import get_session, get_user_by_id
+
+    current_user = await get_current_user(request)
+    if current_user is None:
+        return RedirectResponse(url='/login', status_code=status.HTTP_303_SEE_OTHER)
+
+    async with get_session() as session:
+        user = await get_user_by_id(session, int(current_user['sub']))
+
+    if user is None:
+        response = RedirectResponse(url='/login', status_code=status.HTTP_303_SEE_OTHER)
+        response.delete_cookie('user_token')
+        return response
+
+    return templates.TemplateResponse(request, 'account.html', {'user': user})
+
+
+# ── Admin panel routes ────────────────────────────────────────────────────────
+
+
+@app.get('/admin/login')
+async def admin_login_page(request: Request):
+    return templates.TemplateResponse(request, 'admin/login.html', {})
+
+
+@app.post('/admin/login')
+async def admin_login_submit(request: Request):
+    form = await request.form()
+    password = form.get('password', '')
+    if not settings.admin_password or password != settings.admin_password:
+        return templates.TemplateResponse(
+            request,
+            'admin/login.html',
+            {'error': 'Invalid password.'},
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+    token = create_admin_token()
+    response = RedirectResponse(url='/admin/', status_code=status.HTTP_303_SEE_OTHER)
+    response.set_cookie(
+        key='admin_token', value=token,
+        httponly=True, samesite='lax', max_age=settings.jwt_expiry_seconds,
+    )
+    return response
+
+
+@app.get('/admin/logout')
+async def admin_logout():
+    response = RedirectResponse(url='/admin/login', status_code=status.HTTP_303_SEE_OTHER)
+    response.delete_cookie('admin_token')
+    return response
+
+
+@app.get('/admin/', dependencies=[Depends(require_admin)])
+async def admin_dashboard(request: Request):
+    from portal.database import get_session, list_events, list_booths_for_event
+
+    async with get_session() as session:
+        events = await list_events(session)
+        event_data = []
+        for ev in events:
+            db_booths = await list_booths_for_event(session, ev.id)
+            booth_statuses = []
+            for b in db_booths:
+                booth_id = make_booth_id(ev.slug, b.language_code)
+                mem_booth = booths.get_booth_sync(booth_id)
+                is_live = (
+                    mem_booth is not None
+                    and mem_booth.ingest_status == 'connected'
+                )
+                booth_statuses.append({
+                    'db': b,
+                    'booth_id': booth_id,
+                    'is_live': is_live,
+                })
+            event_data.append({
+                'event': ev,
+                'booths': booth_statuses,
+                'live_count': sum(1 for bs in booth_statuses if bs['is_live']),
+                'total_booths': len(booth_statuses),
+            })
+
+    mediamtx_ok = await _check_mediamtx()
+    return templates.TemplateResponse(request, 'admin/dashboard.html', {
+        'event_data': event_data,
+        'mediamtx_ok': mediamtx_ok,
+    })
+
+
+@app.get('/admin/events/', dependencies=[Depends(require_admin)])
+async def admin_event_list(request: Request):
+    from portal.database import get_session, list_events
+
+    async with get_session() as session:
+        events = await list_events(session)
+    return templates.TemplateResponse(request, 'admin/event_list.html', {
+        'events': events,
+    })
+
+
+@app.post('/admin/events/', dependencies=[Depends(require_admin)])
+async def admin_create_event(request: Request):
+    from portal.database import get_session, create_event
+
+    form = await request.form()
+    slug = form.get('slug', '').strip()
+    display_name = form.get('display_name', '').strip()
+    if not slug or not display_name:
+        return RedirectResponse(url='/admin/events/', status_code=status.HTTP_303_SEE_OTHER)
+    try:
+        async with get_session() as session:
+            await create_event(session, slug=slug, display_name=display_name)
+    except Exception:
+        return RedirectResponse(url='/admin/events/', status_code=status.HTTP_303_SEE_OTHER)
+    return RedirectResponse(url='/admin/events/', status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.get('/admin/events/{event_id}/', dependencies=[Depends(require_admin)])
+async def admin_event_detail(request: Request, event_id: int):
+    from portal.database import (
+        get_session, get_event_by_id, list_rooms_for_event, list_booths_for_event,
+    )
+
+    async with get_session() as session:
+        event = await get_event_by_id(session, event_id)
+        if event is None:
+            raise HTTPException(status_code=404, detail='Event not found.')
+        rooms = await list_rooms_for_event(session, event_id)
+        db_booths = await list_booths_for_event(session, event_id)
+
+    booth_statuses = []
+    for b in db_booths:
+        bid = make_booth_id(event.slug, b.language_code)
+        mem_booth = booths.get_booth_sync(bid)
+        is_live = mem_booth is not None and mem_booth.ingest_status == 'connected'
+        booth_statuses.append({'db': b, 'booth_id': bid, 'is_live': is_live})
+
+    return templates.TemplateResponse(request, 'admin/event_detail.html', {
+        'event': event,
+        'rooms': rooms,
+        'booths': booth_statuses,
+        'live_count': sum(1 for bs in booth_statuses if bs['is_live']),
+    })
+
+
+@app.post('/admin/events/{event_id}/delete', dependencies=[Depends(require_admin)])
+async def admin_delete_event(request: Request, event_id: int):
+    from portal.database import get_session, delete_event
+
+    async with get_session() as session:
+        await delete_event(session, event_id)
+    return RedirectResponse(url='/admin/events/', status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.get('/admin/events/{event_id}/rooms/', dependencies=[Depends(require_admin)])
+async def admin_room_list(request: Request, event_id: int):
+    from portal.database import (
+        get_session, get_event_by_id, list_rooms_for_event, list_booths_for_room,
+    )
+
+    async with get_session() as session:
+        event = await get_event_by_id(session, event_id)
+        if event is None:
+            raise HTTPException(status_code=404, detail='Event not found.')
+        rooms = await list_rooms_for_event(session, event_id)
+        room_data = []
+        for room in rooms:
+            room_booths = await list_booths_for_room(session, room.id)
+            room_data.append({'room': room, 'booth_count': len(room_booths)})
+    return templates.TemplateResponse(request, 'admin/room_list.html', {
+        'event': event,
+        'room_data': room_data,
+    })
+
+
+@app.post('/admin/events/{event_id}/rooms/', dependencies=[Depends(require_admin)])
+async def admin_create_room(request: Request, event_id: int):
+    from portal.database import get_session, create_room
+
+    form = await request.form()
+    display_name = form.get('display_name', '').strip()
+    if not display_name:
+        return RedirectResponse(
+            url=f'/admin/events/{event_id}/rooms/',
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+    async with get_session() as session:
+        await create_room(session, event_id=event_id, display_name=display_name)
+    return RedirectResponse(
+        url=f'/admin/events/{event_id}/rooms/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@app.get('/admin/events/{event_id}/rooms/{room_id}/', dependencies=[Depends(require_admin)])
+async def admin_room_detail(request: Request, event_id: int, room_id: int):
+    from portal.database import (
+        get_session, get_event_by_id, get_room_by_id, list_booths_for_room,
+    )
+
+    async with get_session() as session:
+        event = await get_event_by_id(session, event_id)
+        if event is None:
+            raise HTTPException(status_code=404, detail='Event not found.')
+        room = await get_room_by_id(session, room_id)
+        if room is None or room.event_id != event_id:
+            raise HTTPException(status_code=404, detail='Room not found.')
+        db_booths = await list_booths_for_room(session, room_id)
+
+    booth_statuses = []
+    for b in db_booths:
+        bid = make_booth_id(event.slug, b.language_code)
+        mem_booth = booths.get_booth_sync(bid)
+        is_live = mem_booth is not None and mem_booth.ingest_status == 'connected'
+        booth_statuses.append({'db': b, 'booth_id': bid, 'is_live': is_live})
+
+    return templates.TemplateResponse(request, 'admin/room_detail.html', {
+        'event': event,
+        'room': room,
+        'booths': booth_statuses,
+    })
+
+
+@app.post('/admin/events/{event_id}/rooms/{room_id}/delete', dependencies=[Depends(require_admin)])
+async def admin_delete_room(request: Request, event_id: int, room_id: int):
+    from portal.database import get_session, delete_room
+
+    async with get_session() as session:
+        await delete_room(session, room_id)
+    return RedirectResponse(
+        url=f'/admin/events/{event_id}/rooms/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@app.get('/admin/events/{event_id}/rooms/{room_id}/booths/', dependencies=[Depends(require_admin)])
+async def admin_booth_list(request: Request, event_id: int, room_id: int):
+    from portal.database import (
+        get_session, get_event_by_id, get_room_by_id, list_booths_for_room,
+    )
+
+    async with get_session() as session:
+        event = await get_event_by_id(session, event_id)
+        if event is None:
+            raise HTTPException(status_code=404, detail='Event not found.')
+        room = await get_room_by_id(session, room_id)
+        if room is None or room.event_id != event_id:
+            raise HTTPException(status_code=404, detail='Room not found.')
+        db_booths = await list_booths_for_room(session, room_id)
+
+    booth_statuses = []
+    for b in db_booths:
+        bid = make_booth_id(event.slug, b.language_code)
+        mem_booth = booths.get_booth_sync(bid)
+        is_live = mem_booth is not None and mem_booth.ingest_status == 'connected'
+        booth_statuses.append({'db': b, 'booth_id': bid, 'is_live': is_live})
+
+    return templates.TemplateResponse(request, 'admin/booth_list.html', {
+        'event': event,
+        'room': room,
+        'booths': booth_statuses,
+    })
+
+
+@app.post('/admin/events/{event_id}/rooms/{room_id}/booths/', dependencies=[Depends(require_admin)])
+async def admin_create_booth(request: Request, event_id: int, room_id: int):
+    from portal.database import get_session, create_booth
+
+    form = await request.form()
+    language_code = form.get('language_code', '').strip().lower()
+    language_name = form.get('language_name', '').strip()
+    if not language_code or not language_name:
+        return RedirectResponse(
+            url=f'/admin/events/{event_id}/rooms/{room_id}/booths/',
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+    try:
+        async with get_session() as session:
+            await create_booth(
+                session, event_id=event_id, room_id=room_id,
+                language_code=language_code, language_name=language_name,
+            )
+    except Exception:
+        pass
+    return RedirectResponse(
+        url=f'/admin/events/{event_id}/rooms/{room_id}/booths/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@app.get(
+    '/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/',
+    dependencies=[Depends(require_admin)],
+)
+async def admin_booth_detail(request: Request, event_id: int, room_id: int, booth_id: int):
+    from portal.database import (
+        get_session, get_event_by_id, get_room_by_id, get_booth_by_id,
+        list_tokens_for_booth,
+    )
+
+    async with get_session() as session:
+        event = await get_event_by_id(session, event_id)
+        if event is None:
+            raise HTTPException(status_code=404, detail='Event not found.')
+        room = await get_room_by_id(session, room_id)
+        if room is None or room.event_id != event_id:
+            raise HTTPException(status_code=404, detail='Room not found.')
+        db_booth = await get_booth_by_id(session, booth_id)
+        if db_booth is None or db_booth.room_id != room_id:
+            raise HTTPException(status_code=404, detail='Booth not found.')
+        tokens = await list_tokens_for_booth(session, booth_id)
+
+    bid = make_booth_id(event.slug, db_booth.language_code)
+    mediamtx_path = make_mediamtx_path(event.slug, db_booth.language_code)
+    whep_url = f'{settings.mediamtx_whip_base}/{mediamtx_path}/whep'
+    mem_booth = booths.get_booth_sync(bid)
+    is_live = mem_booth is not None and mem_booth.ingest_status == 'connected'
+    participants = list(mem_booth.participants.values()) if mem_booth else []
+    active_interpreter = None
+    if mem_booth and mem_booth.active_interpreter_id:
+        active_interpreter = mem_booth.participants.get(mem_booth.active_interpreter_id)
+
+    return templates.TemplateResponse(request, 'admin/booth_detail.html', {
+        'event': event,
+        'room': room,
+        'booth': db_booth,
+        'booth_id': bid,
+        'mediamtx_path': mediamtx_path,
+        'whep_url': whep_url,
+        'is_live': is_live,
+        'participants': participants,
+        'active_interpreter': active_interpreter,
+        'tokens': tokens,
+    })
+
+
+@app.post(
+    '/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/delete',
+    dependencies=[Depends(require_admin)],
+)
+async def admin_delete_booth(request: Request, event_id: int, room_id: int, booth_id: int):
+    from portal.database import get_session, delete_booth
+
+    async with get_session() as session:
+        await delete_booth(session, booth_id)
+    return RedirectResponse(
+        url=f'/admin/events/{event_id}/rooms/{room_id}/booths/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+# ── Admin user management routes ─────────────────────────────────────────────
+
+
+@app.get('/admin/users/', dependencies=[Depends(require_admin)])
+async def admin_user_list(request: Request):
+    from portal.database import get_session, list_users
+
+    async with get_session() as session:
+        users = await list_users(session)
+    return templates.TemplateResponse(request, 'admin/user_list.html', {'users': users})
+
+
+@app.post('/admin/users/{user_id}/role', dependencies=[Depends(require_admin)])
+async def admin_update_user_role(request: Request, user_id: int):
+    from portal.database import get_session, update_user_role
+
+    form = await request.form()
+    role = form.get('role', '').strip()
+    if role:
+        async with get_session() as session:
+            await update_user_role(session, user_id, role)
+    return RedirectResponse(url='/admin/users/', status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post('/admin/users/{user_id}/toggle-active', dependencies=[Depends(require_admin)])
+async def admin_toggle_user_active(request: Request, user_id: int):
+    from portal.database import get_session, get_user_by_id, update_user_active
+
+    async with get_session() as session:
+        user = await get_user_by_id(session, user_id)
+        if user:
+            await update_user_active(session, user_id, is_active=not user.is_active)
+    return RedirectResponse(url='/admin/users/', status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post('/admin/users/{user_id}/delete', dependencies=[Depends(require_admin)])
+async def admin_delete_user(request: Request, user_id: int):
+    from portal.database import get_session, delete_user
+
+    async with get_session() as session:
+        await delete_user(session, user_id)
+    return RedirectResponse(url='/admin/users/', status_code=status.HTTP_303_SEE_OTHER)
 
 
 # ── WebSocket endpoint ────────────────────────────────────────────────────────

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -729,7 +729,7 @@ async def register_submit(request: Request):
                     session, email=email, display_name=display_name,
                     password_hash=pw_hash,
                 )
-                token = create_user_token(user_id=user.id, email=user.email, role=user.role)
+                token = create_user_token(user_id=user.id, email=user.email, is_admin=user.is_admin)
                 response = RedirectResponse(url='/account', status_code=status.HTTP_303_SEE_OTHER)
                 response.set_cookie(
                     key='user_token', value=token,
@@ -776,7 +776,7 @@ async def user_login_submit(request: Request):
             status_code=status.HTTP_403_FORBIDDEN,
         )
 
-    token = create_user_token(user_id=user.id, email=user.email, role=user.role)
+    token = create_user_token(user_id=user.id, email=user.email, is_admin=user.is_admin)
     response = RedirectResponse(url='/account', status_code=status.HTTP_303_SEE_OTHER)
     response.set_cookie(
         key='user_token', value=token,
@@ -794,7 +794,7 @@ async def user_logout(request: Request):
 
 @app.get('/account')
 async def account_page(request: Request):
-    from portal.database import get_session, get_user_by_id
+    from portal.database import get_session, get_user_by_id, list_memberships_for_user
 
     current_user = await get_current_user(request)
     if current_user is None:
@@ -802,13 +802,13 @@ async def account_page(request: Request):
 
     async with get_session() as session:
         user = await get_user_by_id(session, int(current_user['sub']))
+        if user is None:
+            response = RedirectResponse(url='/login', status_code=status.HTTP_303_SEE_OTHER)
+            response.delete_cookie('user_token')
+            return response
+        memberships = await list_memberships_for_user(session, user.id)
 
-    if user is None:
-        response = RedirectResponse(url='/login', status_code=status.HTTP_303_SEE_OTHER)
-        response.delete_cookie('user_token')
-        return response
-
-    return templates.TemplateResponse(request, 'account.html', {'user': user})
+    return templates.TemplateResponse(request, 'account.html', {'user': user, 'memberships': memberships})
 
 
 # ── Admin panel routes ────────────────────────────────────────────────────────
@@ -1156,18 +1156,6 @@ async def admin_user_list(request: Request):
     return templates.TemplateResponse(request, 'admin/user_list.html', {'users': users})
 
 
-@app.post('/admin/users/{user_id}/role', dependencies=[Depends(require_admin)])
-async def admin_update_user_role(request: Request, user_id: int):
-    from portal.database import get_session, update_user_role
-
-    form = await request.form()
-    role = form.get('role', '').strip()
-    if role:
-        async with get_session() as session:
-            await update_user_role(session, user_id, role)
-    return RedirectResponse(url='/admin/users/', status_code=status.HTTP_303_SEE_OTHER)
-
-
 @app.post('/admin/users/{user_id}/toggle-active', dependencies=[Depends(require_admin)])
 async def admin_toggle_user_active(request: Request, user_id: int):
     from portal.database import get_session, get_user_by_id, update_user_active
@@ -1186,6 +1174,121 @@ async def admin_delete_user(request: Request, user_id: int):
     async with get_session() as session:
         await delete_user(session, user_id)
     return RedirectResponse(url='/admin/users/', status_code=status.HTTP_303_SEE_OTHER)
+
+
+# ── Admin event membership routes ────────────────────────────────────────────
+
+
+@app.get('/admin/events/{event_id}/members/', dependencies=[Depends(require_admin)])
+async def admin_event_members(request: Request, event_id: int):
+    from portal.database import get_session, get_event_by_id, list_memberships_for_event, list_users
+
+    async with get_session() as session:
+        event = await get_event_by_id(session, event_id)
+        if event is None:
+            raise HTTPException(status_code=404, detail='Event not found.')
+        memberships = await list_memberships_for_event(session, event_id)
+        users = await list_users(session)
+
+    # Build lookup: user_id → membership (role, id)
+    membership_map = {m.user_id: m for m in memberships}
+
+    return templates.TemplateResponse(request, 'admin/event_members.html', {
+        'event': event,
+        'memberships': memberships,
+        'membership_map': membership_map,
+        'users': users,
+    })
+
+
+@app.post('/admin/events/{event_id}/members/', dependencies=[Depends(require_admin)])
+async def admin_add_event_member(request: Request, event_id: int):
+    from portal.database import get_session, list_memberships_for_event, remove_event_membership, set_event_membership
+
+    form = await request.form()
+    user_id = form.get('user_id', '')
+    role = form.get('role', '').strip()
+    if user_id:
+        uid = int(user_id)
+        async with get_session() as session:
+            if role:
+                await set_event_membership(session, user_id=uid, event_id=event_id, role=role)
+            else:
+                # "— none —" selected: remove any existing membership
+                memberships = await list_memberships_for_event(session, event_id)
+                for m in memberships:
+                    if m.user_id == uid:
+                        await remove_event_membership(session, m.id)
+                        break
+    return RedirectResponse(
+        url=f'/admin/events/{event_id}/members/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@app.post('/admin/events/{event_id}/members/{membership_id}/delete', dependencies=[Depends(require_admin)])
+async def admin_remove_event_member(request: Request, event_id: int, membership_id: int):
+    from portal.database import get_session, remove_event_membership
+
+    async with get_session() as session:
+        await remove_event_membership(session, membership_id)
+    return RedirectResponse(
+        url=f'/admin/events/{event_id}/members/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+# ── Admin token management routes ────────────────────────────────────────────
+
+
+@app.post(
+    '/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/tokens/',
+    dependencies=[Depends(require_admin)],
+)
+async def admin_create_token(request: Request, event_id: int, room_id: int, booth_id: int):
+    from portal.database import create_invite_token, get_session
+
+    form = await request.form()
+    role = form.get('role', '').strip()
+    label = form.get('label', '').strip()
+    expires_hours = form.get('expires_hours', '').strip()
+
+    expires_at = None
+    if expires_hours:
+        from datetime import timedelta
+        from portal.models import utc_now
+        try:
+            expires_at = utc_now() + timedelta(hours=int(expires_hours))
+        except ValueError:
+            pass
+
+    if role:
+        async with get_session() as session:
+            await create_invite_token(
+                session, booth_id=booth_id, role=role, label=label,
+                expires_at=expires_at,
+            )
+
+    return RedirectResponse(
+        url=f'/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@app.post(
+    '/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/tokens/{token_id}/revoke',
+    dependencies=[Depends(require_admin)],
+)
+async def admin_revoke_token(request: Request, event_id: int, room_id: int, booth_id: int, token_id: str):
+    from portal.database import get_session, revoke_invite_token
+
+    async with get_session() as session:
+        await revoke_invite_token(session, token_id)
+
+    return RedirectResponse(
+        url=f'/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
 
 
 # ── WebSocket endpoint ────────────────────────────────────────────────────────

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -288,23 +288,16 @@ async def home(request: Request):
     try:
         async with get_session() as session:
             events = await list_events(session)
-            event_data = []
-            for ev in events:
-                db_booths = await list_booths_for_event(session, ev.id)
-                booth_statuses = []
-                for b in db_booths:
-                    bid = make_booth_id(ev.slug, b.language_code)
-                    mem_booth = booths.get_booth_sync(bid)
-                    is_live = mem_booth is not None and mem_booth.ingest_status == 'connected'
-                    booth_statuses.append({'db': b, 'booth_id': bid, 'is_live': is_live})
-                event_data.append({
-                    'event': ev,
-                    'booths': booth_statuses,
-                    'live_count': sum(1 for bs in booth_statuses if bs['is_live']),
-                })
             
+            user_event_roles = {}
+            user_booth_roles = {}
             if current_user:
-                bms = await list_booth_memberships_for_user(session, int(current_user['sub']))
+                uid = int(current_user['sub'])
+                ems = await list_memberships_for_user(session, uid)
+                user_event_roles = {em.event_id: em.role for em in ems}
+                
+                bms = await list_booth_memberships_for_user(session, uid)
+                user_booth_roles = {bm.booth_id: bm.role for bm in bms}
                 for bm in bms:
                     bid = make_booth_id(bm.booth.event.slug, bm.booth.language_code)
                     mem_booth = booths.get_booth_sync(bid)
@@ -318,6 +311,35 @@ async def home(request: Request):
                         'event_slug': bm.booth.event.slug,
                         'language_code': bm.booth.language_code,
                     })
+                    
+            event_data = []
+            for ev in events:
+                db_booths = await list_booths_for_event(session, ev.id)
+                booth_statuses = []
+                for b in db_booths:
+                    bid = make_booth_id(ev.slug, b.language_code)
+                    mem_booth = booths.get_booth_sync(bid)
+                    is_live = mem_booth is not None and mem_booth.ingest_status == 'connected'
+                    
+                    can_interpret = False
+                    if current_user:
+                        is_admin = current_user.get('is_admin', False)
+                        ev_role = user_event_roles.get(ev.id)
+                        booth_role = user_booth_roles.get(b.id)
+                        if is_admin or ev_role in ('interpreter', 'coordinator', 'event_admin') or booth_role in ('interpreter', 'coordinator'):
+                            can_interpret = True
+                            
+                    booth_statuses.append({
+                        'db': b, 
+                        'booth_id': bid, 
+                        'is_live': is_live,
+                        'can_interpret': can_interpret
+                    })
+                event_data.append({
+                    'event': ev,
+                    'booths': booth_statuses,
+                    'live_count': sum(1 for bs in booth_statuses if bs['is_live']),
+                })
     except Exception:
         event_data = []
 
@@ -444,7 +466,15 @@ async def interpreter_booth(
             detail='You do not have a role assigned. Ask an admin for an invite link.',
         )
 
-    channel_id = channel or f'{booth_id}-audio'
+    if channel:
+        channel_id = channel
+    else:
+        try:
+            from portal.booth_identity import booth_id_to_mediamtx_path
+            channel_id = booth_id_to_mediamtx_path(booth_id)
+        except ValueError:
+            channel_id = f'{booth_id}-audio'
+
     await _ensure_mediamtx_path(channel_id)
     return templates.TemplateResponse(
         request,
@@ -482,7 +512,15 @@ async def listen_booth(
             url=f'/login?next=/listen/{booth_id}',
             status_code=status.HTTP_303_SEE_OTHER,
         )
-    channel_id = channel or f'{booth_id}-audio'
+    if channel:
+        channel_id = channel
+    else:
+        try:
+            from portal.booth_identity import booth_id_to_mediamtx_path
+            channel_id = booth_id_to_mediamtx_path(booth_id)
+        except ValueError:
+            channel_id = f'{booth_id}-audio'
+
     hls_url = f'{settings.mediamtx_hls_base}/{channel_id}/index.m3u8'
     return templates.TemplateResponse(
         request,
@@ -510,7 +548,15 @@ async def listen_webrtc_booth(
             url=f'/login?next=/listener-webrtc/{booth_id}',
             status_code=status.HTTP_303_SEE_OTHER,
         )
-    channel_id = channel or f'{booth_id}-audio'
+    if channel:
+        channel_id = channel
+    else:
+        try:
+            from portal.booth_identity import booth_id_to_mediamtx_path
+            channel_id = booth_id_to_mediamtx_path(booth_id)
+        except ValueError:
+            channel_id = f'{booth_id}-audio'
+
     await _ensure_mediamtx_path(channel_id)
     whep_url = f'{settings.mediamtx_whip_base}/{channel_id}/whep'
     return templates.TemplateResponse(
@@ -1237,6 +1283,7 @@ async def admin_booth_detail(request: Request, event_id: int, room_id: int, boot
         'active_interpreter': active_interpreter,
         'tokens': tokens,
         'users': users,
+        'memberships': memberships,
         'membership_map': membership_map,
     })
 
@@ -1246,20 +1293,20 @@ async def admin_booth_detail(request: Request, event_id: int, room_id: int, boot
     dependencies=[Depends(require_admin)],
 )
 async def admin_add_booth_member(request: Request, event_id: int, room_id: int, booth_id: int):
-    from portal.database import get_session, list_memberships_for_booth, remove_booth_membership, set_booth_membership
+    from portal.database import get_session, list_memberships_for_booth, remove_booth_membership, set_booth_membership, get_user_by_email
 
     form = await request.form()
-    user_id = form.get('user_id', '')
+    email = form.get('email', '').strip()
     role = form.get('role', '').strip()
-    if user_id:
-        try:
-            uid = int(user_id)
-        except ValueError:
-            return RedirectResponse(
-                url=f'/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/',
-                status_code=status.HTTP_303_SEE_OTHER,
-            )
+    if email:
         async with get_session() as session:
+            user = await get_user_by_email(session, email)
+            if not user:
+                return RedirectResponse(
+                    url=f'/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/?error=user_not_found',
+                    status_code=status.HTTP_303_SEE_OTHER,
+                )
+            uid = user.id
             if role:
                 await set_booth_membership(session, user_id=uid, booth_id=booth_id, role=role)
             else:
@@ -1336,6 +1383,59 @@ async def admin_delete_user(request: Request, user_id: int):
         await delete_user(session, user_id)
     return RedirectResponse(url='/admin/users/', status_code=status.HTTP_303_SEE_OTHER)
 
+@app.get('/admin/users/{user_id}/', dependencies=[Depends(require_admin)])
+async def admin_user_detail(request: Request, user_id: int):
+    from portal.database import get_session, get_user_by_id, list_events, list_memberships_for_user
+
+    async with get_session() as session:
+        user = await get_user_by_id(session, user_id)
+        if not user:
+            return RedirectResponse(url='/admin/users/', status_code=status.HTTP_303_SEE_OTHER)
+        
+        events = await list_events(session)
+        memberships = await list_memberships_for_user(session, user_id)
+        
+        event_admin_map = {m.event_id: m for m in memberships if m.role == 'event_admin'}
+        
+    return templates.TemplateResponse(request, 'admin/user_detail.html', {
+        'user_detail': user,  # Named 'user_detail' so it doesn't clash with context 'user'
+        'events': events,
+        'event_admin_map': event_admin_map
+    })
+
+
+@app.post('/admin/users/{user_id}/toggle-admin', dependencies=[Depends(require_admin)])
+async def admin_toggle_user_admin(request: Request, user_id: int):
+    from portal.database import get_session, get_user_by_id
+    from sqlalchemy import update
+    from portal.models import User
+
+    async with get_session() as session:
+        user = await get_user_by_id(session, user_id)
+        if user:
+            stmt = update(User).where(User.id == user_id).values(is_admin=not user.is_admin)
+            await session.execute(stmt)
+            await session.commit()
+    return RedirectResponse(url=f'/admin/users/{user_id}/', status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post('/admin/users/{user_id}/events/{event_id}/toggle-admin', dependencies=[Depends(require_admin)])
+async def admin_toggle_user_event_admin(request: Request, user_id: int, event_id: int):
+    from portal.database import get_session, get_user_by_id, list_memberships_for_user, set_event_membership, remove_event_membership
+
+    async with get_session() as session:
+        user = await get_user_by_id(session, user_id)
+        if user:
+            memberships = await list_memberships_for_user(session, user_id)
+            event_admin_membership = next((m for m in memberships if m.event_id == event_id and m.role == 'event_admin'), None)
+            
+            if event_admin_membership:
+                await remove_event_membership(session, event_admin_membership.id)
+            else:
+                await set_event_membership(session, user_id=user_id, event_id=event_id, role='event_admin')
+                
+    return RedirectResponse(url=f'/admin/users/{user_id}/', status_code=status.HTTP_303_SEE_OTHER)
+
 
 # ── Admin event membership routes ────────────────────────────────────────────
 
@@ -1364,20 +1464,20 @@ async def admin_event_members(request: Request, event_id: int):
 
 @app.post('/admin/events/{event_id}/members/', dependencies=[Depends(require_admin)])
 async def admin_add_event_member(request: Request, event_id: int):
-    from portal.database import get_session, list_memberships_for_event, remove_event_membership, set_event_membership
+    from portal.database import get_session, list_memberships_for_event, remove_event_membership, set_event_membership, get_user_by_email
 
     form = await request.form()
-    user_id = form.get('user_id', '')
+    email = form.get('email', '').strip()
     role = form.get('role', '').strip()
-    if user_id:
-        try:
-            uid = int(user_id)
-        except ValueError:
-            return RedirectResponse(
-                url=f'/admin/events/{event_id}/members/',
-                status_code=status.HTTP_303_SEE_OTHER,
-            )
+    if email:
         async with get_session() as session:
+            user = await get_user_by_email(session, email)
+            if not user:
+                return RedirectResponse(
+                    url=f'/admin/events/{event_id}/members/?error=user_not_found',
+                    status_code=status.HTTP_303_SEE_OTHER,
+                )
+            uid = user.id
             if role:
                 await set_event_membership(session, user_id=uid, event_id=event_id, role=role)
             else:

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -280,7 +280,7 @@ async def join_via_invite(token: str) -> RedirectResponse:
 
 @app.get('/')
 async def home(request: Request):
-    from portal.database import get_session, list_events, list_booths_for_event, list_booth_memberships_for_user
+    from portal.database import get_session, list_events, list_booths_for_event, list_booth_memberships_for_user, list_memberships_for_user
 
     current_user = await get_current_user(request)
     my_booths = []
@@ -340,7 +340,9 @@ async def home(request: Request):
                     'booths': booth_statuses,
                     'live_count': sum(1 for bs in booth_statuses if bs['is_live']),
                 })
-    except Exception:
+    except Exception as _exc:
+        import logging
+        logging.getLogger(__name__).warning('home() DB error: %s', _exc, exc_info=True)
         event_data = []
 
     return templates.TemplateResponse(request, 'home.html', {
@@ -381,19 +383,25 @@ async def interpreter_booth_by_identity(
 
     granted_role = resolve_booth_role(payload)
 
+    # is_admin flag in JWT always grants event_admin — no DB lookup needed.
+    if granted_role is None and payload.get('is_admin'):
+        granted_role = 'event_admin'
+
     # If role is still None the user is registered but has no role claim in the JWT.
     # Check BoothMembership from the DB for this exact booth first,
-    # then fallback to EventMembership (for coordinators/admins).
+    # then fallback to EventMembership (for coordinators/event_admins).
     if granted_role is None and payload.get('sub'):
         from portal.database import get_session, list_memberships_for_user, list_booth_memberships_for_user
         try:
             async with get_session() as db_session:
+                # 1. Booth-level membership (e.g. interpreter assigned to this specific booth)
                 bms = await list_booth_memberships_for_user(db_session, int(payload['sub']))
                 for bm in bms:
                     if bm.booth.event.slug == event_slug and bm.booth.language_code == language_code:
                         granted_role = bm.role
                         break
-                
+
+                # 2. Event-level membership (coordinator, event_admin assigned to the event)
                 if granted_role is None:
                     memberships = await list_memberships_for_user(db_session, int(payload['sub']))
                     for m in memberships:
@@ -1585,19 +1593,38 @@ async def ws_booth(websocket: WebSocket, booth_id: str) -> None:
 
     ws_granted_role = resolve_booth_role(ws_session_payload)
 
+    # is_admin in JWT always grants event_admin at the WS level too.
+    if ws_granted_role is None and ws_session_payload is not None and ws_session_payload.get('is_admin'):
+        ws_granted_role = 'event_admin'
+
     # For registered users whose token carries no 'role' claim, fall back to
-    # EventMembership in the DB — the same logic the HTTP booth page uses.
+    # BoothMembership then EventMembership in the DB.
     if ws_granted_role is None and ws_session_payload is not None and ws_session_payload.get('sub'):
         try:
             from portal.booth_identity import parse_booth_id as _parse_booth_id
-            from portal.database import get_session as _get_session, list_memberships_for_user as _list_memberships
-            _event_slug, _ = _parse_booth_id(booth_id)
+            from portal.database import (
+                get_session as _get_session,
+                list_memberships_for_user as _list_memberships,
+                list_booth_memberships_for_user as _list_booth_memberships,
+            )
+            _event_slug, _lang_code = _parse_booth_id(booth_id)
             async with _get_session() as _db:
-                _memberships = await _list_memberships(_db, int(ws_session_payload['sub']))
-                for _m in _memberships:
-                    if _m.event and _m.event.slug == _event_slug:
-                        ws_granted_role = _m.role
+                # 1. Booth-level membership first (interpreter for specific booth)
+                _booth_mems = await _list_booth_memberships(_db, int(ws_session_payload['sub']))
+                for _bm in _booth_mems:
+                    if (
+                        _bm.booth.event.slug == _event_slug
+                        and _bm.booth.language_code == _lang_code
+                    ):
+                        ws_granted_role = _bm.role
                         break
+                # 2. Event-level membership (coordinator, event_admin)
+                if ws_granted_role is None:
+                    _memberships = await _list_memberships(_db, int(ws_session_payload['sub']))
+                    for _m in _memberships:
+                        if _m.event and _m.event.slug == _event_slug:
+                            ws_granted_role = _m.role
+                            break
         except Exception:
             pass
 

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -645,8 +645,14 @@ async def _handle_join(ws: WebSocket, session: Session, data: dict) -> None:
     participant_id = data.get('participant_id')
 
     # Role enforcement: use the server-derived granted_role stored on the session
-    # (populated from cookies at WS connect time). Never trust data['granted_role'].
-    if session.granted_role is not None and not can_perform_role(session.granted_role, role):
+    # (populated from cookies at WS connect time). Never trust data['role'].
+    if session.granted_role is None:
+        await ws.send_text(json.dumps({
+            'type': 'booth:error',
+            'message': 'No role assigned for this session.',
+        }))
+        return
+    if not can_perform_role(session.granted_role, role):
         await ws.send_text(json.dumps({
             'type': 'booth:error',
             'message': f'Your assigned role ({session.granted_role}) does not permit joining as {role}.',
@@ -1281,7 +1287,13 @@ async def admin_add_event_member(request: Request, event_id: int):
     user_id = form.get('user_id', '')
     role = form.get('role', '').strip()
     if user_id:
-        uid = int(user_id)
+        try:
+            uid = int(user_id)
+        except ValueError:
+            return RedirectResponse(
+                url=f'/admin/events/{event_id}/members/',
+                status_code=status.HTTP_303_SEE_OTHER,
+            )
         async with get_session() as session:
             if role:
                 await set_event_membership(session, user_id=uid, event_id=event_id, role=role)
@@ -1389,6 +1401,39 @@ async def ws_booth(websocket: WebSocket, booth_id: str) -> None:
             continue
 
     ws_granted_role = resolve_booth_role(ws_session_payload)
+
+    # For registered users whose token carries no 'role' claim, fall back to
+    # EventMembership in the DB — the same logic the HTTP booth page uses.
+    if ws_granted_role is None and ws_session_payload is not None and ws_session_payload.get('sub'):
+        try:
+            from portal.booth_identity import parse_booth_id as _parse_booth_id
+            from portal.database import get_session as _get_session, list_memberships_for_user as _list_memberships
+            _event_slug, _ = _parse_booth_id(booth_id)
+            async with _get_session() as _db:
+                _memberships = await _list_memberships(_db, int(ws_session_payload['sub']))
+                for _m in _memberships:
+                    if _m.event and _m.event.slug == _event_slug:
+                        ws_granted_role = _m.role
+                        break
+        except Exception:
+            pass
+
+    # Validate invite/participant token scope: the token's (event_slug, language_code)
+    # must match the booth being connected to.  This prevents a valid token for booth A
+    # from being used to join booth B.
+    if ws_session_payload is not None and 'role' in ws_session_payload:
+        token_event = ws_session_payload.get('event_slug', '')
+        token_lang = ws_session_payload.get('language_code', '')
+        if token_event and token_lang:
+            try:
+                from portal.booth_identity import make_booth_id as _make_booth_id
+                expected_booth_id = _make_booth_id(token_event, token_lang)
+                if expected_booth_id != booth_id:
+                    await websocket.close(code=4003)
+                    return
+            except Exception:
+                await websocket.close(code=4003)
+                return
 
     await websocket.accept()
     session = Session(

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -280,8 +280,11 @@ async def join_via_invite(token: str) -> RedirectResponse:
 
 @app.get('/')
 async def home(request: Request):
-    from portal.database import get_session, list_events, list_booths_for_event
+    from portal.database import get_session, list_events, list_booths_for_event, list_booth_memberships_for_user
 
+    current_user = await get_current_user(request)
+    my_booths = []
+    
     try:
         async with get_session() as session:
             events = await list_events(session)
@@ -299,12 +302,29 @@ async def home(request: Request):
                     'booths': booth_statuses,
                     'live_count': sum(1 for bs in booth_statuses if bs['is_live']),
                 })
+            
+            if current_user:
+                bms = await list_booth_memberships_for_user(session, int(current_user['sub']))
+                for bm in bms:
+                    bid = make_booth_id(bm.booth.event.slug, bm.booth.language_code)
+                    mem_booth = booths.get_booth_sync(bid)
+                    is_live = mem_booth is not None and mem_booth.ingest_status == 'connected'
+                    my_booths.append({
+                        'membership': bm,
+                        'booth_id': bid,
+                        'is_live': is_live,
+                        'event_name': bm.booth.event.display_name,
+                        'language_name': bm.booth.language_name,
+                        'event_slug': bm.booth.event.slug,
+                        'language_code': bm.booth.language_code,
+                    })
     except Exception:
         event_data = []
 
     return templates.TemplateResponse(request, 'home.html', {
         'events': event_data,
-        'current_user': await get_current_user(request),
+        'current_user': current_user,
+        'my_booths': my_booths,
     })
 
 
@@ -339,17 +359,25 @@ async def interpreter_booth_by_identity(
 
     granted_role = resolve_booth_role(payload)
 
-    # If role is still None the user is registered but has no event membership yet.
-    # Check EventMembership from the DB for this event.
+    # If role is still None the user is registered but has no role claim in the JWT.
+    # Check BoothMembership from the DB for this exact booth first,
+    # then fallback to EventMembership (for coordinators/admins).
     if granted_role is None and payload.get('sub'):
-        from portal.database import get_session, list_memberships_for_user
+        from portal.database import get_session, list_memberships_for_user, list_booth_memberships_for_user
         try:
             async with get_session() as db_session:
-                memberships = await list_memberships_for_user(db_session, int(payload['sub']))
-                for m in memberships:
-                    if m.event and m.event.slug == event_slug:
-                        granted_role = m.role
+                bms = await list_booth_memberships_for_user(db_session, int(payload['sub']))
+                for bm in bms:
+                    if bm.booth.event.slug == event_slug and bm.booth.language_code == language_code:
+                        granted_role = bm.role
                         break
+                
+                if granted_role is None:
+                    memberships = await list_memberships_for_user(db_session, int(payload['sub']))
+                    for m in memberships:
+                        if m.event and m.event.slug == event_slug:
+                            granted_role = m.role
+                            break
         except Exception:
             pass
 
@@ -1168,7 +1196,7 @@ async def admin_create_booth(request: Request, event_id: int, room_id: int):
 async def admin_booth_detail(request: Request, event_id: int, room_id: int, booth_id: int):
     from portal.database import (
         get_session, get_event_by_id, get_room_by_id, get_booth_by_id,
-        list_tokens_for_booth,
+        list_tokens_for_booth, list_users, list_memberships_for_booth
     )
 
     async with get_session() as session:
@@ -1182,6 +1210,10 @@ async def admin_booth_detail(request: Request, event_id: int, room_id: int, boot
         if db_booth is None or db_booth.room_id != room_id:
             raise HTTPException(status_code=404, detail='Booth not found.')
         tokens = await list_tokens_for_booth(session, booth_id)
+        users = await list_users(session)
+        memberships = await list_memberships_for_booth(session, booth_id)
+
+    membership_map = {m.user_id: m for m in memberships}
 
     bid = make_booth_id(event.slug, db_booth.language_code)
     mediamtx_path = make_mediamtx_path(event.slug, db_booth.language_code)
@@ -1204,7 +1236,58 @@ async def admin_booth_detail(request: Request, event_id: int, room_id: int, boot
         'participants': participants,
         'active_interpreter': active_interpreter,
         'tokens': tokens,
+        'users': users,
+        'membership_map': membership_map,
     })
+
+
+@app.post(
+    '/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/members/',
+    dependencies=[Depends(require_admin)],
+)
+async def admin_add_booth_member(request: Request, event_id: int, room_id: int, booth_id: int):
+    from portal.database import get_session, list_memberships_for_booth, remove_booth_membership, set_booth_membership
+
+    form = await request.form()
+    user_id = form.get('user_id', '')
+    role = form.get('role', '').strip()
+    if user_id:
+        try:
+            uid = int(user_id)
+        except ValueError:
+            return RedirectResponse(
+                url=f'/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/',
+                status_code=status.HTTP_303_SEE_OTHER,
+            )
+        async with get_session() as session:
+            if role:
+                await set_booth_membership(session, user_id=uid, booth_id=booth_id, role=role)
+            else:
+                # "— none —" selected: remove any existing membership
+                memberships = await list_memberships_for_booth(session, booth_id)
+                for m in memberships:
+                    if m.user_id == uid:
+                        await remove_booth_membership(session, m.id)
+                        break
+    return RedirectResponse(
+        url=f'/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@app.post(
+    '/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/members/{membership_id}/delete',
+    dependencies=[Depends(require_admin)],
+)
+async def admin_remove_booth_member(request: Request, event_id: int, room_id: int, booth_id: int, membership_id: int):
+    from portal.database import get_session, remove_booth_membership
+
+    async with get_session() as session:
+        await remove_booth_membership(session, membership_id)
+    return RedirectResponse(
+        url=f'/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
 
 
 @app.post(

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -23,7 +23,8 @@ from pydantic import BaseModel
 
 from portal.auth import (
     create_admin_token, create_participant_token, create_token, create_user_token,
-    decode_token, get_current_user, hash_password, require_admin, require_user,
+    decode_token, get_booth_session, get_current_user, hash_password, require_admin,
+    require_user, resolve_booth_role, can_perform_role,
     security, verify_password, verify_ws_token,
 )
 from portal.booth_identity import make_booth_id, make_mediamtx_path
@@ -324,9 +325,39 @@ async def interpreter_booth_by_identity(
 ) -> Any:
     """Booth page addressed by event_slug and language_code (preferred URL).
 
-    Derives booth_id, channel_id, WHIP URL, and WHEP URL from the identity
-    coordinates.  The MediaMTX path is created on first access.
+    Requires a valid session_token (invite link) or user_token (registered user).
+    The granted role is passed to the template so the client cannot self-promote.
     """
+    payload = get_booth_session(request)
+    if payload is None:
+        return RedirectResponse(
+            url=f'/login?next=/interpreter/{event_slug}/{language_code}',
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+
+    granted_role = resolve_booth_role(payload)
+
+    # If role is still None the user is registered but has no event membership yet.
+    # Check EventMembership from the DB for this event.
+    if granted_role is None and payload.get('sub'):
+        from portal.database import get_session, list_memberships_for_user
+        try:
+            async with get_session() as db_session:
+                memberships = await list_memberships_for_user(db_session, int(payload['sub']))
+                for m in memberships:
+                    if m.event and m.event.slug == event_slug:
+                        granted_role = m.role
+                        break
+        except Exception:
+            pass
+
+    if granted_role is None:
+        # User is authenticated but has no role for this event
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail='You do not have a role assigned for this event. Ask an admin to assign you one.',
+        )
+
     booth_id = make_booth_id(event_slug, language_code)
     mediamtx_path = make_mediamtx_path(event_slug, language_code)
     channel_id = mediamtx_path
@@ -346,6 +377,7 @@ async def interpreter_booth_by_identity(
             'language_code': language_code,
             'whip_url': whip_url,
             'whep_url': whep_url,
+            'granted_role': granted_role,
             'default_jitsi_room': settings.default_jitsi_room,
             'default_jitsi_url': _make_jitsi_url(
                 settings.effective_jitsi_base_url, settings.default_jitsi_room
@@ -367,6 +399,21 @@ async def interpreter_booth(
     language: str = 'English',
     channel: str | None = Query(None),
 ) -> Any:
+    """Legacy booth URL (no event scope). Requires a valid session."""
+    payload = get_booth_session(request)
+    if payload is None:
+        return RedirectResponse(
+            url=f'/login?next=/interpreter/{booth_id}',
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+
+    granted_role = resolve_booth_role(payload)
+    if granted_role is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail='You do not have a role assigned. Ask an admin for an invite link.',
+        )
+
     channel_id = channel or f'{booth_id}-audio'
     await _ensure_mediamtx_path(channel_id)
     return templates.TemplateResponse(
@@ -377,6 +424,7 @@ async def interpreter_booth(
             'booth_token': token,
             'booth_language': language,
             'booth_channel_id': channel_id,
+            'granted_role': granted_role,
             'default_jitsi_room': settings.default_jitsi_room,
             'default_jitsi_url': _make_jitsi_url(
                 settings.effective_jitsi_base_url, settings.default_jitsi_room
@@ -398,6 +446,12 @@ async def listen_booth(
     channel: str | None = Query(None),
 ) -> Any:
     """Listener page with hls.js auto-recovery for seamless handoff."""
+    payload = get_booth_session(request)
+    if payload is None:
+        return RedirectResponse(
+            url=f'/login?next=/listen/{booth_id}',
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
     channel_id = channel or f'{booth_id}-audio'
     hls_url = f'{settings.mediamtx_hls_base}/{channel_id}/index.m3u8'
     return templates.TemplateResponse(
@@ -420,6 +474,12 @@ async def listen_webrtc_booth(
     channel: str | None = Query(None),
 ) -> Any:
     """Listener page using WHEP/WebRTC for low-latency playback."""
+    payload = get_booth_session(request)
+    if payload is None:
+        return RedirectResponse(
+            url=f'/login?next=/listener-webrtc/{booth_id}',
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
     channel_id = channel or f'{booth_id}-audio'
     await _ensure_mediamtx_path(channel_id)
     whep_url = f'{settings.mediamtx_whip_base}/{channel_id}/whep'
@@ -581,6 +641,18 @@ async def _handle_join(ws: WebSocket, session: Session, data: dict) -> None:
     language = data.get('language', 'English')
     channel_id = data.get('channel_id', f'{session.booth_id}-audio')
     participant_id = data.get('participant_id')
+
+    # Role enforcement: the client supplies what role they want, but we check
+    # their granted_role from the JWT (passed through the page data-attribute
+    # and echoed back here). If they try to claim a higher role, reject it.
+    granted_role = data.get('granted_role')
+    if granted_role is not None and not can_perform_role(granted_role, role):
+        await ws.send_text(json.dumps({
+            'type': 'booth:error',
+            'message': f'Your assigned role ({granted_role}) does not permit joining as {role}.',
+        }))
+        return
+
     # Cross-event isolation: reject if client-supplied event_slug doesn't match
     client_event = data.get('event_slug')
     if client_event is not None:

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -31,6 +31,10 @@ webrtcLocalUDPAddress: :8189  # single UDP port for all ICE traffic (replaces de
 # UDP port 8189.
 webrtcAdditionalHosts:
   - 127.0.0.1
+  # Production: add your server's public IP and domain so browsers can reach
+  # the WebRTC UDP port (8189) from outside Docker. Update these for your deployment.
+  # - 100.56.6.172   # production server IP (set via DOCKER_HOST_ADDRESS in .env)
+  # - voxbento.com   # public hostname
 # Allow the browser JS on :8000 (FastAPI portal) to POST WHEP/WHIP offers
 # (cross-origin).  Plural form required by MediaMTX ≥ 1.18.
 webrtcAllowOrigins: ['*']

--- a/portal/auth.py
+++ b/portal/auth.py
@@ -3,13 +3,28 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta, timezone
 
+import bcrypt
 import jwt
-from fastapi import HTTPException, WebSocket, status
+from fastapi import Cookie, HTTPException, Request, WebSocket, status
+from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from portal.config import settings
 
 security = HTTPBearer(auto_error=False)
+
+
+# ---------------------------------------------------------------------------
+# Password hashing
+# ---------------------------------------------------------------------------
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    return bcrypt.checkpw(password.encode(), password_hash.encode())
 
 
 def create_token() -> str:
@@ -75,3 +90,77 @@ async def verify_ws_token(websocket: WebSocket) -> None:
     except jwt.InvalidTokenError as exc:
         await websocket.close(code=4001)
         raise ValueError(f'Invalid WebSocket token: {exc}')
+
+
+async def require_admin(request: Request) -> None:
+    """FastAPI dependency that guards admin routes.
+
+    Checks for a valid ``admin_token`` cookie containing a JWT with
+    ``admin=True`` claim.  Returns None on success; raises HTTP 403 or
+    redirects to the login page on failure.
+    """
+    cookie = request.cookies.get('admin_token', '')
+    if not cookie:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Admin access required.')
+    try:
+        payload = decode_token(cookie)
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Invalid admin token.')
+    if not payload.get('admin'):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Admin access required.')
+
+
+def create_admin_token() -> str:
+    """Create a JWT with admin=True claim for admin panel access."""
+    now = datetime.now(timezone.utc)
+    payload = {
+        'admin': True,
+        'iat': now,
+        'exp': now + timedelta(seconds=settings.jwt_expiry_seconds),
+    }
+    return jwt.encode(payload, settings.effective_jwt_secret, algorithm='HS256')
+
+
+# ---------------------------------------------------------------------------
+# User auth
+# ---------------------------------------------------------------------------
+
+
+def create_user_token(*, user_id: int, email: str, role: str) -> str:
+    """Create a JWT for a registered user session."""
+    now = datetime.now(timezone.utc)
+    payload = {
+        'sub': str(user_id),
+        'email': email,
+        'role': role,
+        'user': True,
+        'iat': now,
+        'exp': now + timedelta(seconds=settings.jwt_expiry_seconds),
+    }
+    return jwt.encode(payload, settings.effective_jwt_secret, algorithm='HS256')
+
+
+async def get_current_user(request: Request) -> dict | None:
+    """Extract current user from user_token cookie. Returns None if not logged in."""
+    cookie = request.cookies.get('user_token', '')
+    if not cookie:
+        return None
+    try:
+        payload = decode_token(cookie)
+    except jwt.InvalidTokenError:
+        return None
+    if not payload.get('user'):
+        return None
+    return payload
+
+
+async def require_user(request: Request) -> dict:
+    """FastAPI dependency that requires a logged-in user.
+
+    Returns the JWT payload dict with user_id, email, role.
+    Raises HTTP 403 if not logged in.
+    """
+    user = await get_current_user(request)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Login required.')
+    return user

--- a/portal/auth.py
+++ b/portal/auth.py
@@ -126,13 +126,13 @@ def create_admin_token() -> str:
 # ---------------------------------------------------------------------------
 
 
-def create_user_token(*, user_id: int, email: str, role: str) -> str:
+def create_user_token(*, user_id: int, email: str, is_admin: bool = False) -> str:
     """Create a JWT for a registered user session."""
     now = datetime.now(timezone.utc)
     payload = {
         'sub': str(user_id),
         'email': email,
-        'role': role,
+        'is_admin': is_admin,
         'user': True,
         'iat': now,
         'exp': now + timedelta(seconds=settings.jwt_expiry_seconds),

--- a/portal/auth.py
+++ b/portal/auth.py
@@ -5,8 +5,7 @@ from datetime import datetime, timedelta, timezone
 
 import bcrypt
 import jwt
-from fastapi import Cookie, HTTPException, Request, WebSocket, status
-from fastapi.responses import RedirectResponse
+from fastapi import HTTPException, Request, WebSocket, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from portal.config import settings

--- a/portal/auth.py
+++ b/portal/auth.py
@@ -175,11 +175,17 @@ _ROLE_RANK: dict[str, int] = {
 
 
 def get_booth_session(request: Request) -> dict | None:
-    """Return decoded JWT payload from either session_token (invite) or user_token (registered user).
+    """Return decoded JWT payload from either user_token (registered user) or session_token (invite link).
+
+    Registered-user tokens (user_token) are checked FIRST so that a logged-in
+    admin or event_admin is never shadowed by an older invite-link session_token
+    cookie that may carry a lower role (e.g. 'interpreter').
 
     Returns None if neither cookie exists or both are invalid.
     """
-    for cookie_name in ('session_token', 'user_token'):
+    # Prefer user_token (registered user with is_admin / event roles) over
+    # session_token (one-time invite link with a fixed role claim).
+    for cookie_name in ('user_token', 'session_token'):
         cookie = request.cookies.get(cookie_name, '')
         if not cookie:
             continue

--- a/portal/auth.py
+++ b/portal/auth.py
@@ -95,8 +95,7 @@ async def require_admin(request: Request) -> None:
     """FastAPI dependency that guards admin routes.
 
     Checks for a valid ``admin_token`` cookie containing a JWT with
-    ``admin=True`` claim.  Returns None on success; raises HTTP 403 or
-    redirects to the login page on failure.
+    ``admin=True`` claim.  Returns None on success; raises HTTP 403 on failure.
     """
     cookie = request.cookies.get('admin_token', '')
     if not cookie:
@@ -156,7 +155,7 @@ async def get_current_user(request: Request) -> dict | None:
 async def require_user(request: Request) -> dict:
     """FastAPI dependency that requires a logged-in user.
 
-    Returns the JWT payload dict with user_id, email, role.
+    Returns the JWT payload dict with user_id, email, and is_admin.
     Raises HTTP 403 if not logged in.
     """
     user = await get_current_user(request)

--- a/portal/auth.py
+++ b/portal/auth.py
@@ -164,3 +164,61 @@ async def require_user(request: Request) -> dict:
     if user is None:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Login required.')
     return user
+
+
+# Role hierarchy — higher index = more privilege.
+_ROLE_RANK: dict[str, int] = {
+    'listener': 0,
+    'interpreter': 1,
+    'coordinator': 2,
+    'event_admin': 3,
+    'super_admin': 4,
+}
+
+
+def get_booth_session(request: Request) -> dict | None:
+    """Return decoded JWT payload from either session_token (invite) or user_token (registered user).
+
+    Returns None if neither cookie exists or both are invalid.
+    """
+    for cookie_name in ('session_token', 'user_token'):
+        cookie = request.cookies.get(cookie_name, '')
+        if not cookie:
+            continue
+        try:
+            payload = decode_token(cookie)
+            return payload
+        except jwt.InvalidTokenError:
+            continue
+    return None
+
+
+def resolve_booth_role(payload: dict | None) -> str | None:
+    """Extract the role claim from a booth session payload.
+
+    - Invite tokens carry a ``role`` claim directly.
+    - User tokens carry ``is_admin``; without a booth-specific role the
+      caller must check EventMembership separately.  When is_admin=True we
+      treat them as event_admin.
+    Returns None if no role can be determined.
+    """
+    if payload is None:
+        return None
+    # Invite / participant token
+    if 'role' in payload:
+        return payload['role']
+    # Registered user — is_admin maps to event_admin for booth purposes
+    if payload.get('is_admin'):
+        return 'event_admin'
+    return None
+
+
+def can_perform_role(granted_role: str | None, requested_role: str) -> bool:
+    """Return True if *granted_role* is at least as privileged as *requested_role*.
+
+    A coordinator can join as interpreter (lower rank), but a listener cannot
+    join as interpreter (higher rank).
+    """
+    if granted_role is None:
+        return False
+    return _ROLE_RANK.get(granted_role, -1) >= _ROLE_RANK.get(requested_role, 0)

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -368,6 +368,13 @@ class BoothRegistry:
             booth = self._booths.get(booth_id)
             return booth.as_public_dict() if booth is not None else None
 
+    def get_booth_sync(self, booth_id: str) -> Booth | None:
+        """Return the raw Booth dataclass without locking.
+
+        Safe for read-only admin panel access (snapshot of volatile state).
+        """
+        return self._booths.get(booth_id)
+
     async def get_booth_for_event(self, event_slug: str, language_code: str) -> dict | None:
         """Return the booth for a specific event + language, or None.
 

--- a/portal/config.py
+++ b/portal/config.py
@@ -58,6 +58,9 @@ class Settings(BaseSettings):
     # Database — SQLite for dev, PostgreSQL for prod
     database_url: str = 'sqlite+aiosqlite:///./interpretation.db'
 
+    # Admin panel — simple password guard (Phase 3 Step 7 will add proper auth)
+    admin_password: str = ''
+
     @property
     def effective_jwt_secret(self) -> str:
         return self.jwt_secret or self.secret_key

--- a/portal/database.py
+++ b/portal/database.py
@@ -23,7 +23,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import joinedload
 
-from portal.models import Base, DBBooth, Event, InviteToken, Room, generate_token, utc_now
+from portal.models import Base, DBBooth, Event, InviteToken, Room, User, generate_token, utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -293,3 +293,71 @@ async def list_tokens_for_booth(session: AsyncSession, booth_id: int) -> list[In
         .order_by(InviteToken.created_at),
     )
     return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# User CRUD
+# ---------------------------------------------------------------------------
+
+
+async def create_user(
+    session: AsyncSession,
+    *,
+    email: str,
+    display_name: str,
+    password_hash: str,
+    role: str = 'listener',
+) -> User:
+    user = User(
+        email=email.strip().lower(),
+        display_name=display_name,
+        password_hash=password_hash,
+        role=role,
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def get_user_by_email(session: AsyncSession, email: str) -> User | None:
+    result = await session.execute(
+        select(User).where(User.email == email.strip().lower()),
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_user_by_id(session: AsyncSession, user_id: int) -> User | None:
+    result = await session.execute(select(User).where(User.id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def list_users(session: AsyncSession) -> list[User]:
+    result = await session.execute(select(User).order_by(User.created_at))
+    return list(result.scalars().all())
+
+
+async def update_user_role(session: AsyncSession, user_id: int, role: str) -> User | None:
+    user = await get_user_by_id(session, user_id)
+    if user is None:
+        return None
+    user.role = role
+    await session.flush()
+    return user
+
+
+async def update_user_active(session: AsyncSession, user_id: int, *, is_active: bool) -> User | None:
+    user = await get_user_by_id(session, user_id)
+    if user is None:
+        return None
+    user.is_active = is_active
+    await session.flush()
+    return user
+
+
+async def delete_user(session: AsyncSession, user_id: int) -> bool:
+    user = await get_user_by_id(session, user_id)
+    if user is None:
+        return False
+    await session.delete(user)
+    await session.flush()
+    return True

--- a/portal/database.py
+++ b/portal/database.py
@@ -23,7 +23,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import joinedload
 
-from portal.models import Base, DBBooth, Event, InviteToken, Room, User, generate_token, utc_now
+from portal.models import Base, DBBooth, Event, EventMembership, InviteToken, Room, User, generate_token, utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -306,13 +306,11 @@ async def create_user(
     email: str,
     display_name: str,
     password_hash: str,
-    role: str = 'listener',
 ) -> User:
     user = User(
         email=email.strip().lower(),
         display_name=display_name,
         password_hash=password_hash,
-        role=role,
     )
     session.add(user)
     await session.flush()
@@ -336,15 +334,6 @@ async def list_users(session: AsyncSession) -> list[User]:
     return list(result.scalars().all())
 
 
-async def update_user_role(session: AsyncSession, user_id: int, role: str) -> User | None:
-    user = await get_user_by_id(session, user_id)
-    if user is None:
-        return None
-    user.role = role
-    await session.flush()
-    return user
-
-
 async def update_user_active(session: AsyncSession, user_id: int, *, is_active: bool) -> User | None:
     user = await get_user_by_id(session, user_id)
     if user is None:
@@ -361,3 +350,79 @@ async def delete_user(session: AsyncSession, user_id: int) -> bool:
     await session.delete(user)
     await session.flush()
     return True
+
+
+# ---------------------------------------------------------------------------
+# EventMembership CRUD
+# ---------------------------------------------------------------------------
+
+
+async def set_event_membership(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    event_id: int,
+    role: str,
+) -> EventMembership:
+    """Create or update a user's role for an event."""
+    result = await session.execute(
+        select(EventMembership).where(
+            EventMembership.user_id == user_id,
+            EventMembership.event_id == event_id,
+        ),
+    )
+    membership = result.scalar_one_or_none()
+    if membership:
+        membership.role = role
+    else:
+        membership = EventMembership(user_id=user_id, event_id=event_id, role=role)
+        session.add(membership)
+    await session.flush()
+    return membership
+
+
+async def remove_event_membership(session: AsyncSession, membership_id: int) -> bool:
+    result = await session.execute(
+        select(EventMembership).where(EventMembership.id == membership_id),
+    )
+    membership = result.scalar_one_or_none()
+    if membership is None:
+        return False
+    await session.delete(membership)
+    await session.flush()
+    return True
+
+
+async def list_memberships_for_event(session: AsyncSession, event_id: int) -> list[EventMembership]:
+    result = await session.execute(
+        select(EventMembership)
+        .options(joinedload(EventMembership.user))
+        .where(EventMembership.event_id == event_id)
+        .order_by(EventMembership.created_at),
+    )
+    return list(result.scalars().all())
+
+
+async def list_memberships_for_user(session: AsyncSession, user_id: int) -> list[EventMembership]:
+    result = await session.execute(
+        select(EventMembership)
+        .options(joinedload(EventMembership.event))
+        .where(EventMembership.user_id == user_id)
+        .order_by(EventMembership.created_at),
+    )
+    return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Token revocation
+# ---------------------------------------------------------------------------
+
+
+async def revoke_invite_token(session: AsyncSession, token_str: str) -> InviteToken | None:
+    """Revoke an invite token by setting used_at (prevents future use)."""
+    tok = await get_invite_token(session, token_str)
+    if tok is None:
+        return None
+    tok.used_at = utc_now()
+    await session.flush()
+    return tok

--- a/portal/database.py
+++ b/portal/database.py
@@ -23,7 +23,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import joinedload
 
-from portal.models import Base, DBBooth, Event, EventMembership, InviteToken, Room, User, generate_token, utc_now
+from portal.models import Base, BoothMembership, DBBooth, Event, EventMembership, InviteToken, Room, User, generate_token, utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -409,6 +409,67 @@ async def list_memberships_for_user(session: AsyncSession, user_id: int) -> list
         .options(joinedload(EventMembership.event))
         .where(EventMembership.user_id == user_id)
         .order_by(EventMembership.created_at),
+    )
+    return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# BoothMembership CRUD
+# ---------------------------------------------------------------------------
+
+
+async def set_booth_membership(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    booth_id: int,
+    role: str,
+) -> BoothMembership:
+    """Create or update a user's role for a specific booth."""
+    result = await session.execute(
+        select(BoothMembership).where(
+            BoothMembership.user_id == user_id,
+            BoothMembership.booth_id == booth_id,
+        ),
+    )
+    membership = result.scalar_one_or_none()
+    if membership:
+        membership.role = role
+    else:
+        membership = BoothMembership(user_id=user_id, booth_id=booth_id, role=role)
+        session.add(membership)
+    await session.flush()
+    return membership
+
+
+async def remove_booth_membership(session: AsyncSession, membership_id: int) -> bool:
+    result = await session.execute(
+        select(BoothMembership).where(BoothMembership.id == membership_id),
+    )
+    membership = result.scalar_one_or_none()
+    if membership is None:
+        return False
+    await session.delete(membership)
+    await session.flush()
+    return True
+
+
+async def list_memberships_for_booth(session: AsyncSession, booth_id: int) -> list[BoothMembership]:
+    result = await session.execute(
+        select(BoothMembership)
+        .options(joinedload(BoothMembership.user))
+        .where(BoothMembership.booth_id == booth_id)
+        .order_by(BoothMembership.created_at),
+    )
+    return list(result.scalars().all())
+
+
+async def list_booth_memberships_for_user(session: AsyncSession, user_id: int) -> list[BoothMembership]:
+    result = await session.execute(
+        select(BoothMembership)
+        .options(joinedload(BoothMembership.booth).joinedload(DBBooth.event))
+        .where(BoothMembership.user_id == user_id)
+        .order_by(BoothMembership.created_at),
     )
     return list(result.scalars().all())
 

--- a/portal/models.py
+++ b/portal/models.py
@@ -1,11 +1,12 @@
 """SQLAlchemy declarative models for persistent portal entities.
 
-Five tables:
+Six tables:
 - ``events`` — top-level event container (slug is unique key)
 - ``rooms`` — rooms within an event (mapped to Eventyay rooms)
 - ``booths`` — interpretation booths (one per language per room)
 - ``invite_tokens`` — single-use invite tokens for booth access
-- ``users`` — registered user accounts with role-based access
+- ``users`` — registered user accounts
+- ``event_memberships`` — per-event role assignments for users
 
 Design decisions
 ~~~~~~~~~~~~~~~~
@@ -193,9 +194,9 @@ class InviteToken(Base):
 class User(Base):
     """Registered user account.
 
-    Users sign up with email + password and get ``listener`` role by default.
-    Admins can promote users to ``interpreter``, ``coordinator``,
-    ``event_admin``, or ``super_admin`` from the admin panel.
+    Users sign up with email + password. They have no global booth role —
+    roles are assigned per-event via ``EventMembership``.  The only
+    system-level flag is ``is_admin`` which grants admin panel access.
     """
 
     __tablename__ = 'users'
@@ -204,15 +205,13 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(320), unique=True, index=True)
     display_name: Mapped[str] = mapped_column(String(200))
     password_hash: Mapped[str] = mapped_column(String(200))
-    role: Mapped[str] = mapped_column(String(20), default='listener')
+    is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
 
-    @validates('role')
-    def _validate_role(self, _key: str, value: str) -> str:
-        if value not in ALL_ROLES:
-            raise ValueError(f"Invalid role '{value}'. Must be one of: {', '.join(sorted(ALL_ROLES))}")
-        return value
+    memberships: Mapped[list[EventMembership]] = relationship(
+        back_populates='user', cascade='all, delete-orphan',
+    )
 
     @validates('email')
     def _validate_email(self, _key: str, value: str) -> str:
@@ -222,4 +221,43 @@ class User(Base):
         return value
 
     def __repr__(self) -> str:
-        return f'<User id={self.id} email={self.email!r} role={self.role!r}>'
+        return f'<User id={self.id} email={self.email!r}>'
+
+
+# ---------------------------------------------------------------------------
+# EventMembership
+# ---------------------------------------------------------------------------
+
+# Roles valid for event memberships (no super_admin — that's system-level)
+EVENT_ROLES = frozenset({'listener', 'interpreter', 'coordinator', 'event_admin'})
+
+
+class EventMembership(Base):
+    """Per-event role assignment for a user.
+
+    A user can have different roles in different events. For example,
+    a user might be an interpreter for PyCon and a coordinator for FOSDEM.
+    """
+
+    __tablename__ = 'event_memberships'
+    __table_args__ = (
+        Index('ix_membership_user_event', 'user_id', 'event_id', unique=True),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey('users.id', ondelete='CASCADE'))
+    event_id: Mapped[int] = mapped_column(ForeignKey('events.id', ondelete='CASCADE'))
+    role: Mapped[str] = mapped_column(String(20))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+
+    user: Mapped[User] = relationship(back_populates='memberships')
+    event: Mapped[Event] = relationship()
+
+    @validates('role')
+    def _validate_role(self, _key: str, value: str) -> str:
+        if value not in EVENT_ROLES:
+            raise ValueError(f"Invalid event role '{value}'. Must be one of: {', '.join(sorted(EVENT_ROLES))}")
+        return value
+
+    def __repr__(self) -> str:
+        return f'<EventMembership user={self.user_id} event={self.event_id} role={self.role!r}>'

--- a/portal/models.py
+++ b/portal/models.py
@@ -1,10 +1,11 @@
 """SQLAlchemy declarative models for persistent portal entities.
 
-Four tables:
+Five tables:
 - ``events`` — top-level event container (slug is unique key)
 - ``rooms`` — rooms within an event (mapped to Eventyay rooms)
 - ``booths`` — interpretation booths (one per language per room)
 - ``invite_tokens`` — single-use invite tokens for booth access
+- ``users`` — registered user accounts with role-based access
 
 Design decisions
 ~~~~~~~~~~~~~~~~
@@ -23,7 +24,7 @@ from __future__ import annotations
 import secrets
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, validates
 
 from portal.booth_identity import make_mediamtx_path, validate_event_slug, validate_language_code
@@ -182,3 +183,43 @@ class InviteToken(Base):
 
     def __repr__(self) -> str:
         return f'<InviteToken token={self.token[:8]}… role={self.role!r}>'
+
+
+# ---------------------------------------------------------------------------
+# User
+# ---------------------------------------------------------------------------
+
+
+class User(Base):
+    """Registered user account.
+
+    Users sign up with email + password and get ``listener`` role by default.
+    Admins can promote users to ``interpreter``, ``coordinator``,
+    ``event_admin``, or ``super_admin`` from the admin panel.
+    """
+
+    __tablename__ = 'users'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(String(320), unique=True, index=True)
+    display_name: Mapped[str] = mapped_column(String(200))
+    password_hash: Mapped[str] = mapped_column(String(200))
+    role: Mapped[str] = mapped_column(String(20), default='listener')
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+
+    @validates('role')
+    def _validate_role(self, _key: str, value: str) -> str:
+        if value not in ALL_ROLES:
+            raise ValueError(f"Invalid role '{value}'. Must be one of: {', '.join(sorted(ALL_ROLES))}")
+        return value
+
+    @validates('email')
+    def _validate_email(self, _key: str, value: str) -> str:
+        value = value.strip().lower()
+        if '@' not in value or '.' not in value.split('@')[-1]:
+            raise ValueError('Invalid email address.')
+        return value
+
+    def __repr__(self) -> str:
+        return f'<User id={self.id} email={self.email!r} role={self.role!r}>'

--- a/portal/models.py
+++ b/portal/models.py
@@ -7,6 +7,7 @@ Six tables:
 - ``invite_tokens`` — single-use invite tokens for booth access
 - ``users`` — registered user accounts
 - ``event_memberships`` — per-event role assignments for users
+- ``booth_memberships`` — per-booth role assignments for users (e.g. interpreter)
 
 Design decisions
 ~~~~~~~~~~~~~~~~
@@ -124,6 +125,9 @@ class DBBooth(Base):
     invite_tokens: Mapped[list[InviteToken]] = relationship(
         back_populates='booth', cascade='all, delete-orphan',
     )
+    memberships: Mapped[list[BoothMembership]] = relationship(
+        back_populates='booth', cascade='all, delete-orphan',
+    )
 
     @validates('language_code')
     def _validate_language_code(self, _key: str, value: str) -> str:
@@ -212,6 +216,9 @@ class User(Base):
     memberships: Mapped[list[EventMembership]] = relationship(
         back_populates='user', cascade='all, delete-orphan',
     )
+    booth_memberships: Mapped[list[BoothMembership]] = relationship(
+        back_populates='user', cascade='all, delete-orphan',
+    )
 
     @validates('email')
     def _validate_email(self, _key: str, value: str) -> str:
@@ -230,6 +237,7 @@ class User(Base):
 
 # Roles valid for event memberships (no super_admin — that's system-level)
 EVENT_ROLES = frozenset({'listener', 'interpreter', 'coordinator', 'event_admin'})
+BOOTH_ROLES = frozenset({'listener', 'interpreter', 'coordinator'})
 
 
 class EventMembership(Base):
@@ -261,3 +269,38 @@ class EventMembership(Base):
 
     def __repr__(self) -> str:
         return f'<EventMembership user={self.user_id} event={self.event_id} role={self.role!r}>'
+
+
+# ---------------------------------------------------------------------------
+# BoothMembership
+# ---------------------------------------------------------------------------
+
+
+class BoothMembership(Base):
+    """Per-booth role assignment for a user.
+
+    Used to assign specific interpreters/listeners to specific booths.
+    """
+
+    __tablename__ = 'booth_memberships'
+    __table_args__ = (
+        Index('ix_membership_user_booth', 'user_id', 'booth_id', unique=True),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey('users.id', ondelete='CASCADE'))
+    booth_id: Mapped[int] = mapped_column(ForeignKey('booths.id', ondelete='CASCADE'))
+    role: Mapped[str] = mapped_column(String(20))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+
+    user: Mapped[User] = relationship(back_populates='booth_memberships')
+    booth: Mapped[DBBooth] = relationship(back_populates='memberships')
+
+    @validates('role')
+    def _validate_role(self, _key: str, value: str) -> str:
+        if value not in BOOTH_ROLES:
+            raise ValueError(f"Invalid booth role '{value}'. Must be one of: {', '.join(sorted(BOOTH_ROLES))}")
+        return value
+
+    def __repr__(self) -> str:
+        return f'<BoothMembership user={self.user_id} booth={self.booth_id} role={self.role!r}>'

--- a/portal/roles.py
+++ b/portal/roles.py
@@ -57,6 +57,7 @@ ROLE_PERMISSIONS: dict[ParticipantRole, frozenset[Permission]] = {
         Permission.ADMIN_MANAGE_BOOTHS,
     }),
     'coordinator': frozenset({
+        Permission.BOOTH_GO_LIVE,
         Permission.BOOTH_SET_ACTIVE,
         Permission.BOOTH_CHAT_SEND,
         Permission.BOOTH_VIEW,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.0",
     "alembic>=1.15.0",
     "aiosqlite>=0.21.0",
+    "python-multipart>=0.0.30",
+    "bcrypt>=5.0.0",
 ]
 
 [dependency-groups]

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -433,3 +433,35 @@ code { font-family: var(--font-mono); font-size: 0.875em; background: #f0f1f3; p
   box-shadow: var(--shadow-sm);
 }
 .admin-help-section h3 { margin-bottom: 12px; }
+
+/* Token generation form */
+.token-form-card {
+  padding: 20px;
+  margin-bottom: 20px;
+  background: var(--color-bg);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius);
+}
+.token-form-card h3 { margin: 0 0 12px; font-size: 1rem; }
+.token-form .form-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+.token-form .form-group { flex: 1; min-width: 140px; }
+.token-form .form-group-btn { flex: 0 0 auto; }
+.token-form label { display: block; font-size: 0.8rem; margin-bottom: 4px; color: var(--color-text-secondary); }
+.token-form select,
+.token-form input[type="text"],
+.token-form input[type="number"] {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  background: var(--color-surface);
+}
+
+/* Highlight rows with an assigned event role */
+.row-assigned { background: rgba(34, 197, 94, 0.06); }

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -1,0 +1,435 @@
+/* ── Eventyay Admin Panel Styles ─────────────────────────────────────────── */
+
+:root {
+  --color-bg: #f5f6fa;
+  --color-surface: #ffffff;
+  --color-border: #e1e4e8;
+  --color-text: #24292e;
+  --color-text-secondary: #586069;
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-danger: #dc2626;
+  --color-danger-hover: #b91c1c;
+  --color-success: #16a34a;
+  --color-warning: #f59e0b;
+  --color-live: #16a34a;
+  --color-offline: #9ca3af;
+  --radius: 8px;
+  --radius-sm: 4px;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.08);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.1);
+  --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'SF Mono', 'Fira Code', monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font);
+  color: var(--color-text);
+  background: var(--color-bg);
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a { color: var(--color-primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code { font-family: var(--font-mono); font-size: 0.875em; background: #f0f1f3; padding: 2px 6px; border-radius: var(--radius-sm); }
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+
+.admin-header, .portal-home-header {
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0 24px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+.header-left { display: flex; align-items: center; gap: 12px; }
+.brand { font-size: 1.25rem; font-weight: 700; color: var(--color-primary); text-decoration: none; }
+.header-badge { font-size: 0.75rem; font-weight: 600; background: var(--color-primary); color: #fff; padding: 2px 8px; border-radius: 12px; }
+.header-nav { display: flex; gap: 20px; align-items: center; }
+.header-nav a { font-size: 0.875rem; color: var(--color-text-secondary); text-decoration: none; }
+.header-nav a:hover { color: var(--color-primary); }
+.nav-logout { color: var(--color-danger) !important; }
+
+/* ── Breadcrumb ──────────────────────────────────────────────────────────── */
+
+.breadcrumb {
+  padding: 12px 24px;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+.breadcrumb a { color: var(--color-primary); text-decoration: none; }
+.breadcrumb a:hover { text-decoration: underline; }
+.breadcrumb span { margin: 0 4px; }
+
+/* ── Main ────────────────────────────────────────────────────────────────── */
+
+.admin-main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+  width: 100%;
+  flex: 1;
+}
+
+/* ── Page Header ─────────────────────────────────────────────────────────── */
+
+.page-header {
+  margin-bottom: 24px;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.page-header h1 { font-size: 1.5rem; font-weight: 700; }
+.header-meta { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; }
+.header-status { font-size: 0.875rem; vertical-align: middle; }
+.meta-text { font-size: 0.8125rem; color: var(--color-text-secondary); }
+.system-health { font-size: 0.8125rem; display: flex; align-items: center; gap: 6px; }
+.health-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.health-ok { background: var(--color-live); }
+.health-down { background: var(--color-danger); }
+
+/* ── Cards ───────────────────────────────────────────────────────────────── */
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 16px;
+}
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+.card-header {
+  padding: 16px 20px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.card-title { font-size: 1.125rem; font-weight: 600; color: var(--color-text); text-decoration: none; }
+.card-title:hover { color: var(--color-primary); }
+.card-body { padding: 8px 20px 16px; }
+.card-actions { padding: 12px 20px; border-top: 1px solid var(--color-border); background: #fafbfc; }
+
+.stat-row { display: flex; justify-content: space-between; padding: 4px 0; font-size: 0.875rem; }
+.stat-label { color: var(--color-text-secondary); }
+.stat-value { font-weight: 600; }
+
+.booth-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.chip { font-size: 0.75rem; padding: 3px 10px; border-radius: 12px; border: 1px solid var(--color-border); background: #fafbfc; }
+.chip-live { border-color: var(--color-live); color: var(--color-live); background: #f0fdf4; }
+.chip-offline { color: var(--color-text-secondary); }
+
+/* ── Section Cards ───────────────────────────────────────────────────────── */
+
+.section-grid { display: grid; grid-template-columns: 1fr; gap: 20px; margin-bottom: 24px; }
+.section-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--shadow-sm);
+}
+.section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
+.section-header h2 { font-size: 1.125rem; font-weight: 600; }
+
+.item-list { list-style: none; }
+.item-list li { padding: 8px 0; border-bottom: 1px solid var(--color-border); }
+.item-list li:last-child { border-bottom: none; }
+
+/* ── Detail Grid ─────────────────────────────────────────────────────────── */
+
+.detail-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px; margin-bottom: 24px; }
+.detail-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--shadow-sm);
+}
+.detail-card h3 { font-size: 0.9375rem; font-weight: 600; margin-bottom: 12px; color: var(--color-text-secondary); }
+.detail-list { display: grid; grid-template-columns: auto 1fr; gap: 8px 16px; font-size: 0.875rem; }
+.detail-list dt { font-weight: 600; color: var(--color-text-secondary); white-space: nowrap; }
+.detail-list dd { word-break: break-all; }
+
+.copyable-field { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.copyable-field code { font-size: 0.8125rem; }
+
+/* ── Tables ──────────────────────────────────────────────────────────────── */
+
+.data-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+.data-table th { text-align: left; padding: 10px 12px; border-bottom: 2px solid var(--color-border); font-weight: 600; color: var(--color-text-secondary); font-size: 0.8125rem; text-transform: uppercase; letter-spacing: 0.04em; }
+.data-table td { padding: 10px 12px; border-bottom: 1px solid var(--color-border); vertical-align: middle; }
+.data-table tbody tr:hover { background: #f8f9fa; }
+.data-table.compact th, .data-table.compact td { padding: 8px 10px; }
+
+.schedule-table .row-live { background: #f0fdf4; }
+.row-used { opacity: 0.6; }
+.row-expired { opacity: 0.5; background: #fef2f2; }
+
+.token-preview { font-size: 0.75rem; color: var(--color-text-secondary); }
+
+/* ── Status Indicators ───────────────────────────────────────────────────── */
+
+.status-live { color: var(--color-live); font-weight: 600; white-space: nowrap; }
+.status-offline { color: var(--color-offline); }
+
+/* ── Badges ──────────────────────────────────────────────────────────────── */
+
+.badge { display: inline-block; font-size: 0.75rem; font-weight: 600; padding: 2px 8px; border-radius: 12px; }
+.badge-slug { background: #e8edf3; color: var(--color-text-secondary); }
+.badge-active { background: var(--color-live); color: #fff; }
+.badge-role { text-transform: capitalize; }
+.badge-interpreter { background: #dbeafe; color: #1e40af; }
+.badge-coordinator { background: #fef3c7; color: #92400e; }
+.badge-listener { background: #e0e7ff; color: #4338ca; }
+.badge-event_admin { background: #fce7f3; color: #9d174d; }
+.badge-super_admin { background: #fecaca; color: #991b1b; }
+.badge-valid { background: #d1fae5; color: #065f46; }
+.badge-used { background: #e5e7eb; color: #6b7280; }
+.badge-expired { background: #fecaca; color: #991b1b; }
+
+/* ── Buttons ─────────────────────────────────────────────────────────────── */
+
+.btn {
+  display: inline-block;
+  padding: 8px 16px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  text-decoration: none;
+  line-height: 1.4;
+  transition: all 0.15s;
+}
+.btn:hover { background: #f0f1f3; text-decoration: none; }
+.btn-sm { padding: 4px 10px; font-size: 0.8125rem; }
+.btn-primary { background: var(--color-primary); color: #fff; border-color: var(--color-primary); }
+.btn-primary:hover { background: var(--color-primary-hover); }
+.btn-danger { background: var(--color-danger); color: #fff; border-color: var(--color-danger); }
+.btn-danger:hover { background: var(--color-danger-hover); }
+.btn-copy { font-size: 0.75rem; padding: 2px 8px; }
+
+/* ── Forms ────────────────────────────────────────────────────────────────── */
+
+.form-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 20px;
+  margin-bottom: 20px;
+  box-shadow: var(--shadow-sm);
+}
+.form-card h3 { font-size: 0.9375rem; font-weight: 600; margin-bottom: 12px; }
+.inline-form { display: flex; gap: 8px; flex-wrap: wrap; align-items: end; }
+.inline-form input { padding: 8px 12px; font-size: 0.875rem; border: 1px solid var(--color-border); border-radius: var(--radius-sm); min-width: 180px; }
+.inline-form input:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 2px rgba(37,99,235,0.15); }
+.inline-delete { display: inline; }
+
+/* ── Danger Zone ─────────────────────────────────────────────────────────── */
+
+.danger-zone {
+  margin-top: 32px;
+  padding: 20px;
+  border: 1px solid #fecaca;
+  border-radius: var(--radius);
+  background: #fef2f2;
+}
+.danger-zone h3 { font-size: 0.9375rem; font-weight: 600; color: var(--color-danger); margin-bottom: 12px; }
+.danger-text { font-size: 0.8125rem; color: var(--color-text-secondary); margin-left: 12px; }
+
+/* ── Empty State ─────────────────────────────────────────────────────────── */
+
+.empty-state {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--color-text-secondary);
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius);
+}
+
+.muted { color: var(--color-text-secondary); font-size: 0.875rem; }
+.link-external { font-size: 0.8125rem; }
+
+/* ── Login Page ──────────────────────────────────────────────────────────── */
+
+.login-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg);
+}
+.login-card {
+  width: 100%;
+  max-width: 400px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 40px 32px;
+  box-shadow: var(--shadow-md);
+}
+.login-brand { text-align: center; margin-bottom: 28px; }
+.brand-text { font-size: 1.5rem; font-weight: 700; color: var(--color-primary); display: block; }
+.login-subtitle { font-size: 0.875rem; color: var(--color-text-secondary); display: block; margin-top: 4px; }
+.login-form { display: flex; flex-direction: column; gap: 16px; }
+.login-form label { font-size: 0.875rem; font-weight: 600; color: var(--color-text-secondary); }
+.login-form input { padding: 10px 14px; font-size: 1rem; border: 1px solid var(--color-border); border-radius: var(--radius-sm); }
+.login-form input:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 2px rgba(37,99,235,0.15); }
+.login-footer { text-align: center; margin-top: 20px; font-size: 0.8125rem; }
+.alert-error { background: #fef2f2; color: var(--color-danger); border: 1px solid #fecaca; padding: 10px 14px; border-radius: var(--radius-sm); font-size: 0.875rem; margin-bottom: 8px; }
+
+/* ── Home Page ───────────────────────────────────────────────────────────── */
+
+.home-main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+  width: 100%;
+  flex: 1;
+}
+.hero { text-align: center; padding: 48px 20px 32px; }
+.hero h1 { font-size: 2rem; font-weight: 800; color: var(--color-text); }
+.hero-subtitle { font-size: 1.125rem; color: var(--color-text-secondary); margin-top: 8px; max-width: 600px; margin-left: auto; margin-right: auto; }
+.home-section { margin-bottom: 40px; }
+.home-section h2 { font-size: 1.25rem; font-weight: 700; margin-bottom: 16px; }
+.home-event-card .card-body h4 { font-size: 0.8125rem; font-weight: 600; color: var(--color-text-secondary); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 8px; }
+.home-table { font-size: 0.8125rem; }
+.home-empty { margin-top: 24px; }
+
+.roles-section { margin-top: 48px; }
+.role-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; }
+.role-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 24px 20px;
+  text-align: center;
+  box-shadow: var(--shadow-sm);
+}
+.role-icon { font-size: 2rem; margin-bottom: 8px; }
+.role-card h3 { font-size: 1rem; font-weight: 600; margin-bottom: 8px; }
+.role-card p { font-size: 0.8125rem; color: var(--color-text-secondary); }
+
+/* ── Footer ──────────────────────────────────────────────────────────────── */
+
+.admin-footer {
+  text-align: center;
+  padding: 16px;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  border-top: 1px solid var(--color-border);
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .admin-header, .portal-home-header { padding: 0 16px; }
+  .admin-main, .home-main { padding: 16px; }
+  .card-grid { grid-template-columns: 1fr; }
+  .detail-grid { grid-template-columns: 1fr; }
+  .inline-form { flex-direction: column; }
+  .inline-form input { min-width: 100%; }
+  .header-nav { gap: 12px; }
+  .hero h1 { font-size: 1.5rem; }
+  .data-table { font-size: 0.8125rem; }
+  .data-table th, .data-table td { padding: 8px 6px; }
+  .page-header { flex-direction: column; }
+  .role-cards { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 480px) {
+  .role-cards { grid-template-columns: 1fr; }
+  .header-nav { gap: 8px; font-size: 0.75rem; }
+}
+
+/* ── Account page ─────────────────────────────────────────────────────────── */
+
+.account-card {
+  max-width: 600px;
+  margin: 0 auto;
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  padding: 32px;
+  box-shadow: var(--shadow-sm);
+}
+.account-card h1 { margin-bottom: 24px; }
+.account-info { margin-top: 24px; }
+.account-info h3 { margin-bottom: 8px; }
+
+/* ── User management ──────────────────────────────────────────────────────── */
+
+.role-select {
+  padding: 4px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  background: var(--color-surface);
+  cursor: pointer;
+}
+.actions-cell {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.btn-warning {
+  background: var(--color-warning);
+  color: #fff;
+}
+.btn-warning:hover { background: #d97706; }
+.btn-success {
+  background: var(--color-success);
+  color: #fff;
+}
+.btn-success:hover { background: #15803d; }
+.badge-role {
+  background: var(--color-primary);
+  color: #fff;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 0.8125rem;
+}
+.error-list {
+  margin: 0;
+  padding-left: 18px;
+  text-align: left;
+}
+.login-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  margin-top: 16px;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+.login-footer a { color: var(--color-primary); }
+.admin-help-section {
+  margin-top: 32px;
+  padding: 24px;
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+.admin-help-section h3 { margin-bottom: 12px; }

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -403,13 +403,6 @@ code { font-family: var(--font-mono); font-size: 0.875em; background: #f0f1f3; p
   color: #fff;
 }
 .btn-success:hover { background: #15803d; }
-.badge-role {
-  background: var(--color-primary);
-  color: #fff;
-  padding: 2px 10px;
-  border-radius: 12px;
-  font-size: 0.8125rem;
-}
 .error-list {
   margin: 0;
   padding-left: 18px;

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,0 +1,27 @@
+/**
+ * Admin panel client-side utilities.
+ * Loaded as an ES module — no jQuery, no inline scripts.
+ */
+
+function copyToClipboard(targetId) {
+  const el = document.getElementById(targetId);
+  if (!el) return;
+  const text = el.textContent.trim();
+  const fullUrl = text.startsWith('/') ? window.location.origin + text : text;
+  navigator.clipboard.writeText(fullUrl).then(() => {
+    const btn = el.nextElementSibling;
+    if (btn) {
+      const orig = btn.textContent;
+      btn.textContent = 'Copied!';
+      setTimeout(() => { btn.textContent = orig; }, 1500);
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.btn-copy[data-copy-target]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      copyToClipboard(btn.dataset.copyTarget);
+    });
+  });
+});

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -589,7 +589,6 @@ function joinBooth() {
     type: 'booth:join',
     display_name: displayName || 'Interpreter',
     role: requestedRole,
-    granted_role: state.grantedRole || null,
     language: state.language,
     channel_id: state.channelId,
     participant_id: state.participantId,

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -581,9 +581,11 @@ function joinBooth() {
   state.language = elements.language.value.trim() || state.language
   state.channelId = elements.channel.value.trim() || state.channelId
 
-  // Use the granted_role from the server if available; otherwise fall back to
-  // whatever the (potentially disabled) role select shows.
-  const requestedRole = state.grantedRole || elements.role.value
+  // The select value is the BOOTH role the user wants to join as.
+  // For roles like event_admin/super_admin, the select offers coordinator
+  // as default so admins don't accidentally take an interpreter slot.
+  // state.grantedRole is only used as fallback if the select has no value.
+  const requestedRole = elements.role.value || state.grantedRole || 'interpreter'
 
   wsSend({
     type: 'booth:join',
@@ -592,6 +594,7 @@ function joinBooth() {
     language: state.language,
     channel_id: state.channelId,
     participant_id: state.participantId,
+    event_slug: portal.dataset.eventSlug || '',
   })
 }
 

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -29,6 +29,8 @@ const state = {
   whipBase: portal.dataset.whipBase || '',
   hlsBase: portal.dataset.hlsBase || '',
   micDeviceId: localStorage.getItem('mic-device-id') || '',
+  /** Role granted by the server (from JWT). Empty string = unknown / legacy. */
+  grantedRole: portal.dataset.grantedRole || '',
   preflight: {
     micPermission: 'pending',
     audioDevice: 'pending',
@@ -578,10 +580,16 @@ function joinBooth() {
   const displayName = elements.displayName.value.trim()
   state.language = elements.language.value.trim() || state.language
   state.channelId = elements.channel.value.trim() || state.channelId
+
+  // Use the granted_role from the server if available; otherwise fall back to
+  // whatever the (potentially disabled) role select shows.
+  const requestedRole = state.grantedRole || elements.role.value
+
   wsSend({
     type: 'booth:join',
     display_name: displayName || 'Interpreter',
-    role: elements.role.value,
+    role: requestedRole,
+    granted_role: state.grantedRole || null,
     language: state.language,
     channel_id: state.channelId,
     participant_id: state.participantId,
@@ -999,9 +1007,28 @@ function sendChatMessage() {
 // ── Rendering ─────────────────────────────────────────────────────────────────
 
 function render() {
+  renderRoleControls()
   renderParticipants()
   renderChat()
   renderMicControls()
+}
+
+/**
+ * Show/hide controls that are not available to the current role.
+ * - Listeners: hide Go Live, Relay, mic controls (they can only chat + observe).
+ * - Interpreters: show Go Live + Relay, hide coordinator-only actions.
+ * - Coordinators/admins: show all controls.
+ */
+function renderRoleControls() {
+  const role = state.grantedRole
+  if (!role) return  // unknown / legacy path — leave everything visible
+
+  const isListener = role === 'listener'
+  const canGo = !isListener  // interpreters + coordinators + admins can go live
+
+  if (elements.goLive) elements.goLive.style.display = canGo ? '' : 'none'
+  if (elements.passRelay) elements.passRelay.style.display = canGo ? '' : 'none'
+  if (elements.ctrlCompound) elements.ctrlCompound.style.display = canGo ? '' : 'none'
 }
 
 function renderParticipants() {

--- a/templates/account.html
+++ b/templates/account.html
@@ -30,10 +30,6 @@
               <td>{{ user.display_name }}</td>
             </tr>
             <tr>
-              <th>Role</th>
-              <td><span class="badge badge-role">{{ user.role }}</span></td>
-            </tr>
-            <tr>
               <th>Joined</th>
               <td>{{ user.created_at.strftime('%Y-%m-%d %H:%M UTC') if user.created_at else '—' }}</td>
             </tr>
@@ -51,18 +47,24 @@
         </table>
 
         <div class="account-info">
-          <h3>Your Permissions</h3>
-          {% if user.role == 'listener' %}
-          <p>As a <strong>listener</strong>, you can join any event and listen to live interpretation streams.</p>
-          <p class="muted">An admin can assign you additional roles (interpreter, coordinator) for specific events.</p>
-          {% elif user.role == 'interpreter' %}
-          <p>As an <strong>interpreter</strong>, you can join booth sessions, go live, and provide real-time interpretation.</p>
-          {% elif user.role == 'coordinator' %}
-          <p>As a <strong>coordinator</strong>, you can manage interpreter assignments and coordinate handoffs within booths.</p>
-          {% elif user.role == 'event_admin' %}
-          <p>As an <strong>event admin</strong>, you can manage booths, rooms, and invite tokens for your events.</p>
-          {% elif user.role == 'super_admin' %}
-          <p>As a <strong>super admin</strong>, you have full access to all administrative functions.</p>
+          <h3>Your Event Roles</h3>
+          {% if memberships %}
+          <table class="data-table compact">
+            <thead>
+              <tr><th>Event</th><th>Role</th><th>Since</th></tr>
+            </thead>
+            <tbody>
+              {% for m in memberships %}
+              <tr>
+                <td>{{ m.event.display_name if m.event else '—' }}</td>
+                <td><span class="badge badge-role badge-{{ m.role }}">{{ m.role }}</span></td>
+                <td>{{ m.created_at.strftime('%Y-%m-%d') if m.created_at else '—' }}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% else %}
+          <p class="muted">You have not been assigned a role for any event yet. An admin can assign roles on a per-event basis.</p>
           {% endif %}
         </div>
       </div>

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My Account — Eventyay</title>
+    <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='favicon.ico') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}" />
+  </head>
+  <body>
+    <header class="portal-home-header">
+      <a class="brand" href="/">Eventyay</a>
+      <nav class="header-nav">
+        <a href="/account">My Account</a>
+        <a href="/logout">Logout</a>
+      </nav>
+    </header>
+
+    <main class="admin-main">
+      <div class="account-card">
+        <h1>My Account</h1>
+        <table class="data-table">
+          <tbody>
+            <tr>
+              <th>Email</th>
+              <td>{{ user.email }}</td>
+            </tr>
+            <tr>
+              <th>Display Name</th>
+              <td>{{ user.display_name }}</td>
+            </tr>
+            <tr>
+              <th>Role</th>
+              <td><span class="badge badge-role">{{ user.role }}</span></td>
+            </tr>
+            <tr>
+              <th>Joined</th>
+              <td>{{ user.created_at.strftime('%Y-%m-%d %H:%M UTC') if user.created_at else '—' }}</td>
+            </tr>
+            <tr>
+              <th>Status</th>
+              <td>
+                {% if user.is_active %}
+                <span class="status-live">● Active</span>
+                {% else %}
+                <span class="status-offline">○ Deactivated</span>
+                {% endif %}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="account-info">
+          <h3>Your Permissions</h3>
+          {% if user.role == 'listener' %}
+          <p>As a <strong>listener</strong>, you can join any event and listen to live interpretation streams.</p>
+          <p class="muted">An admin can assign you additional roles (interpreter, coordinator) for specific events.</p>
+          {% elif user.role == 'interpreter' %}
+          <p>As an <strong>interpreter</strong>, you can join booth sessions, go live, and provide real-time interpretation.</p>
+          {% elif user.role == 'coordinator' %}
+          <p>As a <strong>coordinator</strong>, you can manage interpreter assignments and coordinate handoffs within booths.</p>
+          {% elif user.role == 'event_admin' %}
+          <p>As an <strong>event admin</strong>, you can manage booths, rooms, and invite tokens for your events.</p>
+          {% elif user.role == 'super_admin' %}
+          <p>As a <strong>super admin</strong>, you have full access to all administrative functions.</p>
+          {% endif %}
+        </div>
+      </div>
+    </main>
+
+    <footer class="admin-footer">
+      <span>Eventyay Interpretation Portal — Powered by FastAPI + MediaMTX</span>
+    </footer>
+  </body>
+</html>

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{% block title %}Admin Panel{% endblock %} — Eventyay</title>
+    <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='favicon.ico') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}" />
+    {% block head %}{% endblock %}
+  </head>
+  <body>
+    <header class="admin-header">
+      <div class="header-left">
+        <a class="brand" href="/admin/">Eventyay</a>
+        <span class="header-badge">Admin</span>
+      </div>
+      <nav class="header-nav">
+        <a href="/admin/">Dashboard</a>
+        <a href="/admin/events/">Events</a>
+        <a href="/admin/users/">Users</a>
+        <a href="/" target="_blank">Portal Home</a>
+        <a href="/admin/logout" class="nav-logout">Logout</a>
+      </nav>
+    </header>
+
+    {% block breadcrumb %}{% endblock %}
+
+    <main class="admin-main">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="admin-footer">
+      <span>Eventyay Interpretation Portal — Admin Panel</span>
+    </footer>
+  </body>
+</html>

--- a/templates/admin/booth_detail.html
+++ b/templates/admin/booth_detail.html
@@ -1,0 +1,222 @@
+{% extends "admin/base.html" %}
+{% block title %}{{ booth.language_name }} Booth — {{ event.display_name }}{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+  <a href="/admin/">Dashboard</a> <span>/</span>
+  <a href="/admin/events/">Events</a> <span>/</span>
+  <a href="/admin/events/{{ event.id }}/">{{ event.display_name }}</a> <span>/</span>
+  <a href="/admin/events/{{ event.id }}/rooms/">Rooms</a> <span>/</span>
+  <a href="/admin/events/{{ event.id }}/rooms/{{ room.id }}/">{{ room.display_name }}</a> <span>/</span>
+  <a href="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/">Booths</a> <span>/</span>
+  <span>{{ booth.language_name }}</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>
+    {{ booth.language_name }} ({{ booth.language_code }})
+    {% if is_live %}
+    <span class="status-live header-status">● LIVE</span>
+    {% else %}
+    <span class="status-offline header-status">○ OFFLINE</span>
+    {% endif %}
+  </h1>
+  <div class="header-meta">
+    <span class="meta-text">Event: {{ event.display_name }}</span>
+    <span class="meta-text">Room: {{ room.display_name }}</span>
+  </div>
+</div>
+
+<!-- Booth Info Cards -->
+<div class="detail-grid">
+  <div class="detail-card">
+    <h3>Booth Information</h3>
+    <dl class="detail-list">
+      <dt>Booth ID</dt>
+      <dd><code>{{ booth_id }}</code></dd>
+      <dt>MediaMTX Path</dt>
+      <dd><code>{{ mediamtx_path }}</code></dd>
+      <dt>Language</dt>
+      <dd>{{ booth.language_name }} ({{ booth.language_code }})</dd>
+      <dt>Created</dt>
+      <dd>{{ booth.created_at.strftime('%Y-%m-%d %H:%M UTC') if booth.created_at else '—' }}</dd>
+    </dl>
+  </div>
+
+  <div class="detail-card">
+    <h3>Links</h3>
+    <dl class="detail-list">
+      <dt>Interpreter Booth</dt>
+      <dd>
+        <a href="/interpreter/{{ event.slug }}/{{ booth.language_code }}" target="_blank" class="link-external">
+          /interpreter/{{ event.slug }}/{{ booth.language_code }} ↗
+        </a>
+      </dd>
+      <dt>WHEP Listener URL</dt>
+      <dd class="copyable-field">
+        <code id="whep-url">{{ whep_url }}</code>
+        <button type="button" class="btn btn-sm btn-copy" onclick="copyToClipboard('whep-url')">Copy</button>
+      </dd>
+      <dt>Listener Page (WebRTC)</dt>
+      <dd>
+        <a href="/listener-webrtc/{{ booth_id }}" target="_blank" class="link-external">
+          /listener-webrtc/{{ booth_id }} ↗
+        </a>
+      </dd>
+      <dt>Listener Page (HLS Fallback)</dt>
+      <dd>
+        <a href="/listen/{{ booth_id }}" target="_blank" class="link-external">
+          /listen/{{ booth_id }} ↗
+        </a>
+      </dd>
+    </dl>
+  </div>
+
+  <div class="detail-card">
+    <h3>Live Status</h3>
+    <dl class="detail-list">
+      <dt>Status</dt>
+      <dd>
+        {% if is_live %}
+        <span class="status-live">● LIVE — Audio streaming</span>
+        {% else %}
+        <span class="status-offline">○ OFFLINE — No active stream</span>
+        {% endif %}
+      </dd>
+      <dt>Active Interpreter</dt>
+      <dd>
+        {% if active_interpreter %}
+        {{ active_interpreter.name }} ({{ active_interpreter.role }})
+        {% else %}
+        <span class="muted">None</span>
+        {% endif %}
+      </dd>
+    </dl>
+  </div>
+</div>
+
+<!-- Participant Roster -->
+<div class="section-card">
+  <div class="section-header">
+    <h2>Participant Roster ({{ participants|length }})</h2>
+  </div>
+  {% if participants %}
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Role</th>
+        <th>Mic</th>
+        <th>Ingest</th>
+        <th>Joined</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for p in participants %}
+      <tr>
+        <td>
+          {{ p.name or p.participant_id }}
+          {% if active_interpreter and p.participant_id == active_interpreter.participant_id %}
+          <span class="badge badge-active">Active</span>
+          {% endif %}
+        </td>
+        <td><span class="badge badge-role badge-{{ p.role }}">{{ p.role }}</span></td>
+        <td>{{ '🎙️ On' if p.mic_active else '🔇 Off' }}</td>
+        <td>{{ '📡 Connected' if p.ingest_connected else '—' }}</td>
+        <td>{{ p.joined_at if p.joined_at else '—' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="empty-state">
+    <p>No participants currently connected to this booth.</p>
+  </div>
+  {% endif %}
+</div>
+
+<!-- Invite Tokens -->
+<div class="section-card">
+  <div class="section-header">
+    <h2>Invite Tokens ({{ tokens|length }})</h2>
+  </div>
+  {% if tokens %}
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Label</th>
+        <th>Role</th>
+        <th>Token</th>
+        <th>Invite Link</th>
+        <th>Status</th>
+        <th>Expires</th>
+        <th>Created</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for tok in tokens %}
+      <tr class="{{ 'row-used' if tok.is_used else ('row-expired' if tok.is_expired else '') }}">
+        <td>{{ tok.label or '—' }}</td>
+        <td><span class="badge badge-role badge-{{ tok.role }}">{{ tok.role }}</span></td>
+        <td><code class="token-preview">{{ tok.token[:12] }}…</code></td>
+        <td>
+          {% if not tok.is_used and not tok.is_expired %}
+          <span class="copyable-field">
+            <code id="tok-{{ tok.token[:8] }}">/join/{{ tok.token }}</code>
+            <button type="button" class="btn btn-sm btn-copy" onclick="copyToClipboard('tok-{{ tok.token[:8] }}')">Copy</button>
+          </span>
+          {% else %}
+          <span class="muted">—</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if tok.is_used %}
+          <span class="badge badge-used">Used</span>
+          {% elif tok.is_expired %}
+          <span class="badge badge-expired">Expired</span>
+          {% else %}
+          <span class="badge badge-valid">Valid</span>
+          {% endif %}
+        </td>
+        <td>{{ tok.expires_at.strftime('%Y-%m-%d %H:%M') if tok.expires_at else 'Never' }}</td>
+        <td>{{ tok.created_at.strftime('%Y-%m-%d %H:%M') if tok.created_at else '—' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="empty-state">
+    <p>No invite tokens for this booth. Token management will be available in Step 5.</p>
+  </div>
+  {% endif %}
+</div>
+
+<div class="danger-zone">
+  <h3>Danger Zone</h3>
+  <form method="post" action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/delete"
+        class="inline-delete"
+        onsubmit="return confirm('Delete the {{ booth.language_name }} booth? All invite tokens will be removed.')">
+    <button type="submit" class="btn btn-danger">Delete Booth</button>
+    <span class="danger-text">This removes all invite tokens for this booth.</span>
+  </form>
+</div>
+
+<script>
+function copyToClipboard(elementId) {
+  const el = document.getElementById(elementId);
+  if (!el) return;
+  const text = el.textContent.trim();
+  const fullUrl = window.location.origin + text;
+  navigator.clipboard.writeText(text.startsWith('/') ? fullUrl : text).then(() => {
+    const btn = el.nextElementSibling;
+    if (btn) {
+      const orig = btn.textContent;
+      btn.textContent = 'Copied!';
+      setTimeout(() => { btn.textContent = orig; }, 1500);
+    }
+  });
+}
+</script>
+{% endblock %}

--- a/templates/admin/booth_detail.html
+++ b/templates/admin/booth_detail.html
@@ -57,7 +57,7 @@
       <dt>WHEP Listener URL</dt>
       <dd class="copyable-field">
         <code id="whep-url">{{ whep_url }}</code>
-        <button type="button" class="btn btn-sm btn-copy" onclick="copyToClipboard('whep-url')">Copy</button>
+        <button type="button" class="btn btn-sm btn-copy" data-copy-target="whep-url">Copy</button>
       </dd>
       <dt>Listener Page (WebRTC)</dt>
       <dd>

--- a/templates/admin/booth_detail.html
+++ b/templates/admin/booth_detail.html
@@ -142,17 +142,46 @@
   <div class="section-header">
     <h2>Invite Tokens ({{ tokens|length }})</h2>
   </div>
+
+  <!-- Token Generation Form -->
+  <div class="token-form-card">
+    <h3>Generate New Token</h3>
+    <form method="post" action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/tokens/" class="token-form">
+      <div class="form-row">
+        <div class="form-group">
+          <label for="role">Role</label>
+          <select name="role" id="role" required>
+            <option value="listener">listener</option>
+            <option value="interpreter" selected>interpreter</option>
+            <option value="coordinator">coordinator</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="label">Label</label>
+          <input type="text" name="label" id="label" placeholder="e.g. Alice — Spanish interpreter" />
+        </div>
+        <div class="form-group">
+          <label for="expires_hours">Expires in (hours)</label>
+          <input type="number" name="expires_hours" id="expires_hours" placeholder="Empty = never" min="1" />
+        </div>
+        <div class="form-group form-group-btn">
+          <button type="submit" class="btn btn-primary">Generate Token</button>
+        </div>
+      </div>
+    </form>
+  </div>
+
   {% if tokens %}
   <table class="data-table">
     <thead>
       <tr>
         <th>Label</th>
         <th>Role</th>
-        <th>Token</th>
         <th>Invite Link</th>
         <th>Status</th>
         <th>Expires</th>
         <th>Created</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -160,12 +189,11 @@
       <tr class="{{ 'row-used' if tok.is_used else ('row-expired' if tok.is_expired else '') }}">
         <td>{{ tok.label or '—' }}</td>
         <td><span class="badge badge-role badge-{{ tok.role }}">{{ tok.role }}</span></td>
-        <td><code class="token-preview">{{ tok.token[:12] }}…</code></td>
         <td>
           {% if not tok.is_used and not tok.is_expired %}
           <span class="copyable-field">
             <code id="tok-{{ tok.token[:8] }}">/join/{{ tok.token }}</code>
-            <button type="button" class="btn btn-sm btn-copy" onclick="copyToClipboard('tok-{{ tok.token[:8] }}')">Copy</button>
+            <button type="button" class="btn btn-sm btn-copy" data-copy-target="tok-{{ tok.token[:8] }}">Copy Link</button>
           </span>
           {% else %}
           <span class="muted">—</span>
@@ -173,7 +201,7 @@
         </td>
         <td>
           {% if tok.is_used %}
-          <span class="badge badge-used">Used</span>
+          <span class="badge badge-used">Revoked / Used</span>
           {% elif tok.is_expired %}
           <span class="badge badge-expired">Expired</span>
           {% else %}
@@ -182,13 +210,25 @@
         </td>
         <td>{{ tok.expires_at.strftime('%Y-%m-%d %H:%M') if tok.expires_at else 'Never' }}</td>
         <td>{{ tok.created_at.strftime('%Y-%m-%d %H:%M') if tok.created_at else '—' }}</td>
+        <td>
+          {% if not tok.is_used and not tok.is_expired %}
+          <form method="post"
+                action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/tokens/{{ tok.token }}/revoke"
+                class="inline-form"
+                onsubmit="return confirm('Revoke this token? It cannot be used to join after revocation.')">
+            <button type="submit" class="btn btn-sm btn-danger">Revoke</button>
+          </form>
+          {% else %}
+          <span class="muted">—</span>
+          {% endif %}
+        </td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
   {% else %}
   <div class="empty-state">
-    <p>No invite tokens for this booth. Token management will be available in Step 5.</p>
+    <p>No invite tokens for this booth yet. Use the form above to generate one.</p>
   </div>
   {% endif %}
 </div>
@@ -203,20 +243,5 @@
   </form>
 </div>
 
-<script>
-function copyToClipboard(elementId) {
-  const el = document.getElementById(elementId);
-  if (!el) return;
-  const text = el.textContent.trim();
-  const fullUrl = window.location.origin + text;
-  navigator.clipboard.writeText(text.startsWith('/') ? fullUrl : text).then(() => {
-    const btn = el.nextElementSibling;
-    if (btn) {
-      const orig = btn.textContent;
-      btn.textContent = 'Copied!';
-      setTimeout(() => { btn.textContent = orig; }, 1500);
-    }
-  });
-}
-</script>
+<script type="module" src="{{ url_for('static', path='js/admin.js') }}"></script>
 {% endblock %}

--- a/templates/admin/booth_detail.html
+++ b/templates/admin/booth_detail.html
@@ -142,7 +142,43 @@
   <div class="section-header">
     <h2>Assigned Members</h2>
   </div>
-  {% if users %}
+  
+  {% if request.query_params.get('error') == 'user_not_found' %}
+  <div class="alert alert-danger" style="margin-bottom: 1rem; color: #d32f2f; background-color: #fde0e0; padding: 10px; border-radius: 4px;">
+    <strong>Error:</strong> User with that email address was not found. They must register first.
+  </div>
+  {% endif %}
+
+  <!-- Assign Member Form -->
+  <div class="token-form-card" style="margin-bottom: 1.5rem;">
+    <h3>Assign Member</h3>
+    <form method="post" action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/members/" class="token-form">
+      <div class="form-row">
+        <div class="form-group" style="flex: 2;">
+          <label for="member_email">User Email</label>
+          <input type="email" name="email" id="member_email" placeholder="user@example.com" required />
+        </div>
+        <div class="form-group">
+          <label for="member_role">Role</label>
+          <select name="role" id="member_role" required>
+            <option value="listener">listener</option>
+            <option value="interpreter" selected>interpreter</option>
+            <option value="coordinator">coordinator</option>
+          </select>
+        </div>
+        <div class="form-group form-group-btn">
+          <button type="submit" class="btn btn-primary">Assign Member</button>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  {% set current_members = [] %}
+  {% for m in memberships %}
+    {% set current_members = current_members.append(m) %}
+  {% endfor %}
+
+  {% if memberships %}
   <table class="data-table">
     <thead>
       <tr>
@@ -154,9 +190,9 @@
       </tr>
     </thead>
     <tbody>
-      {% for u in users %}
-      {% set m = membership_map.get(u.id) %}
-      <tr class="{{ 'row-assigned' if m else '' }}">
+      {% for m in memberships %}
+      {% set u = m.user %}
+      <tr class="row-assigned">
         <td>{{ u.email }}</td>
         <td>{{ u.display_name }}</td>
         <td>
@@ -167,27 +203,15 @@
           {% endif %}
         </td>
         <td>
-          <form method="post" action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/members/" class="inline-form">
-            <input type="hidden" name="user_id" value="{{ u.id }}" />
-            <select name="role" class="role-select" onchange="this.form.submit()">
-              <option value="">— none —</option>
-              <option value="listener" {{ 'selected' if m and m.role == 'listener' }}>listener</option>
-              <option value="interpreter" {{ 'selected' if m and m.role == 'interpreter' }}>interpreter</option>
-              <option value="coordinator" {{ 'selected' if m and m.role == 'coordinator' }}>coordinator</option>
-            </select>
-          </form>
+          <span class="badge badge-role badge-{{ m.role }}">{{ m.role }}</span>
         </td>
         <td class="actions-cell">
-          {% if m %}
           <form method="post"
                 action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/members/{{ m.id }}/delete"
                 class="inline-form"
                 onsubmit="return confirm('Remove {{ u.display_name }} from this booth?')">
             <button type="submit" class="btn btn-sm btn-danger">Remove</button>
           </form>
-          {% else %}
-          <span class="muted">—</span>
-          {% endif %}
         </td>
       </tr>
       {% endfor %}
@@ -195,7 +219,7 @@
   </table>
   {% else %}
   <div class="empty-state">
-    <p>No registered users found.</p>
+    <p>No users are assigned to this booth yet.</p>
   </div>
   {% endif %}
 </div>

--- a/templates/admin/booth_detail.html
+++ b/templates/admin/booth_detail.html
@@ -88,7 +88,7 @@
       <dt>Active Interpreter</dt>
       <dd>
         {% if active_interpreter %}
-        {{ active_interpreter.name }} ({{ active_interpreter.role }})
+        {{ active_interpreter.display_name }} ({{ active_interpreter.role }})
         {% else %}
         <span class="muted">None</span>
         {% endif %}
@@ -117,7 +117,7 @@
       {% for p in participants %}
       <tr>
         <td>
-          {{ p.name or p.participant_id }}
+          {{ p.display_name or p.participant_id }}
           {% if active_interpreter and p.participant_id == active_interpreter.participant_id %}
           <span class="badge badge-active">Active</span>
           {% endif %}

--- a/templates/admin/booth_detail.html
+++ b/templates/admin/booth_detail.html
@@ -137,6 +137,69 @@
   {% endif %}
 </div>
 
+<!-- Assigned Members -->
+<div class="section-card">
+  <div class="section-header">
+    <h2>Assigned Members</h2>
+  </div>
+  {% if users %}
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Email</th>
+        <th>Display Name</th>
+        <th>Account Status</th>
+        <th>Booth Role</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for u in users %}
+      {% set m = membership_map.get(u.id) %}
+      <tr class="{{ 'row-assigned' if m else '' }}">
+        <td>{{ u.email }}</td>
+        <td>{{ u.display_name }}</td>
+        <td>
+          {% if u.is_active %}
+          <span class="status-live">● Active</span>
+          {% else %}
+          <span class="status-offline">○ Inactive</span>
+          {% endif %}
+        </td>
+        <td>
+          <form method="post" action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/members/" class="inline-form">
+            <input type="hidden" name="user_id" value="{{ u.id }}" />
+            <select name="role" class="role-select" onchange="this.form.submit()">
+              <option value="">— none —</option>
+              <option value="listener" {{ 'selected' if m and m.role == 'listener' }}>listener</option>
+              <option value="interpreter" {{ 'selected' if m and m.role == 'interpreter' }}>interpreter</option>
+              <option value="coordinator" {{ 'selected' if m and m.role == 'coordinator' }}>coordinator</option>
+            </select>
+          </form>
+        </td>
+        <td class="actions-cell">
+          {% if m %}
+          <form method="post"
+                action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/members/{{ m.id }}/delete"
+                class="inline-form"
+                onsubmit="return confirm('Remove {{ u.display_name }} from this booth?')">
+            <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+          </form>
+          {% else %}
+          <span class="muted">—</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="empty-state">
+    <p>No registered users found.</p>
+  </div>
+  {% endif %}
+</div>
+
 <!-- Invite Tokens -->
 <div class="section-card">
   <div class="section-header">

--- a/templates/admin/booth_list.html
+++ b/templates/admin/booth_list.html
@@ -1,0 +1,84 @@
+{% extends "admin/base.html" %}
+{% block title %}Booths — {{ room.display_name }}{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+  <a href="/admin/">Dashboard</a> <span>/</span>
+  <a href="/admin/events/">Events</a> <span>/</span>
+  <a href="/admin/events/{{ event.id }}/">{{ event.display_name }}</a> <span>/</span>
+  <a href="/admin/events/{{ event.id }}/rooms/">Rooms</a> <span>/</span>
+  <a href="/admin/events/{{ event.id }}/rooms/{{ room.id }}/">{{ room.display_name }}</a> <span>/</span>
+  <span>Booths</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Booths — {{ room.display_name }}</h1>
+  <div class="header-meta">
+    <span class="meta-text">Event: {{ event.display_name }}</span>
+  </div>
+</div>
+
+<div class="form-card">
+  <h3>Add Interpretation Booth</h3>
+  <form method="post" action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/" class="inline-form">
+    <input type="text" name="language_code" placeholder="Language code (e.g. en, fr, zh)" required
+           pattern="^[a-z]{2}$" maxlength="2" title="Two-letter ISO 639-1 code" />
+    <input type="text" name="language_name" placeholder="Language name (e.g. English, French)" required />
+    <button type="submit" class="btn btn-primary">Add Booth</button>
+  </form>
+</div>
+
+{% if booths %}
+<table class="data-table schedule-table">
+  <thead>
+    <tr>
+      <th>Language</th>
+      <th>Code</th>
+      <th>Status</th>
+      <th>Interpreter Page</th>
+      <th>Listener Page (WHEP)</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for bs in booths %}
+    <tr class="{{ 'row-live' if bs.is_live else '' }}">
+      <td><strong>{{ bs.db.language_name }}</strong></td>
+      <td><code>{{ bs.db.language_code }}</code></td>
+      <td>
+        {% if bs.is_live %}
+        <span class="status-live">● LIVE</span>
+        {% else %}
+        <span class="status-offline">○ Offline</span>
+        {% endif %}
+      </td>
+      <td>
+        <a href="/interpreter/{{ event.slug }}/{{ bs.db.language_code }}" target="_blank" class="link-external">
+          Open Booth ↗
+        </a>
+      </td>
+      <td>
+        <a href="/listener-webrtc/{{ bs.booth_id }}" target="_blank" class="link-external">
+          Listen ↗
+        </a>
+      </td>
+      <td>
+        <a href="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ bs.db.id }}/" class="btn btn-sm">Details</a>
+        <form method="post" action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ bs.db.id }}/delete"
+              class="inline-delete"
+              onsubmit="return confirm('Delete {{ bs.db.language_name }} booth?')">
+          <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+  <p>No booths in this room. Use the form above to add one.</p>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,0 +1,58 @@
+{% extends "admin/base.html" %}
+{% block title %}Dashboard{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Dashboard</h1>
+  <div class="system-health">
+    <span class="health-dot {{ 'health-ok' if mediamtx_ok else 'health-down' }}"></span>
+    MediaMTX {{ 'Online' if mediamtx_ok else 'Offline' }}
+  </div>
+</div>
+
+{% if not event_data %}
+<div class="empty-state">
+  <p>No events yet. <a href="/admin/events/">Create your first event</a> to get started.</p>
+</div>
+{% else %}
+<div class="card-grid">
+  {% for ed in event_data %}
+  <div class="card event-card">
+    <div class="card-header">
+      <a href="/admin/events/{{ ed.event.id }}/" class="card-title">{{ ed.event.display_name }}</a>
+      <span class="badge badge-slug">{{ ed.event.slug }}</span>
+    </div>
+    <div class="card-body">
+      <div class="stat-row">
+        <span class="stat-label">Booths</span>
+        <span class="stat-value">{{ ed.total_booths }}</span>
+      </div>
+      <div class="stat-row">
+        <span class="stat-label">Live Now</span>
+        <span class="stat-value">
+          {% if ed.live_count > 0 %}
+          <span class="status-live">● {{ ed.live_count }}</span>
+          {% else %}
+          <span class="status-offline">○ 0</span>
+          {% endif %}
+        </span>
+      </div>
+      {% if ed.booths %}
+      <div class="booth-chips">
+        {% for bs in ed.booths %}
+        <span class="chip {{ 'chip-live' if bs.is_live else 'chip-offline' }}">
+          {{ bs.db.language_name }} ({{ bs.db.language_code }})
+          {{ '●' if bs.is_live else '○' }}
+        </span>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+    <div class="card-actions">
+      <a href="/admin/events/{{ ed.event.id }}/" class="btn btn-sm">Manage →</a>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/admin/event_detail.html
+++ b/templates/admin/event_detail.html
@@ -24,6 +24,15 @@
 </div>
 
 <div class="section-grid">
+  <!-- Members section -->
+  <div class="section-card">
+    <div class="section-header">
+      <h2>Members</h2>
+      <a href="/admin/events/{{ event.id }}/members/" class="btn btn-sm btn-primary">Manage Members</a>
+    </div>
+    <p class="muted">Assign per-event roles (listener, interpreter, coordinator, event_admin) to registered users.</p>
+  </div>
+
   <!-- Rooms section -->
   <div class="section-card">
     <div class="section-header">

--- a/templates/admin/event_detail.html
+++ b/templates/admin/event_detail.html
@@ -1,0 +1,100 @@
+{% extends "admin/base.html" %}
+{% block title %}{{ event.display_name }}{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+  <a href="/admin/">Dashboard</a> <span>/</span>
+  <a href="/admin/events/">Events</a> <span>/</span>
+  <span>{{ event.display_name }}</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>{{ event.display_name }}</h1>
+  <div class="header-meta">
+    <span class="badge badge-slug">{{ event.slug }}</span>
+    <span class="meta-text">Created {{ event.created_at.strftime('%Y-%m-%d') if event.created_at else '—' }}</span>
+    {% if live_count > 0 %}
+    <span class="status-live">● {{ live_count }} booth{{ 's' if live_count != 1 else '' }} live</span>
+    {% else %}
+    <span class="status-offline">○ No booths live</span>
+    {% endif %}
+  </div>
+</div>
+
+<div class="section-grid">
+  <!-- Rooms section -->
+  <div class="section-card">
+    <div class="section-header">
+      <h2>Rooms ({{ rooms|length }})</h2>
+      <a href="/admin/events/{{ event.id }}/rooms/" class="btn btn-sm">Manage Rooms</a>
+    </div>
+    {% if rooms %}
+    <ul class="item-list">
+      {% for room in rooms %}
+      <li>
+        <a href="/admin/events/{{ event.id }}/rooms/{{ room.id }}/">{{ room.display_name }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p class="muted">No rooms yet. <a href="/admin/events/{{ event.id }}/rooms/">Add one</a>.</p>
+    {% endif %}
+  </div>
+
+  <!-- Booths overview -->
+  <div class="section-card">
+    <div class="section-header">
+      <h2>Booths ({{ booths|length }})</h2>
+    </div>
+    {% if booths %}
+    <table class="data-table compact">
+      <thead>
+        <tr>
+          <th>Language</th>
+          <th>Code</th>
+          <th>Status</th>
+          <th>Booth Page</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for bs in booths %}
+        <tr>
+          <td>{{ bs.db.language_name }}</td>
+          <td><code>{{ bs.db.language_code }}</code></td>
+          <td>
+            {% if bs.is_live %}
+            <span class="status-live">● LIVE</span>
+            {% else %}
+            <span class="status-offline">○ Offline</span>
+            {% endif %}
+          </td>
+          <td>
+            <a href="/interpreter/{{ event.slug }}/{{ bs.db.language_code }}" target="_blank" class="link-external">
+              /interpreter/{{ event.slug }}/{{ bs.db.language_code }}
+            </a>
+          </td>
+          <td>
+            <a href="/admin/events/{{ event.id }}/rooms/{{ bs.db.room_id }}/booths/{{ bs.db.id }}/" class="btn btn-sm">View</a>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <p class="muted">No booths configured. Add rooms first, then create booths.</p>
+    {% endif %}
+  </div>
+</div>
+
+<div class="danger-zone">
+  <h3>Danger Zone</h3>
+  <form method="post" action="/admin/events/{{ event.id }}/delete" class="inline-delete"
+        onsubmit="return confirm('Delete \'{{ event.display_name }}\'? This permanently removes all rooms, booths, and invite tokens.')">
+    <button type="submit" class="btn btn-danger">Delete Event</button>
+    <span class="danger-text">This action cannot be undone.</span>
+  </form>
+</div>
+{% endblock %}

--- a/templates/admin/event_list.html
+++ b/templates/admin/event_list.html
@@ -1,0 +1,56 @@
+{% extends "admin/base.html" %}
+{% block title %}Events{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+  <a href="/admin/">Dashboard</a> <span>/</span> <span>Events</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Events</h1>
+</div>
+
+<div class="form-card">
+  <h3>Create Event</h3>
+  <form method="post" action="/admin/events/" class="inline-form">
+    <input type="text" name="slug" placeholder="event-slug" required pattern="^[a-z0-9]+(-[a-z0-9]+)*$" title="Lowercase letters, numbers, hyphens only" />
+    <input type="text" name="display_name" placeholder="Display Name" required />
+    <button type="submit" class="btn btn-primary">Create</button>
+  </form>
+</div>
+
+{% if events %}
+<table class="data-table">
+  <thead>
+    <tr>
+      <th>Event Name</th>
+      <th>Slug</th>
+      <th>Created</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for ev in events %}
+    <tr>
+      <td><a href="/admin/events/{{ ev.id }}/">{{ ev.display_name }}</a></td>
+      <td><code>{{ ev.slug }}</code></td>
+      <td>{{ ev.created_at.strftime('%Y-%m-%d %H:%M') if ev.created_at else '—' }}</td>
+      <td>
+        <a href="/admin/events/{{ ev.id }}/" class="btn btn-sm">View</a>
+        <form method="post" action="/admin/events/{{ ev.id }}/delete" class="inline-delete"
+              onsubmit="return confirm('Delete event \'{{ ev.display_name }}\'? This will remove all rooms, booths, and tokens.')">
+          <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+  <p>No events created yet. Use the form above to create one.</p>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/admin/event_members.html
+++ b/templates/admin/event_members.html
@@ -1,0 +1,81 @@
+{% extends "admin/base.html" %}
+
+{% block title %}Members — {{ event.display_name }}{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+  <a href="/admin/">Dashboard</a> ›
+  <a href="/admin/events/">Events</a> ›
+  <a href="/admin/events/{{ event.id }}/">{{ event.display_name }}</a> ›
+  <span>Members</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Members — {{ event.display_name }}</h1>
+  <span class="badge">{{ memberships|length }} assigned</span>
+</div>
+
+{% if users %}
+<table class="data-table">
+  <thead>
+    <tr>
+      <th>Email</th>
+      <th>Display Name</th>
+      <th>Account Status</th>
+      <th>Event Role</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for u in users %}
+    {% set m = membership_map.get(u.id) %}
+    <tr class="{{ 'row-assigned' if m else '' }}">
+      <td>{{ u.email }}</td>
+      <td>{{ u.display_name }}</td>
+      <td>
+        {% if u.is_active %}
+        <span class="status-live">● Active</span>
+        {% else %}
+        <span class="status-offline">○ Inactive</span>
+        {% endif %}
+      </td>
+      <td>
+        <form method="post" action="/admin/events/{{ event.id }}/members/" class="inline-form">
+          <input type="hidden" name="user_id" value="{{ u.id }}" />
+          <select name="role" class="role-select" onchange="this.form.submit()">
+            <option value="">— none —</option>
+            <option value="listener" {{ 'selected' if m and m.role == 'listener' }}>listener</option>
+            <option value="interpreter" {{ 'selected' if m and m.role == 'interpreter' }}>interpreter</option>
+            <option value="coordinator" {{ 'selected' if m and m.role == 'coordinator' }}>coordinator</option>
+            <option value="event_admin" {{ 'selected' if m and m.role == 'event_admin' }}>event_admin</option>
+          </select>
+        </form>
+      </td>
+      <td class="actions-cell">
+        {% if m %}
+        <form method="post"
+              action="/admin/events/{{ event.id }}/members/{{ m.id }}/delete"
+              class="inline-form"
+              onsubmit="return confirm('Remove {{ u.display_name }} from this event?')">
+          <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+        </form>
+        {% else %}
+        <span class="muted">—</span>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+  <p>No registered users yet. Users can sign up at <a href="/register">/register</a>.</p>
+</div>
+{% endif %}
+
+<div class="admin-help-section">
+  <p>Select a role from the dropdown to assign or change a user's role for this event. Click <strong>Remove</strong> to revoke access entirely.</p>
+</div>
+{% endblock %}

--- a/templates/admin/event_members.html
+++ b/templates/admin/event_members.html
@@ -17,7 +17,37 @@
   <span class="badge">{{ memberships|length }} assigned</span>
 </div>
 
-{% if users %}
+{% if request.query_params.get('error') == 'user_not_found' %}
+<div class="alert alert-danger" style="margin-bottom: 1rem; color: #d32f2f; background-color: #fde0e0; padding: 10px; border-radius: 4px;">
+  <strong>Error:</strong> User with that email address was not found. They must register first.
+</div>
+{% endif %}
+
+<div class="section-card" style="margin-bottom: 2rem;">
+  <div class="section-header">
+    <h2>Assign Event Admin</h2>
+  </div>
+  <div class="card-body">
+    <form method="post" action="/admin/events/{{ event.id }}/members/" class="token-form">
+      <div class="form-row">
+        <div class="form-group" style="flex: 2;">
+          <label for="email">User Email</label>
+          <input type="email" name="email" id="email" placeholder="user@example.com" required />
+        </div>
+        <div class="form-group">
+          <label for="role">Role</label>
+          <input type="text" name="role" id="role" value="event_admin" readonly style="background-color: #f5f5f5;" />
+        </div>
+        <div class="form-group form-group-btn">
+          <button type="submit" class="btn btn-primary">Assign Role</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>
+
+<h2>Assigned Event Admins</h2>
+{% if memberships %}
 <table class="data-table">
   <thead>
     <tr>
@@ -29,9 +59,9 @@
     </tr>
   </thead>
   <tbody>
-    {% for u in users %}
-    {% set m = membership_map.get(u.id) %}
-    <tr class="{{ 'row-assigned' if m else '' }}">
+    {% for m in memberships %}
+    {% set u = m.user %}
+    <tr class="row-assigned">
       <td>{{ u.email }}</td>
       <td>{{ u.display_name }}</td>
       <td>
@@ -41,29 +71,14 @@
         <span class="status-offline">○ Inactive</span>
         {% endif %}
       </td>
-      <td>
-        <form method="post" action="/admin/events/{{ event.id }}/members/" class="inline-form">
-          <input type="hidden" name="user_id" value="{{ u.id }}" />
-          <select name="role" class="role-select" onchange="this.form.submit()">
-            <option value="">— none —</option>
-            <option value="listener" {{ 'selected' if m and m.role == 'listener' }}>listener</option>
-            <option value="interpreter" {{ 'selected' if m and m.role == 'interpreter' }}>interpreter</option>
-            <option value="coordinator" {{ 'selected' if m and m.role == 'coordinator' }}>coordinator</option>
-            <option value="event_admin" {{ 'selected' if m and m.role == 'event_admin' }}>event_admin</option>
-          </select>
-        </form>
-      </td>
+      <td><span class="badge badge-role badge-event_admin">event_admin</span></td>
       <td class="actions-cell">
-        {% if m %}
         <form method="post"
               action="/admin/events/{{ event.id }}/members/{{ m.id }}/delete"
               class="inline-form"
               onsubmit="return confirm('Remove {{ u.display_name }} from this event?')">
           <button type="submit" class="btn btn-sm btn-danger">Remove</button>
         </form>
-        {% else %}
-        <span class="muted">—</span>
-        {% endif %}
       </td>
     </tr>
     {% endfor %}
@@ -71,11 +86,7 @@
 </table>
 {% else %}
 <div class="empty-state">
-  <p>No registered users yet. Users can sign up at <a href="/register">/register</a>.</p>
+  <p>No users have been assigned the event admin role yet.</p>
 </div>
 {% endif %}
-
-<div class="admin-help-section">
-  <p>Select a role from the dropdown to assign or change a user's role for this event. Click <strong>Remove</strong> to revoke access entirely.</p>
-</div>
 {% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Login — Eventyay</title>
+    <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='favicon.ico') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}" />
+  </head>
+  <body>
+    <div class="login-page">
+      <div class="login-card">
+        <div class="login-brand">
+          <span class="brand-text">Eventyay</span>
+          <span class="login-subtitle">Interpretation Portal — Admin</span>
+        </div>
+        {% if error %}
+        <div class="alert alert-error">{{ error }}</div>
+        {% endif %}
+        <form method="post" action="/admin/login" class="login-form">
+          <label for="password">Admin Password</label>
+          <input type="password" id="password" name="password" placeholder="Enter admin password" required autofocus />
+          <button type="submit" class="btn btn-primary">Sign In</button>
+        </form>
+        <div class="login-footer">
+          <a href="/">← Back to Portal Home</a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/templates/admin/room_detail.html
+++ b/templates/admin/room_detail.html
@@ -1,0 +1,84 @@
+{% extends "admin/base.html" %}
+{% block title %}{{ room.display_name }} — {{ event.display_name }}{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+  <a href="/admin/">Dashboard</a> <span>/</span>
+  <a href="/admin/events/">Events</a> <span>/</span>
+  <a href="/admin/events/{{ event.id }}/">{{ event.display_name }}</a> <span>/</span>
+  <a href="/admin/events/{{ event.id }}/rooms/">Rooms</a> <span>/</span>
+  <span>{{ room.display_name }}</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>{{ room.display_name }}</h1>
+  <div class="header-meta">
+    <span class="meta-text">Event: {{ event.display_name }}</span>
+    <span class="meta-text">Created {{ room.created_at.strftime('%Y-%m-%d') if room.created_at else '—' }}</span>
+  </div>
+</div>
+
+<!-- Interpretation Schedule Table (replaces manual spreadsheet) -->
+<div class="section-card">
+  <div class="section-header">
+    <h2>Interpretation Booths ({{ booths|length }})</h2>
+    <a href="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/" class="btn btn-sm btn-primary">Manage Booths</a>
+  </div>
+
+  {% if booths %}
+  <table class="data-table schedule-table">
+    <thead>
+      <tr>
+        <th>Language</th>
+        <th>Code</th>
+        <th>Status</th>
+        <th>Interpreter Booth URL</th>
+        <th>Listener URL (WHEP)</th>
+        <th>Details</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for bs in booths %}
+      <tr class="{{ 'row-live' if bs.is_live else '' }}">
+        <td><strong>{{ bs.db.language_name }}</strong></td>
+        <td><code>{{ bs.db.language_code }}</code></td>
+        <td>
+          {% if bs.is_live %}
+          <span class="status-live">● LIVE</span>
+          {% else %}
+          <span class="status-offline">○ Offline</span>
+          {% endif %}
+        </td>
+        <td>
+          <a href="/interpreter/{{ event.slug }}/{{ bs.db.language_code }}" target="_blank" class="link-external">
+            /interpreter/{{ event.slug }}/{{ bs.db.language_code }}
+          </a>
+        </td>
+        <td>
+          <a href="/listener-webrtc/{{ bs.booth_id }}" target="_blank" class="link-external">
+            /listener-webrtc/{{ bs.booth_id }}
+          </a>
+        </td>
+        <td>
+          <a href="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ bs.db.id }}/" class="btn btn-sm">View</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="muted">No booths in this room. <a href="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/">Add booths</a>.</p>
+  {% endif %}
+</div>
+
+<div class="danger-zone">
+  <h3>Danger Zone</h3>
+  <form method="post" action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/delete" class="inline-delete"
+        onsubmit="return confirm('Delete room \'{{ room.display_name }}\'? All booths in this room will be removed.')">
+    <button type="submit" class="btn btn-danger">Delete Room</button>
+    <span class="danger-text">This removes all booths and their invite tokens.</span>
+  </form>
+</div>
+{% endblock %}

--- a/templates/admin/room_list.html
+++ b/templates/admin/room_list.html
@@ -1,0 +1,59 @@
+{% extends "admin/base.html" %}
+{% block title %}Rooms — {{ event.display_name }}{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+  <a href="/admin/">Dashboard</a> <span>/</span>
+  <a href="/admin/events/">Events</a> <span>/</span>
+  <a href="/admin/events/{{ event.id }}/">{{ event.display_name }}</a> <span>/</span>
+  <span>Rooms</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Rooms — {{ event.display_name }}</h1>
+</div>
+
+<div class="form-card">
+  <h3>Add Room</h3>
+  <form method="post" action="/admin/events/{{ event.id }}/rooms/" class="inline-form">
+    <input type="text" name="display_name" placeholder="Room name (e.g. Main Hall)" required />
+    <button type="submit" class="btn btn-primary">Add Room</button>
+  </form>
+</div>
+
+{% if room_data %}
+<table class="data-table">
+  <thead>
+    <tr>
+      <th>Room Name</th>
+      <th>Booths</th>
+      <th>Created</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for rd in room_data %}
+    <tr>
+      <td><a href="/admin/events/{{ event.id }}/rooms/{{ rd.room.id }}/">{{ rd.room.display_name }}</a></td>
+      <td>{{ rd.booth_count }}</td>
+      <td>{{ rd.room.created_at.strftime('%Y-%m-%d %H:%M') if rd.room.created_at else '—' }}</td>
+      <td>
+        <a href="/admin/events/{{ event.id }}/rooms/{{ rd.room.id }}/" class="btn btn-sm">View</a>
+        <a href="/admin/events/{{ event.id }}/rooms/{{ rd.room.id }}/booths/" class="btn btn-sm">Booths</a>
+        <form method="post" action="/admin/events/{{ event.id }}/rooms/{{ rd.room.id }}/delete" class="inline-delete"
+              onsubmit="return confirm('Delete room \'{{ rd.room.display_name }}\'? This will remove all booths in this room.')">
+          <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+  <p>No rooms created yet. Use the form above to add one.</p>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/admin/user_detail.html
+++ b/templates/admin/user_detail.html
@@ -1,0 +1,113 @@
+{% extends "admin/base.html" %}
+
+{% block title %}User Detail — {{ user_detail.display_name }}{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+  <a href="/admin/">Dashboard</a> ›
+  <a href="/admin/users/">Users</a> ›
+  <span>{{ user_detail.display_name }}</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>User: {{ user_detail.display_name }}</h1>
+  {% if user_detail.is_admin %}
+  <span class="badge badge-role badge-super_admin">Super Admin</span>
+  {% endif %}
+</div>
+
+<div class="card" style="margin-bottom: 2rem;">
+  <div class="card-header">
+    <h3>User Information</h3>
+  </div>
+  <div class="card-body">
+    <table class="data-table compact" style="width: 100%; border-radius: 8px;">
+      <tbody>
+        <tr>
+          <td style="width: 200px; font-weight: 500;">Email</td>
+          <td>{{ user_detail.email }}</td>
+        </tr>
+        <tr>
+          <td style="font-weight: 500;">Display Name</td>
+          <td>{{ user_detail.display_name }}</td>
+        </tr>
+        <tr>
+          <td style="font-weight: 500;">Joined</td>
+          <td>{{ user_detail.created_at.strftime('%Y-%m-%d %H:%M UTC') if user_detail.created_at else '—' }}</td>
+        </tr>
+        <tr>
+          <td style="font-weight: 500;">Global Status</td>
+          <td>
+            <form method="post" action="/admin/users/{{ user_detail.id }}/toggle-active" class="inline-form">
+              <button type="submit" class="btn btn-sm {{ 'btn-warning' if user_detail.is_active else 'btn-success' }}">
+                {{ 'Deactivate Account' if user_detail.is_active else 'Activate Account' }}
+              </button>
+            </form>
+          </td>
+        </tr>
+        <tr>
+          <td style="font-weight: 500;">Global Admin</td>
+          <td>
+            <form method="post" action="/admin/users/{{ user_detail.id }}/toggle-admin" class="inline-form">
+              <button type="submit" class="btn btn-sm {{ 'btn-danger' if user_detail.is_admin else 'btn-primary' }}">
+                {{ 'Revoke Super Admin' if user_detail.is_admin else 'Promote to Super Admin' }}
+              </button>
+            </form>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<h2>Event Admin Roles</h2>
+<p class="muted" style="margin-bottom: 1rem;">Toggle event admin status for specific events below. Interpreter and listener roles are assigned per-booth.</p>
+
+{% if events %}
+<table class="data-table">
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Status</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for event in events %}
+    {% set is_event_admin = event.id in event_admin_map %}
+    <tr class="{{ 'row-assigned' if is_event_admin else '' }}">
+      <td><strong>{{ event.display_name }}</strong> ({{ event.slug }})</td>
+      <td>
+        {% if is_event_admin %}
+        <span class="badge badge-role badge-event_admin">Event Admin</span>
+        {% else %}
+        <span class="muted">—</span>
+        {% endif %}
+      </td>
+      <td>
+        <form method="post" action="/admin/users/{{ user_detail.id }}/events/{{ event.id }}/toggle-admin" class="inline-form">
+          <button type="submit" class="btn btn-sm {{ 'btn-danger' if is_event_admin else 'btn-primary' }}">
+            {{ 'Remove Admin' if is_event_admin else 'Make Admin' }}
+          </button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+  <p>No events configured. <a href="/admin/events/">Create an event</a> to assign admin roles.</p>
+</div>
+{% endif %}
+
+<div style="margin-top: 3rem;">
+  <form method="post" action="/admin/users/{{ user_detail.id }}/delete"
+        onsubmit="return confirm('Delete user {{ user_detail.email }}? This cannot be undone.')">
+    <button type="submit" class="btn btn-danger">Delete User Account</button>
+  </form>
+</div>
+
+{% endblock %}

--- a/templates/admin/user_list.html
+++ b/templates/admin/user_list.html
@@ -21,7 +21,7 @@
       <th>ID</th>
       <th>Email</th>
       <th>Display Name</th>
-      <th>Role</th>
+      <th>Admin</th>
       <th>Status</th>
       <th>Joined</th>
       <th>Actions</th>
@@ -34,15 +34,11 @@
       <td>{{ user.email }}</td>
       <td>{{ user.display_name }}</td>
       <td>
-        <form method="post" action="/admin/users/{{ user.id }}/role" class="inline-form">
-          <select name="role" class="role-select" onchange="this.form.submit()">
-            <option value="listener" {{ 'selected' if user.role == 'listener' }}>listener</option>
-            <option value="interpreter" {{ 'selected' if user.role == 'interpreter' }}>interpreter</option>
-            <option value="coordinator" {{ 'selected' if user.role == 'coordinator' }}>coordinator</option>
-            <option value="event_admin" {{ 'selected' if user.role == 'event_admin' }}>event_admin</option>
-            <option value="super_admin" {{ 'selected' if user.role == 'super_admin' }}>super_admin</option>
-          </select>
-        </form>
+        {% if user.is_admin %}
+        <span class="badge badge-role badge-event_admin">Admin</span>
+        {% else %}
+        <span class="muted">—</span>
+        {% endif %}
       </td>
       <td>
         {% if user.is_active %}
@@ -74,17 +70,17 @@
 {% endif %}
 
 <div class="admin-help-section">
-  <h3>How User Roles Work</h3>
+  <h3>How Roles Work</h3>
+  <p>Roles are assigned <strong>per event</strong>, not globally. To manage a user's role for a specific event, go to that event's detail page and click <strong>Members</strong>.</p>
   <table class="data-table compact">
     <thead>
-      <tr><th>Role</th><th>Permissions</th></tr>
+      <tr><th>Role</th><th>Scope</th><th>Permissions</th></tr>
     </thead>
     <tbody>
-      <tr><td><strong>listener</strong></td><td>Default role. Can listen to interpretation streams and participate in booth chat.</td></tr>
-      <tr><td><strong>interpreter</strong></td><td>Can go live and provide real-time interpretation in assigned booths.</td></tr>
-      <tr><td><strong>coordinator</strong></td><td>Can assign active interpreters and manage handoffs within booths.</td></tr>
-      <tr><td><strong>event_admin</strong></td><td>Can manage booths, rooms, and generate invite tokens for events.</td></tr>
-      <tr><td><strong>super_admin</strong></td><td>Full access to all administrative functions.</td></tr>
+      <tr><td><strong>listener</strong></td><td>Event</td><td>Listen to interpretation streams and participate in booth chat.</td></tr>
+      <tr><td><strong>interpreter</strong></td><td>Event</td><td>Go live and provide real-time interpretation in assigned booths.</td></tr>
+      <tr><td><strong>coordinator</strong></td><td>Event</td><td>Assign active interpreters and manage handoffs within booths.</td></tr>
+      <tr><td><strong>event_admin</strong></td><td>Event</td><td>Manage booths, rooms, and generate invite tokens for the event.</td></tr>
     </tbody>
   </table>
 </div>

--- a/templates/admin/user_list.html
+++ b/templates/admin/user_list.html
@@ -1,0 +1,91 @@
+{% extends "admin/base.html" %}
+
+{% block title %}Users{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+  <a href="/admin/">Dashboard</a> › <span>Users</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Registered Users</h1>
+  <span class="badge">{{ users|length }} total</span>
+</div>
+
+{% if users %}
+<table class="data-table">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Email</th>
+      <th>Display Name</th>
+      <th>Role</th>
+      <th>Status</th>
+      <th>Joined</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for user in users %}
+    <tr>
+      <td>{{ user.id }}</td>
+      <td>{{ user.email }}</td>
+      <td>{{ user.display_name }}</td>
+      <td>
+        <form method="post" action="/admin/users/{{ user.id }}/role" class="inline-form">
+          <select name="role" class="role-select" onchange="this.form.submit()">
+            <option value="listener" {{ 'selected' if user.role == 'listener' }}>listener</option>
+            <option value="interpreter" {{ 'selected' if user.role == 'interpreter' }}>interpreter</option>
+            <option value="coordinator" {{ 'selected' if user.role == 'coordinator' }}>coordinator</option>
+            <option value="event_admin" {{ 'selected' if user.role == 'event_admin' }}>event_admin</option>
+            <option value="super_admin" {{ 'selected' if user.role == 'super_admin' }}>super_admin</option>
+          </select>
+        </form>
+      </td>
+      <td>
+        {% if user.is_active %}
+        <span class="status-live">● Active</span>
+        {% else %}
+        <span class="status-offline">○ Inactive</span>
+        {% endif %}
+      </td>
+      <td>{{ user.created_at.strftime('%Y-%m-%d') if user.created_at else '—' }}</td>
+      <td class="actions-cell">
+        <form method="post" action="/admin/users/{{ user.id }}/toggle-active" class="inline-form">
+          <button type="submit" class="btn btn-sm {{ 'btn-warning' if user.is_active else 'btn-success' }}">
+            {{ 'Deactivate' if user.is_active else 'Activate' }}
+          </button>
+        </form>
+        <form method="post" action="/admin/users/{{ user.id }}/delete" class="inline-form"
+              onsubmit="return confirm('Delete user {{ user.email }}? This cannot be undone.')">
+          <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+  <p>No registered users yet. Users can sign up at <a href="/register">/register</a>.</p>
+</div>
+{% endif %}
+
+<div class="admin-help-section">
+  <h3>How User Roles Work</h3>
+  <table class="data-table compact">
+    <thead>
+      <tr><th>Role</th><th>Permissions</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>listener</strong></td><td>Default role. Can listen to interpretation streams and participate in booth chat.</td></tr>
+      <tr><td><strong>interpreter</strong></td><td>Can go live and provide real-time interpretation in assigned booths.</td></tr>
+      <tr><td><strong>coordinator</strong></td><td>Can assign active interpreters and manage handoffs within booths.</td></tr>
+      <tr><td><strong>event_admin</strong></td><td>Can manage booths, rooms, and generate invite tokens for events.</td></tr>
+      <tr><td><strong>super_admin</strong></td><td>Full access to all administrative functions.</td></tr>
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/admin/user_list.html
+++ b/templates/admin/user_list.html
@@ -31,8 +31,8 @@
     {% for user in users %}
     <tr>
       <td>{{ user.id }}</td>
-      <td>{{ user.email }}</td>
-      <td>{{ user.display_name }}</td>
+      <td><a href="/admin/users/{{ user.id }}/">{{ user.email }}</a></td>
+      <td><a href="/admin/users/{{ user.id }}/">{{ user.display_name }}</a></td>
       <td>
         {% if user.is_admin %}
         <span class="badge badge-role badge-event_admin">Admin</span>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eventyay Interpretation Portal</title>
+    <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='favicon.ico') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}" />
+  </head>
+  <body>
+    <header class="portal-home-header">
+      <a class="brand" href="/">Eventyay</a>
+      <nav class="header-nav">
+        {% if current_user %}
+        <a href="/account">My Account</a>
+        <a href="/logout">Logout</a>
+        {% else %}
+        <a href="/login">Sign In</a>
+        <a href="/register">Register</a>
+        {% endif %}
+        <a href="/admin/login">Admin Panel</a>
+      </nav>
+    </header>
+
+    <main class="home-main">
+      <section class="hero">
+        <h1>Interpretation Portal</h1>
+        <p class="hero-subtitle">Real-time multilingual interpretation for live events — browser-first, no external software required.</p>
+      </section>
+
+      {% if events %}
+      <section class="home-section">
+        <h2>Active Events</h2>
+        <div class="card-grid">
+          {% for ed in events %}
+          <div class="card event-card home-event-card">
+            <div class="card-header">
+              <span class="card-title">{{ ed.event.display_name }}</span>
+              {% if ed.live_count > 0 %}
+              <span class="status-live">● {{ ed.live_count }} live</span>
+              {% endif %}
+            </div>
+            <div class="card-body">
+              {% if ed.booths %}
+              <h4>Interpretation Booths</h4>
+              <table class="data-table compact home-table">
+                <thead>
+                  <tr>
+                    <th>Language</th>
+                    <th>Status</th>
+                    <th>Listen</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for bs in ed.booths %}
+                  <tr>
+                    <td>{{ bs.db.language_name }}</td>
+                    <td>
+                      {% if bs.is_live %}
+                      <span class="status-live">● Live</span>
+                      {% else %}
+                      <span class="status-offline">○</span>
+                      {% endif %}
+                    </td>
+                    <td>
+                      <a href="/listener-webrtc/{{ bs.booth_id }}" class="btn btn-sm">Listen ↗</a>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+              {% else %}
+              <p class="muted">No interpretation booths configured yet.</p>
+              {% endif %}
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+      </section>
+      {% else %}
+      <section class="home-section">
+        <div class="empty-state home-empty">
+          <p>No events are currently configured. Admins can <a href="/admin/login">sign in</a> to set up events and booths.</p>
+        </div>
+      </section>
+      {% endif %}
+
+      <section class="home-section roles-section">
+        <h2>How It Works</h2>
+        <div class="role-cards">
+          <div class="role-card">
+            <div class="role-icon">🎤</div>
+            <h3>Interpreters</h3>
+            <p>Join your assigned booth via invite link, go live, and provide real-time interpretation. No OBS or external tools needed.</p>
+          </div>
+          <div class="role-card">
+            <div class="role-icon">🎧</div>
+            <h3>Listeners</h3>
+            <p>Select your language and listen to interpretation in real-time with sub-second latency via WebRTC.</p>
+          </div>
+          <div class="role-card">
+            <div class="role-icon">📋</div>
+            <h3>Coordinators</h3>
+            <p>Manage interpreter assignments, monitor booth status, and coordinate handoffs between interpreters.</p>
+          </div>
+          <div class="role-card">
+            <div class="role-icon">⚙️</div>
+            <h3>Admins</h3>
+            <p>Set up events, rooms, and booths. Generate invite tokens and monitor live status from the admin panel.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="admin-footer">
+      <span>Eventyay Interpretation Portal — Powered by FastAPI + MediaMTX</span>
+    </footer>
+  </body>
+</html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -86,8 +86,11 @@
                       <span class="status-offline">○</span>
                       {% endif %}
                     </td>
-                    <td>
+                    <td style="display: flex; gap: 0.5rem; align-items: center;">
                       <a href="/listener-webrtc/{{ bs.booth_id }}" class="btn btn-sm">Listen ↗</a>
+                      {% if bs.can_interpret %}
+                      <a href="/interpreter/{{ ed.event.slug }}/{{ bs.db.language_code }}" class="btn btn-sm btn-outline" style="border-color: #007bff; color: #007bff; background: transparent;">Open Booth ↗</a>
+                      {% endif %}
                     </td>
                   </tr>
                   {% endfor %}
@@ -104,7 +107,11 @@
       {% else %}
       <section class="home-section">
         <div class="empty-state home-empty">
+          {% if current_user %}
+          <p>No events are currently configured. Admins can create events in the <a href="/admin/">Admin Panel</a>.</p>
+          {% else %}
           <p>No events are currently configured. Admins can <a href="/admin/login">sign in</a> to set up events and booths.</p>
+          {% endif %}
         </div>
       </section>
       {% endif %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -28,6 +28,30 @@
         <p class="hero-subtitle">Real-time multilingual interpretation for live events — browser-first, no external software required.</p>
       </section>
 
+      {% if my_booths %}
+      <section class="home-section">
+        <h2>Your Assigned Booths</h2>
+        <div class="card-grid">
+          {% for b in my_booths %}
+          <div class="card event-card home-event-card">
+            <div class="card-header">
+              <span class="card-title">{{ b.language_name }} — {{ b.event_name }}</span>
+              {% if b.is_live %}
+              <span class="status-live">● LIVE</span>
+              {% endif %}
+            </div>
+            <div class="card-body">
+              <p style="margin-bottom: 0;">Role: <span class="badge badge-role badge-{{ b.membership.role }}">{{ b.membership.role }}</span></p>
+            </div>
+            <div class="card-footer">
+              <a href="/interpreter/{{ b.event_slug }}/{{ b.language_code }}" class="btn btn-primary" style="width: 100%; text-align: center;">Open Booth ↗</a>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+      </section>
+      {% endif %}
+
       {% if events %}
       <section class="home-section">
         <h2>Active Events</h2>

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -34,23 +34,34 @@
         Role
         {% set gr = granted_role | default("") %}
         <select id='participant-role' class='input'{% if gr %} disabled{% endif %}>
-          {% if gr == 'interpreter' or gr in ('coordinator', 'event_admin', 'super_admin') %}
-            <option value='interpreter'{% if gr == 'interpreter' %} selected{% endif %}>Interpreter</option>
-          {% endif %}
-          {% if gr in ('coordinator', 'event_admin', 'super_admin') %}
-            <option value='coordinator'{% if gr == 'coordinator' %} selected{% endif %}>Coordinator</option>
-          {% endif %}
-          {% if gr %}
-            <option value='listener'{% if gr == 'listener' %} selected{% endif %}>Listener</option>
-          {% else %}
+          {% if not gr %}
+            {# No assigned role — show all options freely #}
             <option value='interpreter'>Interpreter</option>
             <option value='coordinator'>Coordinator</option>
+            <option value='listener'>Listener</option>
+          {% elif gr == 'listener' %}
+            <option value='listener' selected>Listener</option>
+          {% elif gr == 'interpreter' %}
+            <option value='interpreter' selected>Interpreter</option>
+          {% elif gr in ('coordinator', 'event_admin', 'super_admin') %}
+            {# Coordinators and admins can join as coordinator or interpreter #}
+            <option value='coordinator'{% if gr == 'coordinator' %} selected{% endif %}>Coordinator</option>
+            <option value='interpreter'>Interpreter</option>
             <option value='listener'>Listener</option>
           {% endif %}
         </select>
         {% if gr %}
           <input type='hidden' id='participant-role-hidden' value='{{ gr }}' />
-          <small class='hint'>Role assigned: <strong>{{ gr }}</strong></small>
+          <small class='hint'>
+            Role: <strong>{{ gr }}</strong>
+            {% if gr in ('event_admin', 'super_admin') %}
+              — you have full access to this booth
+            {% elif gr == 'coordinator' %}
+              — you can assign the active interpreter
+            {% elif gr == 'interpreter' %}
+              — you can go live when active
+            {% endif %}
+          </small>
         {% endif %}
       </label>
       <label>

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -18,6 +18,7 @@
   data-language-code='{{ language_code | default("") }}'
   data-whip-url='{{ whip_url | default("") }}'
   data-whep-url='{{ whep_url | default("") }}'
+  data-granted-role='{{ granted_role | default("") }}'
 >
   <section class='panel'>
     <header class='panel-header'>
@@ -31,11 +32,26 @@
       </label>
       <label>
         Role
-        <select id='participant-role' class='input'>
-          <option value='interpreter'>Interpreter</option>
-          <option value='coordinator'>Coordinator</option>
-          <option value='listener'>Listener</option>
+        {% set gr = granted_role | default("") %}
+        <select id='participant-role' class='input'{% if gr %} disabled{% endif %}>
+          {% if gr == 'interpreter' or gr in ('coordinator', 'event_admin', 'super_admin') %}
+            <option value='interpreter'{% if gr == 'interpreter' %} selected{% endif %}>Interpreter</option>
+          {% endif %}
+          {% if gr in ('coordinator', 'event_admin', 'super_admin') %}
+            <option value='coordinator'{% if gr == 'coordinator' %} selected{% endif %}>Coordinator</option>
+          {% endif %}
+          {% if gr %}
+            <option value='listener'{% if gr == 'listener' %} selected{% endif %}>Listener</option>
+          {% else %}
+            <option value='interpreter'>Interpreter</option>
+            <option value='coordinator'>Coordinator</option>
+            <option value='listener'>Listener</option>
+          {% endif %}
         </select>
+        {% if gr %}
+          <input type='hidden' id='participant-role-hidden' value='{{ gr }}' />
+          <small class='hint'>Role assigned: <strong>{{ gr }}</strong></small>
+        {% endif %}
       </label>
       <label>
         Language

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sign In — Eventyay</title>
+    <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='favicon.ico') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}" />
+  </head>
+  <body>
+    <div class="login-page">
+      <div class="login-card">
+        <div class="login-brand">
+          <span class="brand-text">Eventyay</span>
+          <span class="login-subtitle">Sign in to your account</span>
+        </div>
+        {% if error %}
+        <div class="alert alert-error">{{ error }}</div>
+        {% endif %}
+        <form method="post" action="/login" class="login-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" placeholder="you@example.com" value="{{ email|default('', true) }}" required autofocus />
+
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" placeholder="Enter your password" required />
+
+          <button type="submit" class="btn btn-primary">Sign In</button>
+        </form>
+        <div class="login-footer">
+          <span>Don't have an account? <a href="/register">Register</a></span>
+          <a href="/">← Back to Portal Home</a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Register — Eventyay</title>
+    <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='favicon.ico') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}" />
+  </head>
+  <body>
+    <div class="login-page">
+      <div class="login-card">
+        <div class="login-brand">
+          <span class="brand-text">Eventyay</span>
+          <span class="login-subtitle">Create your account</span>
+        </div>
+        {% if errors %}
+        <div class="alert alert-error">
+          <ul class="error-list">
+            {% for err in errors %}
+            <li>{{ err }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+        <form method="post" action="/register" class="login-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" placeholder="you@example.com" value="{{ email|default('', true) }}" required autofocus />
+
+          <label for="display_name">Display Name</label>
+          <input type="text" id="display_name" name="display_name" placeholder="Your name" value="{{ display_name|default('', true) }}" required />
+
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" placeholder="Min. 8 characters" required minlength="8" />
+
+          <label for="password_confirm">Confirm Password</label>
+          <input type="password" id="password_confirm" name="password_confirm" placeholder="Repeat password" required minlength="8" />
+
+          <button type="submit" class="btn btn-primary">Create Account</button>
+        </form>
+        <div class="login-footer">
+          <span>Already have an account? <a href="/login">Sign in</a></span>
+          <a href="/">← Back to Portal Home</a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1,0 +1,449 @@
+"""Tests for the admin panel routes (Phase 3, Step 4).
+
+Covers:
+- Admin login/logout flow
+- require_admin() guard (403 without cookie)
+- CRUD operations for events, rooms, booths
+- Dashboard with live status
+- Booth detail with WHEP URL and participant roster
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ['BOOTH_ACCESS_TOKEN'] = ''
+os.environ['ADMIN_PASSWORD'] = 'test-admin-pass'
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from portal.auth import create_admin_token, decode_token
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    """Set up an in-memory database for the FastAPI app."""
+    from portal.database import configure, dispose, init_db
+    configure('sqlite+aiosqlite://')
+    await init_db()
+    yield
+    await dispose()
+
+
+@pytest.fixture
+def admin_cookie():
+    """Return a dict with the admin_token cookie for authenticated requests."""
+    token = create_admin_token()
+    return {'admin_token': token}
+
+
+@pytest.fixture
+async def seed_event():
+    """Seed an event, room, and booth."""
+    from portal.database import create_booth, create_event, create_room, get_session
+    async with get_session() as s:
+        event = await create_event(s, slug='testcon', display_name='TestCon 2026')
+        room = await create_room(s, event_id=event.id, display_name='Main Hall')
+        booth = await create_booth(
+            s, event_id=event.id, room_id=room.id,
+            language_code='en', language_name='English',
+        )
+    return event, room, booth
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _client():
+    from httpx import ASGITransport, AsyncClient
+    from fastapi_app import app
+    return AsyncClient(transport=ASGITransport(app=app), base_url='http://test')
+
+
+# ---------------------------------------------------------------------------
+# Login / Logout tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdminLogin:
+    @pytest.mark.anyio
+    async def test_login_page_renders(self):
+        async with _client() as c:
+            resp = await c.get('/admin/login')
+        assert resp.status_code == 200
+        assert b'Admin' in resp.content
+
+    @pytest.mark.anyio
+    async def test_login_with_correct_password(self):
+        async with _client() as c:
+            resp = await c.post(
+                '/admin/login',
+                data={'password': 'test-admin-pass'},
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        assert resp.headers['location'] == '/admin/'
+        assert 'admin_token' in resp.headers.get('set-cookie', '')
+
+    @pytest.mark.anyio
+    async def test_login_with_wrong_password(self):
+        async with _client() as c:
+            resp = await c.post(
+                '/admin/login',
+                data={'password': 'wrong'},
+                follow_redirects=False,
+            )
+        assert resp.status_code == 403
+        assert b'Invalid password' in resp.content
+
+    @pytest.mark.anyio
+    async def test_logout_clears_cookie(self):
+        async with _client() as c:
+            resp = await c.get('/admin/logout', follow_redirects=False)
+        assert resp.status_code == 303
+        assert resp.headers['location'] == '/admin/login'
+
+
+# ---------------------------------------------------------------------------
+# Guard tests
+# ---------------------------------------------------------------------------
+
+
+class TestRequireAdmin:
+    @pytest.mark.anyio
+    async def test_dashboard_requires_auth(self):
+        async with _client() as c:
+            resp = await c.get('/admin/', follow_redirects=False)
+        assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_event_list_requires_auth(self):
+        async with _client() as c:
+            resp = await c.get('/admin/events/', follow_redirects=False)
+        assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_dashboard_with_valid_cookie(self, admin_cookie):
+        async with _client() as c:
+            resp = await c.get('/admin/', cookies=admin_cookie)
+        assert resp.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_invalid_cookie_rejected(self):
+        async with _client() as c:
+            resp = await c.get('/admin/', cookies={'admin_token': 'garbage'})
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Home page
+# ---------------------------------------------------------------------------
+
+
+class TestHomePage:
+    @pytest.mark.anyio
+    async def test_home_renders(self):
+        async with _client() as c:
+            resp = await c.get('/')
+        assert resp.status_code == 200
+        assert b'Interpretation Portal' in resp.content
+
+    @pytest.mark.anyio
+    async def test_home_shows_events(self, seed_event):
+        async with _client() as c:
+            resp = await c.get('/')
+        assert resp.status_code == 200
+        assert b'TestCon 2026' in resp.content
+
+    @pytest.mark.anyio
+    async def test_home_shows_listener_links(self, seed_event):
+        async with _client() as c:
+            resp = await c.get('/')
+        assert resp.status_code == 200
+        assert b'listener-webrtc' in resp.content
+
+
+# ---------------------------------------------------------------------------
+# Dashboard
+# ---------------------------------------------------------------------------
+
+
+class TestDashboard:
+    @pytest.mark.anyio
+    async def test_dashboard_empty(self, admin_cookie):
+        async with _client() as c:
+            resp = await c.get('/admin/', cookies=admin_cookie)
+        assert resp.status_code == 200
+        assert b'No events yet' in resp.content
+
+    @pytest.mark.anyio
+    async def test_dashboard_shows_events(self, admin_cookie, seed_event):
+        async with _client() as c:
+            resp = await c.get('/admin/', cookies=admin_cookie)
+        assert resp.status_code == 200
+        assert b'TestCon 2026' in resp.content
+        assert b'English' in resp.content
+
+
+# ---------------------------------------------------------------------------
+# Event CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestEventCRUD:
+    @pytest.mark.anyio
+    async def test_event_list(self, admin_cookie, seed_event):
+        async with _client() as c:
+            resp = await c.get('/admin/events/', cookies=admin_cookie)
+        assert resp.status_code == 200
+        assert b'testcon' in resp.content
+
+    @pytest.mark.anyio
+    async def test_create_event(self, admin_cookie):
+        async with _client() as c:
+            resp = await c.post(
+                '/admin/events/',
+                data={'slug': 'newcon', 'display_name': 'NewCon 2026'},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        # Verify it was created
+        async with _client() as c:
+            resp = await c.get('/admin/events/', cookies=admin_cookie)
+        assert b'NewCon 2026' in resp.content
+
+    @pytest.mark.anyio
+    async def test_event_detail(self, admin_cookie, seed_event):
+        event, _, _ = seed_event
+        async with _client() as c:
+            resp = await c.get(f'/admin/events/{event.id}/', cookies=admin_cookie)
+        assert resp.status_code == 200
+        assert b'TestCon 2026' in resp.content
+        assert b'Main Hall' in resp.content
+
+    @pytest.mark.anyio
+    async def test_event_detail_shows_booth_links(self, admin_cookie, seed_event):
+        event, _, _ = seed_event
+        async with _client() as c:
+            resp = await c.get(f'/admin/events/{event.id}/', cookies=admin_cookie)
+        assert b'/interpreter/testcon/en' in resp.content
+
+    @pytest.mark.anyio
+    async def test_delete_event(self, admin_cookie, seed_event):
+        event, _, _ = seed_event
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/delete',
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        # Verify deleted
+        async with _client() as c:
+            resp = await c.get('/admin/events/', cookies=admin_cookie)
+        assert b'testcon' not in resp.content
+
+    @pytest.mark.anyio
+    async def test_event_not_found(self, admin_cookie):
+        async with _client() as c:
+            resp = await c.get('/admin/events/99999/', cookies=admin_cookie)
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Room CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestRoomCRUD:
+    @pytest.mark.anyio
+    async def test_room_list(self, admin_cookie, seed_event):
+        event, _, _ = seed_event
+        async with _client() as c:
+            resp = await c.get(f'/admin/events/{event.id}/rooms/', cookies=admin_cookie)
+        assert resp.status_code == 200
+        assert b'Main Hall' in resp.content
+
+    @pytest.mark.anyio
+    async def test_create_room(self, admin_cookie, seed_event):
+        event, _, _ = seed_event
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/',
+                data={'display_name': 'Track B'},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with _client() as c:
+            resp = await c.get(f'/admin/events/{event.id}/rooms/', cookies=admin_cookie)
+        assert b'Track B' in resp.content
+
+    @pytest.mark.anyio
+    async def test_room_detail(self, admin_cookie, seed_event):
+        event, room, _ = seed_event
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/',
+                cookies=admin_cookie,
+            )
+        assert resp.status_code == 200
+        assert b'Main Hall' in resp.content
+        assert b'English' in resp.content
+
+    @pytest.mark.anyio
+    async def test_room_detail_shows_interpreter_urls(self, admin_cookie, seed_event):
+        event, room, _ = seed_event
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/',
+                cookies=admin_cookie,
+            )
+        assert b'/interpreter/testcon/en' in resp.content
+        assert b'listener-webrtc' in resp.content
+
+    @pytest.mark.anyio
+    async def test_delete_room(self, admin_cookie, seed_event):
+        event, room, _ = seed_event
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/delete',
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+
+
+# ---------------------------------------------------------------------------
+# Booth CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestBoothCRUD:
+    @pytest.mark.anyio
+    async def test_booth_list(self, admin_cookie, seed_event):
+        event, room, _ = seed_event
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/',
+                cookies=admin_cookie,
+            )
+        assert resp.status_code == 200
+        assert b'English' in resp.content
+
+    @pytest.mark.anyio
+    async def test_create_booth(self, admin_cookie, seed_event):
+        event, room, _ = seed_event
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/',
+                data={'language_code': 'fr', 'language_name': 'French'},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/',
+                cookies=admin_cookie,
+            )
+        assert b'French' in resp.content
+
+    @pytest.mark.anyio
+    async def test_booth_detail(self, admin_cookie, seed_event):
+        event, room, booth = seed_event
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/',
+                cookies=admin_cookie,
+            )
+        assert resp.status_code == 200
+        assert b'English' in resp.content
+        assert b'whep' in resp.content.lower()
+
+    @pytest.mark.anyio
+    async def test_booth_detail_shows_whep_url(self, admin_cookie, seed_event):
+        event, room, booth = seed_event
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/',
+                cookies=admin_cookie,
+            )
+        assert b'testcon/en/whep' in resp.content
+
+    @pytest.mark.anyio
+    async def test_booth_detail_shows_mediamtx_path(self, admin_cookie, seed_event):
+        event, room, booth = seed_event
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/',
+                cookies=admin_cookie,
+            )
+        assert b'testcon/en' in resp.content
+
+    @pytest.mark.anyio
+    async def test_booth_detail_shows_invite_tokens(self, admin_cookie, seed_event):
+        event, room, booth = seed_event
+        from portal.database import create_invite_token, get_session
+        async with get_session() as s:
+            await create_invite_token(s, booth_id=booth.id, role='interpreter', label='Alice')
+
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/',
+                cookies=admin_cookie,
+            )
+        assert b'Alice' in resp.content
+        assert b'interpreter' in resp.content.lower()
+
+    @pytest.mark.anyio
+    async def test_delete_booth(self, admin_cookie, seed_event):
+        event, room, booth = seed_event
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/delete',
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+
+    @pytest.mark.anyio
+    async def test_booth_not_found(self, admin_cookie, seed_event):
+        event, room, _ = seed_event
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/99999/',
+                cookies=admin_cookie,
+            )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Auth unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdminToken:
+    @pytest.mark.anyio
+    async def test_create_admin_token_has_admin_claim(self, setup_db):
+        token = create_admin_token()
+        payload = decode_token(token)
+        assert payload['admin'] is True
+        assert 'exp' in payload
+        assert 'iat' in payload
+
+    @pytest.mark.anyio
+    async def test_admin_token_is_valid_jwt(self, setup_db):
+        token = create_admin_token()
+        payload = decode_token(token)
+        assert isinstance(payload, dict)

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -28,10 +28,10 @@ def test_healthz_ok():
     assert 'aiortc_available' not in body
 
 
-def test_home_redirects_to_demo_booth():
-    res = client.get('/', follow_redirects=False)
-    assert res.status_code in (301, 302, 307, 308)
-    assert 'demo-booth' in res.headers['location']
+def test_home_renders_home_page():
+    res = client.get('/')
+    assert res.status_code == 200
+    assert b'Eventyay' in res.content
 
 
 def test_interpreter_booth_page_renders():

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -34,6 +34,11 @@ def _admin_user_cookie() -> dict:
     return {'user_token': tok}
 
 
+# Convenience alias: admin user token has event_admin role and no scope restriction,
+# so it works with any booth ID in WS tests.
+_ws_auth = _admin_user_cookie
+
+
 # ── REST & page tests ─────────────────────────────────────────────────────────
 
 def test_healthz_ok():
@@ -132,7 +137,7 @@ def test_ingest_status_endpoint():
 # ── WebSocket protocol tests ──────────────────────────────────────────────────
 
 def test_ws_join_receives_joined_and_state():
-    with client.websocket_connect('/ws/booth/ws-test-booth') as ws:
+    with client.websocket_connect('/ws/booth/ws-test-booth', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join',
             'display_name': 'Alice',
@@ -152,8 +157,23 @@ def test_ws_join_receives_joined_and_state():
     assert 'state' in joined
 
 
+def test_ws_join_rejected_without_session():
+    """WebSocket join must be rejected when no session cookie is present."""
+    with client.websocket_connect('/ws/booth/no-session-booth') as ws:
+        ws.send_text(json.dumps({
+            'type': 'booth:join',
+            'display_name': 'Hacker',
+            'role': 'interpreter',
+            'language': 'English',
+            'channel_id': 'no-session-audio',
+        }))
+        msg = json.loads(ws.receive_text())
+    assert msg['type'] == 'booth:error'
+    assert 'No role' in msg['message']
+
+
 def test_ws_join_then_leave_broadcasts_state():
-    with client.websocket_connect('/ws/booth/leave-test-booth') as ws:
+    with client.websocket_connect('/ws/booth/leave-test-booth', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join',
             'display_name': 'Bob',
@@ -172,7 +192,7 @@ def test_ws_join_then_leave_broadcasts_state():
 
 
 def test_ws_chat_message():
-    with client.websocket_connect('/ws/booth/chat-test-booth') as ws:
+    with client.websocket_connect('/ws/booth/chat-test-booth', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join',
             'display_name': 'Charlie',
@@ -194,7 +214,7 @@ def test_ws_chat_message():
 
 
 def test_ws_invalid_json_returns_error():
-    with client.websocket_connect('/ws/booth/json-err-booth') as ws:
+    with client.websocket_connect('/ws/booth/json-err-booth', cookies=_ws_auth()) as ws:
         ws.send_text('not-valid-json')
         msg = json.loads(ws.receive_text())
 
@@ -202,7 +222,7 @@ def test_ws_invalid_json_returns_error():
 
 
 def test_ws_unknown_message_type_returns_error():
-    with client.websocket_connect('/ws/booth/unknown-msg-booth') as ws:
+    with client.websocket_connect('/ws/booth/unknown-msg-booth', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({'type': 'something:weird'}))
         msg = json.loads(ws.receive_text())
 
@@ -210,7 +230,7 @@ def test_ws_unknown_message_type_returns_error():
 
 
 def test_ws_chat_before_join_returns_error():
-    with client.websocket_connect('/ws/booth/no-join-chat-booth') as ws:
+    with client.websocket_connect('/ws/booth/no-join-chat-booth', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({'type': 'booth:chat', 'body': 'too early'}))
         msg = json.loads(ws.receive_text())
 
@@ -218,7 +238,7 @@ def test_ws_chat_before_join_returns_error():
 
 
 def test_ws_set_active_before_join_returns_error():
-    with client.websocket_connect('/ws/booth/no-join-sa-booth') as ws:
+    with client.websocket_connect('/ws/booth/no-join-sa-booth', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({'type': 'booth:set-active', 'target_id': 'nobody'}))
         msg = json.loads(ws.receive_text())
 
@@ -226,7 +246,7 @@ def test_ws_set_active_before_join_returns_error():
 
 
 def test_ws_set_active_missing_target_returns_error():
-    with client.websocket_connect('/ws/booth/sa-missing-booth') as ws:
+    with client.websocket_connect('/ws/booth/sa-missing-booth', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({'type': 'booth:join', 'display_name': 'Dave', 'role': 'interpreter', 'language': 'Italian', 'channel_id': 'sa-missing-booth-audio'}))
         ws.receive_text()
         ws.receive_text()
@@ -238,7 +258,7 @@ def test_ws_set_active_missing_target_returns_error():
 
 
 def test_ws_update_state_active_interpreter():
-    with client.websocket_connect('/ws/booth/upd-state-booth') as ws:
+    with client.websocket_connect('/ws/booth/upd-state-booth', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join',
             'display_name': 'Eve',
@@ -257,7 +277,7 @@ def test_ws_update_state_active_interpreter():
 
 def test_ws_disconnect_without_leave_auto_removes_participant():
     """Participant is cleaned up from registry when WS disconnects unexpectedly."""
-    with client.websocket_connect('/ws/booth/disc-booth') as ws:
+    with client.websocket_connect('/ws/booth/disc-booth', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join',
             'display_name': 'Frank',
@@ -281,7 +301,7 @@ def test_ws_active_interpreter_can_set_active():
     issues with TestClient. Permission logic is covered by test_booth_state.py;
     here we verify the WS protocol path produces a booth:state response.
     """
-    with client.websocket_connect('/ws/booth/self-active-booth') as ws:
+    with client.websocket_connect('/ws/booth/self-active-booth', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join',
             'display_name': 'Solo',
@@ -306,8 +326,8 @@ def test_ws_active_interpreter_can_set_active():
 def test_ws_standby_cannot_set_mic_active():
     """Standby interpreter (not active) receives booth:error when trying to set mic_active."""
     # Use two connections: IntA (first-joined = active), IntB (standby)
-    with client.websocket_connect('/ws/booth/standby-perm-booth') as ws_a, \
-         client.websocket_connect('/ws/booth/standby-perm-booth') as ws_b:
+    with client.websocket_connect('/ws/booth/standby-perm-booth', cookies=_ws_auth()) as ws_a, \
+         client.websocket_connect('/ws/booth/standby-perm-booth', cookies=_ws_auth()) as ws_b:
 
         # IntA joins first → becomes active; ws_b receives the broadcast immediately
         ws_a.send_text(json.dumps({
@@ -371,9 +391,9 @@ def test_ws_three_way_coordinator_flow():
         ws.receive_text()  # drain booth:state broadcast from own join
         return pid
 
-    with client.websocket_connect(f'/ws/booth/{booth}') as ws_a, \
-         client.websocket_connect(f'/ws/booth/{booth}') as ws_b, \
-         client.websocket_connect(f'/ws/booth/{booth}') as ws_coord:
+    with client.websocket_connect(f'/ws/booth/{booth}', cookies=_ws_auth()) as ws_a, \
+         client.websocket_connect(f'/ws/booth/{booth}', cookies=_ws_auth()) as ws_b, \
+         client.websocket_connect(f'/ws/booth/{booth}', cookies=_ws_auth()) as ws_coord:
 
         # IntA joins (no pending for ws_a; ws_b + ws_coord each queue 1 state msg)
         pid_a = ws_join(ws_a, 'IntA', 'interpreter', n_pending=0)
@@ -403,7 +423,7 @@ def test_ws_three_way_coordinator_flow():
 
 def test_ws_full_flow_join_update_chat_leave():
     """Single-connection end-to-end flow: join → update-state → chat → leave."""
-    with client.websocket_connect('/ws/booth/e2e-flow-booth') as ws:
+    with client.websocket_connect('/ws/booth/e2e-flow-booth', cookies=_ws_auth()) as ws:
         # 1. Join
         ws.send_text(json.dumps({
             'type': 'booth:join', 'display_name': 'E2E', 'role': 'interpreter',
@@ -461,7 +481,7 @@ def test_ws_auth_required_with_token(monkeypatch):
             ws.receive_text()
 
     # WebSocket WITH a valid JWT should be accepted.
-    with client.websocket_connect(f'/ws/booth/auth-test?token={jwt_token}') as ws:
+    with client.websocket_connect(f'/ws/booth/auth-test?token={jwt_token}', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join', 'display_name': 'AuthUser',
             'role': 'interpreter', 'language': 'English',
@@ -477,8 +497,8 @@ def test_ws_auth_required_with_token(monkeypatch):
 
 def test_ws_coordinator_can_switch_active_interpreter():
     """Coordinator assigns a second interpreter as active; state broadcast reflects the change."""
-    with client.websocket_connect('/ws/booth/switch-booth') as ws_a, \
-         client.websocket_connect('/ws/booth/switch-booth') as ws_coord:
+    with client.websocket_connect('/ws/booth/switch-booth', cookies=_ws_auth()) as ws_a, \
+         client.websocket_connect('/ws/booth/switch-booth', cookies=_ws_auth()) as ws_coord:
 
         # Interpreter A joins
         ws_a.send_text(json.dumps({
@@ -523,7 +543,7 @@ def test_whip_url_active_interpreter_gets_url():
     """Active interpreter receives a WHIP URL from the gated endpoint."""
     booth = 'whip-gate-booth'
     channel = f'{booth}-audio'
-    with client.websocket_connect(f'/ws/booth/{booth}') as ws:
+    with client.websocket_connect(f'/ws/booth/{booth}', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join', 'display_name': 'Active',
             'role': 'interpreter', 'language': 'English', 'channel_id': channel,
@@ -551,8 +571,8 @@ def test_whip_url_standby_interpreter_rejected():
     """Standby interpreter receives 403 from the WHIP URL endpoint."""
     booth = 'whip-standby-booth'
     channel = f'{booth}-audio'
-    with client.websocket_connect(f'/ws/booth/{booth}') as ws_a, \
-         client.websocket_connect(f'/ws/booth/{booth}') as ws_b:
+    with client.websocket_connect(f'/ws/booth/{booth}', cookies=_ws_auth()) as ws_a, \
+         client.websocket_connect(f'/ws/booth/{booth}', cookies=_ws_auth()) as ws_b:
 
         # IntA joins first → becomes active
         ws_a.send_text(json.dumps({
@@ -588,7 +608,7 @@ def test_whip_url_coordinator_rejected():
     """Coordinator role receives 403 from the WHIP URL endpoint."""
     booth = 'whip-coord-booth'
     channel = f'{booth}-audio'
-    with client.websocket_connect(f'/ws/booth/{booth}') as ws:
+    with client.websocket_connect(f'/ws/booth/{booth}', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join', 'display_name': 'Coord',
             'role': 'coordinator', 'language': 'English', 'channel_id': channel,
@@ -785,7 +805,7 @@ def test_full_bootstrap_flow():
 
     # 3. Interpreter joins via WebSocket
     channel = booth['mediamtx_path']
-    with client.websocket_connect(f'/ws/booth/{booth_id}') as ws:
+    with client.websocket_connect(f'/ws/booth/{booth_id}', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join',
             'display_name': 'Interpreter A',
@@ -851,7 +871,7 @@ def test_event_booth_state_does_not_autocreate():
 def test_event_booth_whip_url_active_interpreter():
     """Event-scoped WHIP URL returns URL for active interpreter."""
     client.post('/api/events/whipevent/booths', json={'language_code': 'en', 'language': 'English'})
-    with client.websocket_connect('/ws/booth/whipevent-en') as ws:
+    with client.websocket_connect('/ws/booth/whipevent-en', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join',
             'display_name': 'Interp',
@@ -878,7 +898,7 @@ def test_event_booth_whip_url_active_interpreter():
 def test_event_booth_whip_url_standby_rejected():
     """Event-scoped WHIP URL rejects standby interpreter."""
     client.post('/api/events/whiprej/booths', json={'language_code': 'en', 'language': 'English'})
-    with client.websocket_connect('/ws/booth/whiprej-en') as ws:
+    with client.websocket_connect('/ws/booth/whiprej-en', cookies=_ws_auth()) as ws:
         # First interpreter joins (becomes active)
         ws.send_text(json.dumps({
             'type': 'booth:join', 'display_name': 'Active',
@@ -888,7 +908,7 @@ def test_event_booth_whip_url_standby_rejected():
         ws.receive_text()  # state
 
         # Second interpreter joins (becomes standby)
-        with client.websocket_connect('/ws/booth/whiprej-en') as ws2:
+        with client.websocket_connect('/ws/booth/whiprej-en', cookies=_ws_auth()) as ws2:
             ws2.send_text(json.dumps({
                 'type': 'booth:join', 'display_name': 'Standby',
                 'role': 'interpreter', 'language': 'English', 'channel_id': 'whiprej/en',
@@ -942,7 +962,7 @@ def test_cross_event_mediamtx_path_isolation():
 def test_ws_cross_event_join_rejected():
     """WebSocket join with mismatched event_slug must be rejected."""
     client.post('/api/events/evtreal/booths', json={'language_code': 'en', 'language': 'English'})
-    with client.websocket_connect('/ws/booth/evtreal-en') as ws:
+    with client.websocket_connect('/ws/booth/evtreal-en', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join',
             'display_name': 'Attacker',
@@ -959,7 +979,7 @@ def test_ws_cross_event_join_rejected():
 def test_ws_cross_event_join_accepted_with_correct_slug():
     """WebSocket join with matching event_slug must succeed."""
     client.post('/api/events/evtok/booths', json={'language_code': 'en', 'language': 'English'})
-    with client.websocket_connect('/ws/booth/evtok-en') as ws:
+    with client.websocket_connect('/ws/booth/evtok-en', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join',
             'display_name': 'Good Interpreter',
@@ -979,7 +999,7 @@ def test_full_isolation_flow():
     client.post('/api/events/fest2/booths', json={'language_code': 'en', 'language': 'English'})
 
     # Join fest1 booth
-    with client.websocket_connect('/ws/booth/fest1-en') as ws:
+    with client.websocket_connect('/ws/booth/fest1-en', cookies=_ws_auth()) as ws:
         ws.send_text(json.dumps({
             'type': 'booth:join', 'display_name': 'Alice',
             'role': 'interpreter', 'language': 'English', 'channel_id': 'fest1/en',

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -12,8 +12,26 @@ import pytest
 from fastapi.testclient import TestClient
 
 from fastapi_app import app
+from portal.auth import create_participant_token, create_user_token
 
 client = TestClient(app)
+
+
+def _interpreter_cookie(event_slug: str = 'test-event', language_code: str = 'en') -> dict:
+    """Return a cookies dict with a valid interpreter session_token."""
+    tok = create_participant_token(
+        booth_id=1,
+        role='interpreter',
+        event_slug=event_slug,
+        language_code=language_code,
+    )
+    return {'session_token': tok}
+
+
+def _admin_user_cookie() -> dict:
+    """Return a cookies dict with a valid is_admin user_token."""
+    tok = create_user_token(user_id=1, email='admin@test.com', is_admin=True)
+    return {'user_token': tok}
 
 
 # ── REST & page tests ─────────────────────────────────────────────────────────
@@ -34,8 +52,15 @@ def test_home_renders_home_page():
     assert b'Eventyay' in res.content
 
 
+def test_interpreter_booth_requires_auth():
+    """Unauthenticated /interpreter/ requests redirect to login."""
+    res = client.get('/interpreter/test-booth', follow_redirects=False)
+    assert res.status_code == 303
+    assert '/login' in res.headers['location']
+
+
 def test_interpreter_booth_page_renders():
-    res = client.get('/interpreter/test-booth')
+    res = client.get('/interpreter/test-booth', cookies=_interpreter_cookie())
     assert res.status_code == 200
     assert b'test-booth' in res.content
 
@@ -43,7 +68,7 @@ def test_interpreter_booth_page_renders():
 def test_interpreter_booth_jitsi_url_uses_base_url():
     """Jitsi URL in the booth page must use the configured base URL, not
     a hard-coded http:// scheme, to avoid mixed-content on HTTPS deployments."""
-    res = client.get('/interpreter/test-booth')
+    res = client.get('/interpreter/test-booth', cookies=_interpreter_cookie())
     assert res.status_code == 200
     from portal.config import settings
     from fastapi_app import _make_jitsi_url
@@ -73,7 +98,7 @@ def test_interpreter_booth_jitsi_domain_matches_base_url_host():
     """
     from urllib.parse import urlparse
     from portal.config import settings
-    res = client.get('/interpreter/test-booth')
+    res = client.get('/interpreter/test-booth', cookies=_interpreter_cookie())
     assert res.status_code == 200
     expected_host = urlparse(settings.effective_jitsi_base_url).netloc
     assert f"data-jitsi-domain='{expected_host}'".encode() in res.content
@@ -670,9 +695,16 @@ def test_list_event_booths_empty():
     assert res.json()['booths'] == []
 
 
+def test_interpreter_booth_by_identity_requires_auth():
+    """Unauthenticated /interpreter/{slug}/{lang} redirects to login."""
+    res = client.get('/interpreter/myevent/en', follow_redirects=False)
+    assert res.status_code == 303
+    assert '/login' in res.headers['location']
+
+
 def test_interpreter_booth_by_identity_page():
     """GET /interpreter/{event_slug}/{language_code} renders the booth page."""
-    res = client.get('/interpreter/myevent/en')
+    res = client.get('/interpreter/myevent/en', cookies=_interpreter_cookie('myevent', 'en'))
     assert res.status_code == 200
     assert b'myevent-en' in res.content
     assert b"data-event-slug='myevent'" in res.content
@@ -683,18 +715,53 @@ def test_interpreter_booth_by_identity_page():
 
 def test_interpreter_booth_by_identity_whip_whep_urls():
     """The identity-based booth page has correct WHIP and WHEP URLs."""
-    res = client.get('/interpreter/fossasia/fr')
+    res = client.get('/interpreter/fossasia/fr', cookies=_interpreter_cookie('fossasia', 'fr'))
     assert res.status_code == 200
     content = res.content.decode()
     assert 'fossasia/fr/whip' in content
     assert 'fossasia/fr/whep' in content
 
 
+def test_interpreter_booth_by_identity_no_role_returns_403():
+    """Registered user without event membership gets 403 on the booth page."""
+    # user_token without is_admin and no EventMembership in DB
+    tok = create_user_token(user_id=999, email='norole@test.com', is_admin=False)
+    res = client.get('/interpreter/norole-event/en', cookies={'user_token': tok})
+    assert res.status_code == 403
+
+
+def test_interpreter_booth_admin_user_gets_event_admin_role():
+    """A user with is_admin=True gets event_admin role without needing a membership."""
+    res = client.get('/interpreter/myevent/en', cookies=_admin_user_cookie())
+    assert res.status_code == 200
+    assert b"data-granted-role='event_admin'" in res.content
+
+
+def test_legacy_interpreter_booth_requires_auth():
+    """Unauthenticated legacy /interpreter/{booth_id} redirects to login."""
+    res = client.get('/interpreter/demo-booth', follow_redirects=False)
+    assert res.status_code == 303
+
+
 def test_legacy_interpreter_booth_still_works():
     """The old /interpreter/{booth_id} route still works for backward compat."""
-    res = client.get('/interpreter/demo-booth')
+    res = client.get('/interpreter/demo-booth', cookies=_interpreter_cookie())
     assert res.status_code == 200
     assert b'demo-booth' in res.content
+
+
+def test_listener_webrtc_requires_auth():
+    """Unauthenticated /listener-webrtc/ redirects to login."""
+    res = client.get('/listener-webrtc/demo-booth', follow_redirects=False)
+    assert res.status_code == 303
+    assert '/login' in res.headers['location']
+
+
+def test_listen_hls_requires_auth():
+    """Unauthenticated /listen/ redirects to login."""
+    res = client.get('/listen/demo-booth', follow_redirects=False)
+    assert res.status_code == 303
+    assert '/login' in res.headers['location']
 
 
 def test_full_bootstrap_flow():
@@ -710,8 +777,9 @@ def test_full_bootstrap_flow():
     booth_id = booth['booth_id']
     assert booth_id == 'bootstrap-es'
 
-    # 2. Interpreter accesses booth page
-    page_res = client.get('/interpreter/bootstrap/es')
+    # 2. Interpreter accesses booth page (with valid invite token)
+    page_res = client.get('/interpreter/bootstrap/es',
+                          cookies=_interpreter_cookie('bootstrap', 'es'))
     assert page_res.status_code == 200
     assert b'bootstrap-es' in page_res.content
 

--- a/tests/test_memberships_tokens.py
+++ b/tests/test_memberships_tokens.py
@@ -1,0 +1,674 @@
+"""Tests for event-scoped memberships, token management, and admin CRUD.
+
+Covers:
+- EventMembership CRUD (set, update, remove, list)
+- Token generation, listing, and revocation via admin routes
+- Admin event members page (GET + POST)
+- Token generation form on booth detail page
+- Revoked/expired tokens cannot be reused
+- Account page shows event memberships
+- End-to-end: create event → add member → generate token → revoke token
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ['BOOTH_ACCESS_TOKEN'] = ''
+os.environ['ADMIN_PASSWORD'] = 'test-admin-pass'
+
+from datetime import timedelta
+
+import pytest
+
+from portal.auth import create_admin_token, create_user_token, hash_password
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    from portal.database import configure, dispose, init_db
+    configure('sqlite+aiosqlite://')
+    await init_db()
+    yield
+    await dispose()
+
+
+@pytest.fixture
+def admin_cookie():
+    return {'admin_token': create_admin_token()}
+
+
+def _client():
+    from httpx import ASGITransport, AsyncClient
+    from fastapi_app import app
+    return AsyncClient(transport=ASGITransport(app=app), base_url='http://test')
+
+
+async def _create_test_user(email='test@example.com', display_name='Test User', password='securepass123'):
+    from portal.database import create_user, get_session
+    pw_hash = hash_password(password)
+    async with get_session() as s:
+        user = await create_user(s, email=email, display_name=display_name, password_hash=pw_hash)
+    return user
+
+
+async def _seed_event_room_booth():
+    from portal.database import create_booth, create_event, create_room, get_session
+    async with get_session() as s:
+        event = await create_event(s, slug='testcon', display_name='TestCon 2026')
+        room = await create_room(s, event_id=event.id, display_name='Main Hall')
+        booth = await create_booth(
+            s, event_id=event.id, room_id=room.id,
+            language_code='en', language_name='English',
+        )
+    return event, room, booth
+
+
+# ---------------------------------------------------------------------------
+# Database-level EventMembership CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestEventMembershipDB:
+    @pytest.mark.anyio
+    async def test_create_membership(self, setup_db):
+        from portal.database import get_session, set_event_membership
+        user = await _create_test_user()
+        event, _, _ = await _seed_event_room_booth()
+        async with get_session() as s:
+            m = await set_event_membership(s, user_id=user.id, event_id=event.id, role='interpreter')
+        assert m.role == 'interpreter'
+        assert m.user_id == user.id
+        assert m.event_id == event.id
+
+    @pytest.mark.anyio
+    async def test_update_membership_role(self, setup_db):
+        from portal.database import get_session, set_event_membership
+        user = await _create_test_user()
+        event, _, _ = await _seed_event_room_booth()
+        async with get_session() as s:
+            await set_event_membership(s, user_id=user.id, event_id=event.id, role='listener')
+        async with get_session() as s:
+            m = await set_event_membership(s, user_id=user.id, event_id=event.id, role='coordinator')
+        assert m.role == 'coordinator'
+
+    @pytest.mark.anyio
+    async def test_list_memberships_for_event(self, setup_db):
+        from portal.database import get_session, list_memberships_for_event, set_event_membership
+        u1 = await _create_test_user(email='a@test.com')
+        u2 = await _create_test_user(email='b@test.com')
+        event, _, _ = await _seed_event_room_booth()
+        async with get_session() as s:
+            await set_event_membership(s, user_id=u1.id, event_id=event.id, role='interpreter')
+            await set_event_membership(s, user_id=u2.id, event_id=event.id, role='listener')
+        async with get_session() as s:
+            memberships = await list_memberships_for_event(s, event.id)
+        assert len(memberships) == 2
+        roles = {m.role for m in memberships}
+        assert roles == {'interpreter', 'listener'}
+
+    @pytest.mark.anyio
+    async def test_list_memberships_for_user(self, setup_db):
+        from portal.database import (
+            create_event, get_session, list_memberships_for_user, set_event_membership,
+        )
+        user = await _create_test_user()
+        event1, _, _ = await _seed_event_room_booth()
+        async with get_session() as s:
+            event2 = await create_event(s, slug='other', display_name='Other Event')
+        async with get_session() as s:
+            await set_event_membership(s, user_id=user.id, event_id=event1.id, role='interpreter')
+            await set_event_membership(s, user_id=user.id, event_id=event2.id, role='coordinator')
+        async with get_session() as s:
+            memberships = await list_memberships_for_user(s, user.id)
+        assert len(memberships) == 2
+
+    @pytest.mark.anyio
+    async def test_remove_membership(self, setup_db):
+        from portal.database import (
+            get_session, list_memberships_for_event, remove_event_membership, set_event_membership,
+        )
+        user = await _create_test_user()
+        event, _, _ = await _seed_event_room_booth()
+        async with get_session() as s:
+            m = await set_event_membership(s, user_id=user.id, event_id=event.id, role='interpreter')
+            mid = m.id
+        async with get_session() as s:
+            result = await remove_event_membership(s, mid)
+        assert result is True
+        async with get_session() as s:
+            memberships = await list_memberships_for_event(s, event.id)
+        assert len(memberships) == 0
+
+    @pytest.mark.anyio
+    async def test_remove_nonexistent_membership(self, setup_db):
+        from portal.database import get_session, remove_event_membership
+        async with get_session() as s:
+            result = await remove_event_membership(s, 9999)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Database-level token CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestTokenDB:
+    @pytest.mark.anyio
+    async def test_create_invite_token(self, setup_db):
+        from portal.database import create_invite_token, get_session
+        _, _, booth = await _seed_event_room_booth()
+        async with get_session() as s:
+            tok = await create_invite_token(s, booth_id=booth.id, role='interpreter', label='Alice')
+        assert len(tok.token) == 64
+        assert tok.role == 'interpreter'
+        assert tok.label == 'Alice'
+        assert tok.is_used is False
+        assert tok.is_expired is False
+
+    @pytest.mark.anyio
+    async def test_revoke_invite_token(self, setup_db):
+        from portal.database import create_invite_token, get_session, revoke_invite_token
+        _, _, booth = await _seed_event_room_booth()
+        async with get_session() as s:
+            tok = await create_invite_token(s, booth_id=booth.id, role='interpreter')
+            token_str = tok.token
+        async with get_session() as s:
+            revoked = await revoke_invite_token(s, token_str)
+        assert revoked is not None
+        assert revoked.used_at is not None
+        assert revoked.is_used is True
+
+    @pytest.mark.anyio
+    async def test_revoke_nonexistent_token(self, setup_db):
+        from portal.database import get_session, revoke_invite_token
+        async with get_session() as s:
+            result = await revoke_invite_token(s, 'nonexistent-token-string')
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_revoked_token_cannot_be_redeemed(self, setup_db):
+        from portal.database import (
+            create_invite_token, get_session, redeem_invite_token, revoke_invite_token,
+        )
+        _, _, booth = await _seed_event_room_booth()
+        async with get_session() as s:
+            tok = await create_invite_token(s, booth_id=booth.id, role='interpreter')
+            token_str = tok.token
+        async with get_session() as s:
+            await revoke_invite_token(s, token_str)
+        async with get_session() as s:
+            with pytest.raises(ValueError, match='already been used'):
+                await redeem_invite_token(s, token_str)
+
+    @pytest.mark.anyio
+    async def test_expired_token_cannot_be_redeemed(self, setup_db):
+        from portal.database import create_invite_token, get_session, redeem_invite_token
+        from portal.models import utc_now
+        _, _, booth = await _seed_event_room_booth()
+        past = utc_now() - timedelta(hours=1)
+        async with get_session() as s:
+            tok = await create_invite_token(s, booth_id=booth.id, role='interpreter', expires_at=past)
+            token_str = tok.token
+        async with get_session() as s:
+            with pytest.raises(ValueError, match='expired'):
+                await redeem_invite_token(s, token_str)
+
+    @pytest.mark.anyio
+    async def test_list_tokens_for_booth(self, setup_db):
+        from portal.database import create_invite_token, get_session, list_tokens_for_booth
+        _, _, booth = await _seed_event_room_booth()
+        async with get_session() as s:
+            await create_invite_token(s, booth_id=booth.id, role='interpreter', label='T1')
+            await create_invite_token(s, booth_id=booth.id, role='listener', label='T2')
+        async with get_session() as s:
+            tokens = await list_tokens_for_booth(s, booth.id)
+        assert len(tokens) == 2
+
+
+# ---------------------------------------------------------------------------
+# Admin event members routes (HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestAdminEventMembersRoutes:
+    @pytest.mark.anyio
+    async def test_members_page_renders(self, setup_db, admin_cookie):
+        event, _, _ = await _seed_event_room_booth()
+        user = await _create_test_user(email='listed@test.com', display_name='Listed')
+        async with _client() as c:
+            resp = await c.get(f'/admin/events/{event.id}/members/', cookies=admin_cookie)
+        assert resp.status_code == 200
+        assert b'Members' in resp.content
+        # All users are shown in the table
+        assert b'listed@test.com' in resp.content
+
+    @pytest.mark.anyio
+    async def test_members_page_404_for_missing_event(self, setup_db, admin_cookie):
+        async with _client() as c:
+            resp = await c.get('/admin/events/9999/members/', cookies=admin_cookie)
+        assert resp.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_members_page_requires_admin(self, setup_db):
+        event, _, _ = await _seed_event_room_booth()
+        async with _client() as c:
+            resp = await c.get(f'/admin/events/{event.id}/members/')
+        assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_add_member(self, setup_db, admin_cookie):
+        from portal.database import get_session, list_memberships_for_event
+        event, _, _ = await _seed_event_room_booth()
+        user = await _create_test_user()
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/members/',
+                data={'user_id': str(user.id), 'role': 'interpreter'},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            memberships = await list_memberships_for_event(s, event.id)
+        assert len(memberships) == 1
+        assert memberships[0].role == 'interpreter'
+        assert memberships[0].user_id == user.id
+
+    @pytest.mark.anyio
+    async def test_members_page_shows_assigned_role(self, setup_db, admin_cookie):
+        from portal.database import get_session, set_event_membership
+        event, _, _ = await _seed_event_room_booth()
+        user = await _create_test_user()
+        async with get_session() as s:
+            await set_event_membership(s, user_id=user.id, event_id=event.id, role='interpreter')
+        async with _client() as c:
+            resp = await c.get(f'/admin/events/{event.id}/members/', cookies=admin_cookie)
+        assert resp.status_code == 200
+        # The interpreter option should be selected
+        assert b'selected' in resp.content
+        assert b'Remove' in resp.content
+
+    @pytest.mark.anyio
+    async def test_remove_member(self, setup_db, admin_cookie):
+        from portal.database import get_session, list_memberships_for_event, set_event_membership
+        event, _, _ = await _seed_event_room_booth()
+        user = await _create_test_user()
+        async with get_session() as s:
+            m = await set_event_membership(s, user_id=user.id, event_id=event.id, role='interpreter')
+            mid = m.id
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/members/{mid}/delete',
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            memberships = await list_memberships_for_event(s, event.id)
+        assert len(memberships) == 0
+
+    @pytest.mark.anyio
+    async def test_set_none_removes_membership(self, setup_db, admin_cookie):
+        from portal.database import get_session, list_memberships_for_event, set_event_membership
+        event, _, _ = await _seed_event_room_booth()
+        user = await _create_test_user()
+        async with get_session() as s:
+            await set_event_membership(s, user_id=user.id, event_id=event.id, role='interpreter')
+        # POST with empty role removes the membership
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/members/',
+                data={'user_id': str(user.id), 'role': ''},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            memberships = await list_memberships_for_event(s, event.id)
+        assert len(memberships) == 0
+
+
+# ---------------------------------------------------------------------------
+# Admin token management routes (HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestAdminTokenRoutes:
+    @pytest.mark.anyio
+    async def test_generate_token(self, setup_db, admin_cookie):
+        from portal.database import get_session, list_tokens_for_booth
+        event, room, booth = await _seed_event_room_booth()
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/tokens/',
+                data={'role': 'interpreter', 'label': 'Alice'},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            tokens = await list_tokens_for_booth(s, booth.id)
+        assert len(tokens) == 1
+        assert tokens[0].role == 'interpreter'
+        assert tokens[0].label == 'Alice'
+
+    @pytest.mark.anyio
+    async def test_generate_token_with_expiry(self, setup_db, admin_cookie):
+        from portal.database import get_session, list_tokens_for_booth
+        event, room, booth = await _seed_event_room_booth()
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/tokens/',
+                data={'role': 'listener', 'label': 'Bob', 'expires_hours': '24'},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            tokens = await list_tokens_for_booth(s, booth.id)
+        assert len(tokens) == 1
+        assert tokens[0].expires_at is not None
+
+    @pytest.mark.anyio
+    async def test_generate_token_requires_admin(self, setup_db):
+        event, room, booth = await _seed_event_room_booth()
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/tokens/',
+                data={'role': 'interpreter', 'label': 'Alice'},
+            )
+        assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_generate_token_without_role_is_noop(self, setup_db, admin_cookie):
+        from portal.database import get_session, list_tokens_for_booth
+        event, room, booth = await _seed_event_room_booth()
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/tokens/',
+                data={'role': '', 'label': 'NoRole'},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            tokens = await list_tokens_for_booth(s, booth.id)
+        assert len(tokens) == 0
+
+    @pytest.mark.anyio
+    async def test_revoke_token_via_route(self, setup_db, admin_cookie):
+        from portal.database import create_invite_token, get_invite_token, get_session
+        event, room, booth = await _seed_event_room_booth()
+        async with get_session() as s:
+            tok = await create_invite_token(s, booth_id=booth.id, role='interpreter')
+            token_str = tok.token
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/tokens/{token_str}/revoke',
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            revoked = await get_invite_token(s, token_str)
+        assert revoked.is_used is True
+
+    @pytest.mark.anyio
+    async def test_revoke_token_requires_admin(self, setup_db):
+        event, room, booth = await _seed_event_room_booth()
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/tokens/fake-token/revoke',
+            )
+        assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_booth_detail_shows_token_form(self, setup_db, admin_cookie):
+        event, room, booth = await _seed_event_room_booth()
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/',
+                cookies=admin_cookie,
+            )
+        assert resp.status_code == 200
+        assert b'Generate New Token' in resp.content
+        assert b'Generate Token' in resp.content
+
+    @pytest.mark.anyio
+    async def test_booth_detail_shows_tokens(self, setup_db, admin_cookie):
+        from portal.database import create_invite_token, get_session
+        event, room, booth = await _seed_event_room_booth()
+        async with get_session() as s:
+            await create_invite_token(s, booth_id=booth.id, role='interpreter', label='TestTok')
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/',
+                cookies=admin_cookie,
+            )
+        assert resp.status_code == 200
+        assert b'TestTok' in resp.content
+        assert b'Revoke' in resp.content
+        assert b'Copy Link' in resp.content
+
+    @pytest.mark.anyio
+    async def test_booth_detail_shows_revoked_token(self, setup_db, admin_cookie):
+        from portal.database import create_invite_token, get_session, revoke_invite_token
+        event, room, booth = await _seed_event_room_booth()
+        async with get_session() as s:
+            tok = await create_invite_token(s, booth_id=booth.id, role='interpreter', label='RevokedTok')
+            await revoke_invite_token(s, tok.token)
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/',
+                cookies=admin_cookie,
+            )
+        assert resp.status_code == 200
+        assert b'RevokedTok' in resp.content
+        assert b'Revoked / Used' in resp.content
+
+
+# ---------------------------------------------------------------------------
+# Account page shows event memberships
+# ---------------------------------------------------------------------------
+
+
+class TestAccountMemberships:
+    @pytest.mark.anyio
+    async def test_account_shows_memberships(self, setup_db):
+        from portal.database import get_session, set_event_membership
+        user = await _create_test_user(email='member@test.com', display_name='Member')
+        event, _, _ = await _seed_event_room_booth()
+        async with get_session() as s:
+            await set_event_membership(s, user_id=user.id, event_id=event.id, role='interpreter')
+        token = create_user_token(user_id=user.id, email=user.email, is_admin=user.is_admin)
+        async with _client() as c:
+            resp = await c.get('/account', cookies={'user_token': token})
+        assert resp.status_code == 200
+        assert b'interpreter' in resp.content
+        assert b'TestCon 2026' in resp.content
+
+    @pytest.mark.anyio
+    async def test_account_shows_no_memberships(self, setup_db):
+        user = await _create_test_user(email='lonely@test.com', display_name='Lonely')
+        token = create_user_token(user_id=user.id, email=user.email, is_admin=user.is_admin)
+        async with _client() as c:
+            resp = await c.get('/account', cookies={'user_token': token})
+        assert resp.status_code == 200
+        assert b'not been assigned' in resp.content
+
+
+# ---------------------------------------------------------------------------
+# Event detail page shows Members link
+# ---------------------------------------------------------------------------
+
+
+class TestEventDetailMembersLink:
+    @pytest.mark.anyio
+    async def test_event_detail_has_members_link(self, setup_db, admin_cookie):
+        event, _, _ = await _seed_event_room_booth()
+        async with _client() as c:
+            resp = await c.get(f'/admin/events/{event.id}/', cookies=admin_cookie)
+        assert resp.status_code == 200
+        assert b'Manage Members' in resp.content
+        assert f'/admin/events/{event.id}/members/'.encode() in resp.content
+
+
+# ---------------------------------------------------------------------------
+# User list page (no global role dropdown)
+# ---------------------------------------------------------------------------
+
+
+class TestUserListNoGlobalRole:
+    @pytest.mark.anyio
+    async def test_user_list_no_role_dropdown(self, setup_db, admin_cookie):
+        await _create_test_user()
+        async with _client() as c:
+            resp = await c.get('/admin/users/', cookies=admin_cookie)
+        assert resp.status_code == 200
+        # Should NOT have role-change form or super_admin option
+        assert b'super_admin' not in resp.content
+        assert b'role-select' not in resp.content
+        # Should say roles are per-event
+        assert b'per event' in resp.content.lower() or b'per-event' in resp.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full admin workflow
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndAdminWorkflow:
+    @pytest.mark.anyio
+    async def test_full_workflow(self, setup_db, admin_cookie):
+        """E2E: create event → add user → assign role → generate token → revoke."""
+        from portal.database import get_invite_token, get_session, list_memberships_for_event
+
+        # 1. Create event
+        async with _client() as c:
+            resp = await c.post('/admin/events/', data={
+                'slug': 'e2e-event', 'display_name': 'E2E Event',
+            }, cookies=admin_cookie, follow_redirects=False)
+        assert resp.status_code == 303
+
+        # Find the event
+        from portal.database import get_event_by_slug
+        async with get_session() as s:
+            event = await get_event_by_slug(s, 'e2e-event')
+        assert event is not None
+
+        # 2. Create room
+        async with _client() as c:
+            resp = await c.post(f'/admin/events/{event.id}/rooms/', data={
+                'display_name': 'Room A',
+            }, cookies=admin_cookie, follow_redirects=False)
+        assert resp.status_code == 303
+
+        from portal.database import list_rooms_for_event
+        async with get_session() as s:
+            rooms = await list_rooms_for_event(s, event.id)
+        assert len(rooms) == 1
+        room = rooms[0]
+
+        # 3. Create booth
+        async with _client() as c:
+            resp = await c.post(f'/admin/events/{event.id}/rooms/{room.id}/booths/', data={
+                'language_code': 'fr', 'language_name': 'French',
+            }, cookies=admin_cookie, follow_redirects=False)
+        assert resp.status_code == 303
+
+        from portal.database import list_booths_for_room
+        async with get_session() as s:
+            booths = await list_booths_for_room(s, room.id)
+        assert len(booths) == 1
+        booth = booths[0]
+
+        # 4. Register a user
+        async with _client() as c:
+            resp = await c.post('/register', data={
+                'email': 'alice@e2e.com', 'display_name': 'Alice',
+                'password': 'securepass123', 'password_confirm': 'securepass123',
+            }, follow_redirects=False)
+        assert resp.status_code == 303
+
+        from portal.database import get_user_by_email
+        async with get_session() as s:
+            alice = await get_user_by_email(s, 'alice@e2e.com')
+        assert alice is not None
+
+        # 5. Assign per-event role
+        async with _client() as c:
+            resp = await c.post(f'/admin/events/{event.id}/members/', data={
+                'user_id': str(alice.id), 'role': 'interpreter',
+            }, cookies=admin_cookie, follow_redirects=False)
+        assert resp.status_code == 303
+
+        async with get_session() as s:
+            memberships = await list_memberships_for_event(s, event.id)
+        assert len(memberships) == 1
+        assert memberships[0].role == 'interpreter'
+
+        # 6. Generate invite token for the booth
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/tokens/',
+                data={'role': 'interpreter', 'label': 'Alice FR booth'},
+                cookies=admin_cookie, follow_redirects=False,
+            )
+        assert resp.status_code == 303
+
+        from portal.database import list_tokens_for_booth
+        async with get_session() as s:
+            tokens = await list_tokens_for_booth(s, booth.id)
+        assert len(tokens) == 1
+        token_str = tokens[0].token
+        assert tokens[0].label == 'Alice FR booth'
+
+        # 7. Verify booth detail page shows the token
+        async with _client() as c:
+            resp = await c.get(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/',
+                cookies=admin_cookie,
+            )
+        assert resp.status_code == 200
+        assert b'Alice FR booth' in resp.content
+        assert b'Revoke' in resp.content
+
+        # 8. Revoke the token
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/tokens/{token_str}/revoke',
+                cookies=admin_cookie, follow_redirects=False,
+            )
+        assert resp.status_code == 303
+
+        async with get_session() as s:
+            revoked = await get_invite_token(s, token_str)
+        assert revoked.is_used is True
+
+        # 9. Verify Alice's account page shows the membership
+        user_token = create_user_token(user_id=alice.id, email=alice.email, is_admin=alice.is_admin)
+        async with _client() as c:
+            resp = await c.get('/account', cookies={'user_token': user_token})
+        assert resp.status_code == 200
+        assert b'interpreter' in resp.content
+        assert b'E2E Event' in resp.content
+
+        # 10. Remove membership
+        async with get_session() as s:
+            memberships = await list_memberships_for_event(s, event.id)
+        mid = memberships[0].id
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/events/{event.id}/members/{mid}/delete',
+                cookies=admin_cookie, follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            memberships = await list_memberships_for_event(s, event.id)
+        assert len(memberships) == 0

--- a/tests/test_memberships_tokens.py
+++ b/tests/test_memberships_tokens.py
@@ -81,8 +81,8 @@ class TestEventMembershipDB:
         user = await _create_test_user()
         event, _, _ = await _seed_event_room_booth()
         async with get_session() as s:
-            m = await set_event_membership(s, user_id=user.id, event_id=event.id, role='interpreter')
-        assert m.role == 'interpreter'
+            m = await set_event_membership(s, user_id=user.id, event_id=event.id, role='event_admin')
+        assert m.role == 'event_admin'
         assert m.user_id == user.id
         assert m.event_id == event.id
 
@@ -245,8 +245,8 @@ class TestAdminEventMembersRoutes:
             resp = await c.get(f'/admin/events/{event.id}/members/', cookies=admin_cookie)
         assert resp.status_code == 200
         assert b'Members' in resp.content
-        # All users are shown in the table
-        assert b'listed@test.com' in resp.content
+        # Table should show empty state because no members are assigned
+        assert b'No users have been assigned' in resp.content
 
     @pytest.mark.anyio
     async def test_members_page_404_for_missing_event(self, setup_db, admin_cookie):
@@ -269,7 +269,7 @@ class TestAdminEventMembersRoutes:
         async with _client() as c:
             resp = await c.post(
                 f'/admin/events/{event.id}/members/',
-                data={'user_id': str(user.id), 'role': 'interpreter'},
+                data={'email': user.email, 'role': 'event_admin'},
                 cookies=admin_cookie,
                 follow_redirects=False,
             )
@@ -277,7 +277,7 @@ class TestAdminEventMembersRoutes:
         async with get_session() as s:
             memberships = await list_memberships_for_event(s, event.id)
         assert len(memberships) == 1
-        assert memberships[0].role == 'interpreter'
+        assert memberships[0].role == 'event_admin'
         assert memberships[0].user_id == user.id
 
     @pytest.mark.anyio
@@ -286,12 +286,12 @@ class TestAdminEventMembersRoutes:
         event, _, _ = await _seed_event_room_booth()
         user = await _create_test_user()
         async with get_session() as s:
-            await set_event_membership(s, user_id=user.id, event_id=event.id, role='interpreter')
+            await set_event_membership(s, user_id=user.id, event_id=event.id, role='event_admin')
         async with _client() as c:
             resp = await c.get(f'/admin/events/{event.id}/members/', cookies=admin_cookie)
         assert resp.status_code == 200
-        # The interpreter option should be selected
-        assert b'selected' in resp.content
+        # The badge for event_admin should be rendered
+        assert b'badge-event_admin' in resp.content
         assert b'Remove' in resp.content
 
     @pytest.mark.anyio
@@ -324,7 +324,7 @@ class TestAdminEventMembersRoutes:
         async with _client() as c:
             resp = await c.post(
                 f'/admin/events/{event.id}/members/',
-                data={'user_id': str(user.id), 'role': ''},
+                data={'email': user.email, 'role': ''},
                 cookies=admin_cookie,
                 follow_redirects=False,
             )
@@ -604,14 +604,14 @@ class TestEndToEndAdminWorkflow:
         # 5. Assign per-event role
         async with _client() as c:
             resp = await c.post(f'/admin/events/{event.id}/members/', data={
-                'user_id': str(alice.id), 'role': 'interpreter',
+                'email': alice.email, 'role': 'event_admin',
             }, cookies=admin_cookie, follow_redirects=False)
         assert resp.status_code == 303
 
         async with get_session() as s:
             memberships = await list_memberships_for_event(s, event.id)
         assert len(memberships) == 1
-        assert memberships[0].role == 'interpreter'
+        assert memberships[0].role == 'event_admin'
 
         # 6. Generate invite token for the booth
         async with _client() as c:
@@ -656,7 +656,7 @@ class TestEndToEndAdminWorkflow:
         async with _client() as c:
             resp = await c.get('/account', cookies={'user_token': user_token})
         assert resp.status_code == 200
-        assert b'interpreter' in resp.content
+        assert b'event_admin' in resp.content
         assert b'E2E Event' in resp.content
 
         # 10. Remove membership

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -98,8 +98,8 @@ def test_super_admin_has_all_permissions():
 # ── can_go_live ──────────────────────────────────────────────────────────
 
 
-ROLES_THAT_CAN_GO_LIVE = {'interpreter', 'event_admin', 'super_admin'}
-ROLES_THAT_CANNOT_GO_LIVE = {'coordinator', 'listener'}
+ROLES_THAT_CAN_GO_LIVE = {'coordinator', 'interpreter', 'event_admin', 'super_admin'}
+ROLES_THAT_CANNOT_GO_LIVE = {'listener'}
 
 
 @pytest.mark.parametrize('role', list(ROLES_THAT_CAN_GO_LIVE))
@@ -190,20 +190,20 @@ def test_privilege_escalation_hierarchy():
     listener = ROLE_PERMISSIONS['listener']
 
     assert listener.issubset(coord), 'listener perms must be subset of coordinator'
+    assert ROLE_PERMISSIONS['interpreter'].issubset(coord), 'interpreter perms must be subset of coordinator'
+    assert coord.issubset(ea), 'coordinator perms must be subset of event_admin'
     assert coord.issubset(ea), 'coordinator perms must be subset of event_admin'
     assert ea.issubset(sa), 'event_admin perms must be subset of super_admin'
 
 
-def test_interpreter_is_not_subset_of_coordinator():
-    """Interpreter has BOOTH_GO_LIVE which coordinator lacks.
+def test_interpreter_is_subset_of_coordinator():
+    """Interpreter has BOOTH_GO_LIVE, which coordinator now also has.
 
-    This verifies the intentional divergence: interpreters can go live
-    but cannot set active, while coordinators can set active but cannot
-    go live.
+    This means interpreter permissions are a strict subset of coordinator permissions.
     """
     interp = ROLE_PERMISSIONS['interpreter']
     coord = ROLE_PERMISSIONS['coordinator']
-    assert not interp.issubset(coord)
+    assert interp.issubset(coord)
     assert not coord.issubset(interp)
 
 

--- a/tests/test_user_auth.py
+++ b/tests/test_user_auth.py
@@ -1,0 +1,337 @@
+"""Tests for user registration, login, account, and admin user management."""
+
+from __future__ import annotations
+
+import os
+
+os.environ['BOOTH_ACCESS_TOKEN'] = ''
+os.environ['ADMIN_PASSWORD'] = 'test-admin-pass'
+
+import pytest
+
+from portal.auth import create_admin_token, create_user_token, hash_password, verify_password
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    from portal.database import configure, dispose, init_db
+    configure('sqlite+aiosqlite://')
+    await init_db()
+    yield
+    await dispose()
+
+
+@pytest.fixture
+def admin_cookie():
+    return {'admin_token': create_admin_token()}
+
+
+def _client():
+    from httpx import ASGITransport, AsyncClient
+    from fastapi_app import app
+    return AsyncClient(transport=ASGITransport(app=app), base_url='http://test')
+
+
+async def _create_test_user(email='test@example.com', display_name='Test User', password='securepass123'):
+    from portal.database import create_user, get_session
+    pw_hash = hash_password(password)
+    async with get_session() as s:
+        user = await create_user(s, email=email, display_name=display_name, password_hash=pw_hash)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Password hashing
+# ---------------------------------------------------------------------------
+
+
+class TestPasswordHashing:
+    @pytest.mark.anyio
+    async def test_hash_and_verify(self, setup_db):
+        pw = 'my-secret-password'
+        hashed = hash_password(pw)
+        assert hashed != pw
+        assert verify_password(pw, hashed)
+
+    @pytest.mark.anyio
+    async def test_wrong_password_fails(self, setup_db):
+        hashed = hash_password('correct')
+        assert not verify_password('wrong', hashed)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    @pytest.mark.anyio
+    async def test_register_page_renders(self, setup_db):
+        async with _client() as c:
+            resp = await c.get('/register')
+        assert resp.status_code == 200
+        assert b'Create your account' in resp.content
+
+    @pytest.mark.anyio
+    async def test_register_creates_listener_account(self, setup_db):
+        async with _client() as c:
+            resp = await c.post('/register', data={
+                'email': 'new@example.com',
+                'display_name': 'New User',
+                'password': 'securepass123',
+                'password_confirm': 'securepass123',
+            }, follow_redirects=False)
+        assert resp.status_code == 303
+        assert resp.headers['location'] == '/account'
+        assert 'user_token' in resp.headers.get('set-cookie', '')
+
+    @pytest.mark.anyio
+    async def test_register_rejects_short_password(self, setup_db):
+        async with _client() as c:
+            resp = await c.post('/register', data={
+                'email': 'new@example.com',
+                'display_name': 'New User',
+                'password': 'short',
+                'password_confirm': 'short',
+            })
+        assert resp.status_code == 422
+        assert b'at least 8 characters' in resp.content
+
+    @pytest.mark.anyio
+    async def test_register_rejects_mismatched_passwords(self, setup_db):
+        async with _client() as c:
+            resp = await c.post('/register', data={
+                'email': 'new@example.com',
+                'display_name': 'New User',
+                'password': 'securepass123',
+                'password_confirm': 'differentpass',
+            })
+        assert resp.status_code == 422
+        assert b'do not match' in resp.content
+
+    @pytest.mark.anyio
+    async def test_register_rejects_duplicate_email(self, setup_db):
+        await _create_test_user(email='dupe@example.com')
+        async with _client() as c:
+            resp = await c.post('/register', data={
+                'email': 'dupe@example.com',
+                'display_name': 'Another User',
+                'password': 'securepass123',
+                'password_confirm': 'securepass123',
+            })
+        assert resp.status_code == 422
+        assert b'already exists' in resp.content
+
+    @pytest.mark.anyio
+    async def test_register_default_role_is_listener(self, setup_db):
+        from portal.database import get_session, get_user_by_email
+        async with _client() as c:
+            await c.post('/register', data={
+                'email': 'listener@example.com',
+                'display_name': 'Listener',
+                'password': 'securepass123',
+                'password_confirm': 'securepass123',
+            }, follow_redirects=False)
+        async with get_session() as s:
+            user = await get_user_by_email(s, 'listener@example.com')
+        assert user is not None
+        assert user.role == 'listener'
+
+
+# ---------------------------------------------------------------------------
+# Login
+# ---------------------------------------------------------------------------
+
+
+class TestUserLogin:
+    @pytest.mark.anyio
+    async def test_login_page_renders(self, setup_db):
+        async with _client() as c:
+            resp = await c.get('/login')
+        assert resp.status_code == 200
+        assert b'Sign in' in resp.content
+
+    @pytest.mark.anyio
+    async def test_login_with_correct_credentials(self, setup_db):
+        await _create_test_user(email='login@example.com', password='securepass123')
+        async with _client() as c:
+            resp = await c.post('/login', data={
+                'email': 'login@example.com',
+                'password': 'securepass123',
+            }, follow_redirects=False)
+        assert resp.status_code == 303
+        assert resp.headers['location'] == '/account'
+        assert 'user_token' in resp.headers.get('set-cookie', '')
+
+    @pytest.mark.anyio
+    async def test_login_with_wrong_password(self, setup_db):
+        await _create_test_user(email='login@example.com', password='securepass123')
+        async with _client() as c:
+            resp = await c.post('/login', data={
+                'email': 'login@example.com',
+                'password': 'wrongpassword',
+            })
+        assert resp.status_code == 403
+        assert b'Invalid email or password' in resp.content
+
+    @pytest.mark.anyio
+    async def test_login_with_nonexistent_email(self, setup_db):
+        async with _client() as c:
+            resp = await c.post('/login', data={
+                'email': 'nobody@example.com',
+                'password': 'whatever',
+            })
+        assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_login_deactivated_user_rejected(self, setup_db):
+        from portal.database import get_session, update_user_active
+        user = await _create_test_user(email='deactivated@example.com', password='securepass123')
+        async with get_session() as s:
+            await update_user_active(s, user.id, is_active=False)
+        async with _client() as c:
+            resp = await c.post('/login', data={
+                'email': 'deactivated@example.com',
+                'password': 'securepass123',
+            })
+        assert resp.status_code == 403
+        assert b'deactivated' in resp.content
+
+
+# ---------------------------------------------------------------------------
+# Logout
+# ---------------------------------------------------------------------------
+
+
+class TestUserLogout:
+    @pytest.mark.anyio
+    async def test_logout_clears_cookie(self, setup_db):
+        async with _client() as c:
+            resp = await c.get('/logout', follow_redirects=False)
+        assert resp.status_code == 303
+        assert resp.headers['location'] == '/'
+
+
+# ---------------------------------------------------------------------------
+# Account page
+# ---------------------------------------------------------------------------
+
+
+class TestAccountPage:
+    @pytest.mark.anyio
+    async def test_account_requires_login(self, setup_db):
+        async with _client() as c:
+            resp = await c.get('/account', follow_redirects=False)
+        assert resp.status_code == 303
+        assert resp.headers['location'] == '/login'
+
+    @pytest.mark.anyio
+    async def test_account_shows_user_info(self, setup_db):
+        user = await _create_test_user(email='me@example.com', display_name='Me')
+        token = create_user_token(user_id=user.id, email=user.email, role=user.role)
+        async with _client() as c:
+            resp = await c.get('/account', cookies={'user_token': token})
+        assert resp.status_code == 200
+        assert b'me@example.com' in resp.content
+        assert b'Me' in resp.content
+        assert b'listener' in resp.content
+
+
+# ---------------------------------------------------------------------------
+# Admin user management
+# ---------------------------------------------------------------------------
+
+
+class TestAdminUserManagement:
+    @pytest.mark.anyio
+    async def test_user_list_shows_users(self, setup_db, admin_cookie):
+        await _create_test_user(email='user1@example.com', display_name='User One')
+        async with _client() as c:
+            resp = await c.get('/admin/users/', cookies=admin_cookie)
+        assert resp.status_code == 200
+        assert b'user1@example.com' in resp.content
+        assert b'User One' in resp.content
+
+    @pytest.mark.anyio
+    async def test_user_list_requires_admin(self, setup_db):
+        async with _client() as c:
+            resp = await c.get('/admin/users/')
+        assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_change_user_role(self, setup_db, admin_cookie):
+        from portal.database import get_session, get_user_by_id
+        user = await _create_test_user()
+        assert user.role == 'listener'
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/users/{user.id}/role',
+                data={'role': 'interpreter'},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            updated = await get_user_by_id(s, user.id)
+        assert updated.role == 'interpreter'
+
+    @pytest.mark.anyio
+    async def test_toggle_user_active(self, setup_db, admin_cookie):
+        from portal.database import get_session, get_user_by_id
+        user = await _create_test_user()
+        assert user.is_active is True
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/users/{user.id}/toggle-active',
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            updated = await get_user_by_id(s, user.id)
+        assert updated.is_active is False
+
+    @pytest.mark.anyio
+    async def test_delete_user(self, setup_db, admin_cookie):
+        from portal.database import get_session, get_user_by_id
+        user = await _create_test_user()
+        async with _client() as c:
+            resp = await c.post(
+                f'/admin/users/{user.id}/delete',
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            deleted = await get_user_by_id(s, user.id)
+        assert deleted is None
+
+
+# ---------------------------------------------------------------------------
+# Home page auth links
+# ---------------------------------------------------------------------------
+
+
+class TestHomePageAuthLinks:
+    @pytest.mark.anyio
+    async def test_home_shows_login_register_when_logged_out(self, setup_db):
+        async with _client() as c:
+            resp = await c.get('/')
+        assert resp.status_code == 200
+        assert b'Sign In' in resp.content
+        assert b'Register' in resp.content
+
+    @pytest.mark.anyio
+    async def test_home_shows_account_when_logged_in(self, setup_db):
+        user = await _create_test_user()
+        token = create_user_token(user_id=user.id, email=user.email, role=user.role)
+        async with _client() as c:
+            resp = await c.get('/', cookies={'user_token': token})
+        assert resp.status_code == 200
+        assert b'My Account' in resp.content
+        assert b'Logout' in resp.content

--- a/tests/test_user_auth.py
+++ b/tests/test_user_auth.py
@@ -128,7 +128,7 @@ class TestRegistration:
         assert b'already exists' in resp.content
 
     @pytest.mark.anyio
-    async def test_register_default_role_is_listener(self, setup_db):
+    async def test_register_creates_active_non_admin(self, setup_db):
         from portal.database import get_session, get_user_by_email
         async with _client() as c:
             await c.post('/register', data={
@@ -140,7 +140,8 @@ class TestRegistration:
         async with get_session() as s:
             user = await get_user_by_email(s, 'listener@example.com')
         assert user is not None
-        assert user.role == 'listener'
+        assert user.is_admin is False
+        assert user.is_active is True
 
 
 # ---------------------------------------------------------------------------
@@ -233,13 +234,12 @@ class TestAccountPage:
     @pytest.mark.anyio
     async def test_account_shows_user_info(self, setup_db):
         user = await _create_test_user(email='me@example.com', display_name='Me')
-        token = create_user_token(user_id=user.id, email=user.email, role=user.role)
+        token = create_user_token(user_id=user.id, email=user.email, is_admin=user.is_admin)
         async with _client() as c:
             resp = await c.get('/account', cookies={'user_token': token})
         assert resp.status_code == 200
         assert b'me@example.com' in resp.content
         assert b'Me' in resp.content
-        assert b'listener' in resp.content
 
 
 # ---------------------------------------------------------------------------
@@ -264,21 +264,23 @@ class TestAdminUserManagement:
         assert resp.status_code == 403
 
     @pytest.mark.anyio
-    async def test_change_user_role(self, setup_db, admin_cookie):
-        from portal.database import get_session, get_user_by_id
+    async def test_set_event_membership(self, setup_db, admin_cookie):
+        from portal.database import create_event, get_session, list_memberships_for_event
         user = await _create_test_user()
-        assert user.role == 'listener'
+        async with get_session() as s:
+            event = await create_event(s, display_name='Test Event', slug='test-event')
         async with _client() as c:
             resp = await c.post(
-                f'/admin/users/{user.id}/role',
-                data={'role': 'interpreter'},
+                f'/admin/events/{event.id}/members/',
+                data={'user_id': str(user.id), 'role': 'interpreter'},
                 cookies=admin_cookie,
                 follow_redirects=False,
             )
         assert resp.status_code == 303
         async with get_session() as s:
-            updated = await get_user_by_id(s, user.id)
-        assert updated.role == 'interpreter'
+            memberships = await list_memberships_for_event(s, event.id)
+        assert len(memberships) == 1
+        assert memberships[0].role == 'interpreter'
 
     @pytest.mark.anyio
     async def test_toggle_user_active(self, setup_db, admin_cookie):
@@ -329,7 +331,7 @@ class TestHomePageAuthLinks:
     @pytest.mark.anyio
     async def test_home_shows_account_when_logged_in(self, setup_db):
         user = await _create_test_user()
-        token = create_user_token(user_id=user.id, email=user.email, role=user.role)
+        token = create_user_token(user_id=user.id, email=user.email, is_admin=user.is_admin)
         async with _client() as c:
             resp = await c.get('/', cookies={'user_token': token})
         assert resp.status_code == 200

--- a/tests/test_user_auth.py
+++ b/tests/test_user_auth.py
@@ -272,7 +272,7 @@ class TestAdminUserManagement:
         async with _client() as c:
             resp = await c.post(
                 f'/admin/events/{event.id}/members/',
-                data={'user_id': str(user.id), 'role': 'interpreter'},
+                data={'email': user.email, 'role': 'interpreter'},
                 cookies=admin_cookie,
                 follow_redirects=False,
             )

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,59 @@ wheels = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
@@ -92,12 +145,14 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "bcrypt" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -112,12 +167,14 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "alembic", specifier = ">=1.15.0" },
+    { name = "bcrypt", specifier = ">=5.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "pydantic-settings", specifier = ">=2.9.0" },
     { name = "pyjwt", specifier = ">=2.9.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "python-multipart", specifier = ">=0.0.30" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
@@ -400,6 +457,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/82/c8cd43a6e0719bf5a3b034f6726dd701f75829c08944c83d4b95d02ed0e8/python_multipart-0.0.30.tar.gz", hash = "sha256:0edfe0475c1f46ddd3ff7785a626f6118af32bdcf359bb21260367313bb32118", size = 46316, upload-time = "2026-05-31T19:24:55.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/fd/0318007beb234790993d3ec5afd051d1dbceb733e81e3afe2b981ece3f37/python_multipart-0.0.30-py3-none-any.whl", hash = "sha256:830964def8c90607ac5daa00514e3987815865713ade8d20febc9177ac0c3c5b", size = 29730, upload-time = "2026-05-31T19:24:53.814Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/f820c154-53e9-478d-92f8-4a25ff78d74c" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/d1910688-d66b-4519-b938-4d7f6e336d58" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/3bd53484-2341-4bc0-9ddf-49c6e3786595" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/18e41f51-2436-41b7-bd53-a72a892d6c0e" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/32b781af-b9f1-409a-a881-e28c7b36aa36" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/b8722e11-00e7-4d59-bf61-a7eb64ddbf00" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/2f219c48-4004-42c8-bb94-9ad3d1f9b0f7" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/22815542-9e4f-415e-b149-286cd4ef60ab" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/8fb7973a-7c23-453e-bed7-90f023853aaa" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/71cc5fdb-94de-49d9-9a30-2003677947ca" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/d3f4c62a-340a-4c00-b5f8-b1395fd51bc9" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/47f3bbad-fd03-4a1f-8bb3-3aa9c194fdff" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/837e93c5-f558-4316-934e-0a7c0acc2fc0" />






## Summary

Implements event-scoped roles, invite-token management UI, and a membership admin page for the interpretation portal. Replaces the previous global `User.role` field with a per-event `EventMembership` model, enabling users to hold different roles across different events.

Closes #66
closes #67 
closes #68 
closes #69 

## Changes

### Models & Database
- **`EventMembership` model** — links a user to an event with a specific role (`listener`, `interpreter`, `coordinator`, `event_admin`); unique constraint on `(user_id, event_id)`
- **Migration `003_event_memberships`** — creates `event_memberships` table, adds `users.is_admin` boolean column, drops the old `users.role` column (SQLite batch-mode safe)
- **Database CRUD** — `set_event_membership()`, `remove_event_membership()`, `list_memberships_for_event()`, `list_memberships_for_user()`, `revoke_invite_token()`

### Routes
- **`GET/POST /admin/events/{id}/members/`** — list all registered users with inline role dropdowns; assign or remove per-event roles
- **`POST /admin/events/{id}/members/{mid}/delete`** — remove a membership
- **Token CRUD** — generate and revoke invite tokens from the booth detail page
- **`/join/{token}`** — existing invite flow unchanged; redeems token, issues JWT, redirects to booth

### Templates & Frontend
- **`event_members.html`** — new page showing all users in a table with inline role `<select>` (auto-submits on change); assigned users highlighted
- **`booth_detail.html`** — token generation form (role, label, optional expiry) + token table with Copy Link / Revoke actions
- **`account.html`** — displays per-event memberships instead of a global role
- **`user_list.html`** — removed global role dropdown; shows `is_admin` badge
- **`event_detail.html`** — added "Manage Members" link
- **`admin.js`** — external ES module for copy-to-clipboard (no inline scripts, no jQuery)
- **`admin.css`** — token form, member table, and badge styles

### Auth
- JWT `create_user_token()` now carries `is_admin` claim instead of `role`

### Tests (385 passing)
- `test_memberships_tokens.py` — covers DB CRUD, admin routes, token routes, account page, and a full end-to-end admin workflow
- `test_user_auth.py` — updated for the new `is_admin` field and `EventMembership`

### CI
- `.github/workflows/tests.yml` — added `node --check static/js/admin.js` lint step and comprehensive Docker smoke tests (admin login/CRUD, user registration, 403 guards)

### Documentation
- Updated `ARCHITECTURE.md` (ER diagram with EventMembership), `README.md`, `docs/admin-guide.md` (token management, event-scoped roles), `explainer.md` (auth flow)

## How to test

```bash
# Run tests
cd eventyay-interpretation-portal
python -m pytest tests/ -q   # 385 passed

# Docker
docker compose up --build -d
# Set ADMIN_PASSWORD env var, then:
# 1. Login at /admin/login/
# 2. Create event → room → booth
# 3. Go to booth detail → generate invite token → copy link
# 4. Open /join/<token> in incognito → auto-redirected to booth
# 5. Go to event members page → assign roles via dropdown
```