### PR TITLE
fix(ui): add css cache buster

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{% block title %}Voxbento Interpreter Booth{% endblock %}</title>
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='favicon.ico') }}" />
-    <link rel="stylesheet" href="{{ url_for('static', path='css/interpreter.css') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/interpreter.css') }}?v=2" />
     {% block head %}{% endblock %}
   </head>
   <body>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent stale CSS from being served by appending a versioned query parameter to the interpreter stylesheet URL.