### PR TITLE
fix(ui): re-add missing monitor-status to prevent js crash

### DIFF
--- a/static/css/interpreter.css
+++ b/static/css/interpreter.css
@@ -288,7 +288,8 @@ label {
 
 .monitor-controls {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
   gap: 0.5rem;
 }
 

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -84,6 +84,7 @@
           <div class='monitor-controls'>
             <input id='jitsi-url' class='input input-sm' type='url' value='{{ default_jitsi_url }}' />
             <button id='join-jitsi' type='button' class='btn btn-primary btn-sm'>Join Monitoring</button>
+            <span id='monitor-status' class='status-badge'>Idle</span>
           </div>
           <div class='monitor-frame'>
             <iframe id='jitsi-frame' title='Jitsi monitoring feed' allow='autoplay; fullscreen'></iframe>


### PR DESCRIPTION
## Summary by Sourcery

Restore the monitor status indicator in the interpreter booth monitoring UI and adjust the layout to accommodate it.

Bug Fixes:
- Reintroduce the monitor status element in the interpreter booth template to prevent JavaScript errors when monitoring.
- Align monitor controls grid styling to support the re-added status indicator without breaking layout.