### PR TITLE
ci: add GitHub Actions auto-deploy workflow on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,81 @@
+name: Deploy to Production
+
+# Trigger: auto-deploy whenever a commit lands on main (direct push or PR merge)
+on:
+  push:
+    branches:
+      - main
+
+  # Manual trigger for rollbacks / forced re-deploy
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false   # Never cancel a running deploy — finish it
+
+jobs:
+  deploy:
+    name: SSH deploy → voxbento.com
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout (for reference — actual code pull happens on server)
+        uses: actions/checkout@v4
+
+      # ── SSH into the production server and pull latest code ──────────────
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          port: 22
+          # Timeout: 5 minutes (alembic migrations + docker restart can take ~60s)
+          command_timeout: 5m
+          script: |
+            set -e
+
+            echo "=== Deploying to production: $(date) ==="
+            cd /home/ubuntu/voxbento
+
+            # ── Pull latest code from main ─────────────────────────────────
+            echo "--- git pull ---"
+            git fetch origin main
+            git checkout main
+            git pull origin main
+
+            # ── Copy Caddyfile to system location ──────────────────────────
+            if [ -f Caddyfile ]; then
+              sudo cp Caddyfile /etc/caddy/Caddyfile
+              sudo systemctl reload caddy
+              echo "Caddy config updated and reloaded"
+            fi
+
+            # ── Restart portal (uvicorn --reload picks up code changes) ────
+            # Full restart ensures env changes and new dependencies are loaded.
+            echo "--- docker compose restart portal ---"
+            docker compose restart portal
+
+            # ── Restart mediamtx if mediamtx.yml changed ───────────────────
+            echo "--- docker compose restart mediamtx ---"
+            docker compose restart mediamtx
+
+            # ── Wait for portal health ──────────────────────────────────────
+            echo "--- waiting for portal health ---"
+            for i in $(seq 1 30); do
+              status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/healthz 2>/dev/null || echo "000")
+              echo "  attempt $i/30: HTTP $status"
+              if [ "$status" = "200" ]; then
+                echo "Portal is healthy!"
+                break
+              fi
+              if [ "$i" = "30" ]; then
+                echo "ERROR: Portal did not become healthy within 90s"
+                docker compose logs portal --tail=50
+                exit 1
+              fi
+              sleep 3
+            done
+
+            echo "=== Deploy complete: $(date) ==="
+            docker compose ps


### PR DESCRIPTION
Triggers on every push to main (PR merge or direct push). SSHes into the production server via appleboy/ssh-action, pulls latest code from origin/main, reloads Caddy if Caddyfile changed, restarts portal and mediamtx, then polls /healthz for up to 90s.

Required GitHub repository secrets:
  PROD_HOST    — server hostname or IP
  PROD_USER    — SSH username (ubuntu)
  PROD_SSH_KEY — full PEM private key contents