### PR TITLE
fix: enable audio and video permissions for Jitsi monitoring feed

### DIFF
--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -547,8 +547,7 @@ function joinMonitoringFeed() {
       'config.startWithAudioMuted': 'true',
       'config.startWithVideoMuted': 'true',
       'config.prejoinPageEnabled': 'false',
-      'config.disableInitialGUM': 'true',
-      'config.startSilent': 'true',
+      'config.disableInitialGUM': 'false',
     }).toString()
     elements.jitsiFrame.src = `${meetingUrl.origin}${meetingUrl.pathname}#${hash}`
     setBadge(elements.monitorStatus, 'Connecting', 'warning')

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -87,7 +87,7 @@
             <span id='monitor-status' class='status-badge'>Idle</span>
           </div>
           <div class='monitor-frame'>
-            <iframe id='jitsi-frame' title='Jitsi monitoring feed' allow='autoplay; fullscreen'></iframe>
+            <iframe id='jitsi-frame' title='Jitsi monitoring feed' allow='camera; microphone; autoplay; fullscreen; display-capture; speaker-selection'></iframe>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
fix: enable audio and video permissions for Jitsi monitoring feed

## Changes Made
- [ ] Added feature X
- [x] Fixed bug Y
- [ ] Updated documentation Z
