### PR TITLE
fix(booth): unify join/leave button, fix ws disconnect, and set primary color

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1655,7 +1655,6 @@ async def ws_booth(websocket: WebSocket, booth_id: str) -> None:
                 await _handle_join(websocket, session, data)
             elif msg_type == 'booth:leave':
                 await _handle_leave(session)
-                break
             elif msg_type == 'booth:chat':
                 await _handle_chat(websocket, session, data)
             elif msg_type == 'booth:set-active':

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -51,11 +51,8 @@ const elements = {
   jitsiFrame: document.getElementById('jitsi-frame'),
   jitsiUrl: document.getElementById('jitsi-url'),
   joinJitsi: document.getElementById('join-jitsi'),
-  joinBooth: document.getElementById('join-booth'),
-  displayName: document.getElementById('display-name'),
-  role: document.getElementById('participant-role'),
-  language: document.getElementById('booth-language'),
-  channel: document.getElementById('booth-channel'),
+  joinLeaveBtn: document.getElementById('join-leave-btn'),
+  joinLeaveLabel: document.getElementById('join-leave-label'),
   chatForm: document.getElementById('chat-form'),
   chatInput: document.getElementById('chat-input'),
   toggleMic: document.getElementById('toggle-mic'),
@@ -73,7 +70,7 @@ const elements = {
   muteLabel: document.getElementById('mute-label'),
   liveLabel: document.getElementById('live-label'),
   ctrlCompound: document.querySelector('.ctrl-compound'),
-  leaveBooth: document.getElementById('leave-booth-btn'),
+  // leaveBooth removed
   preflightRetry: document.getElementById('preflight-retry'),
   checkMicPermission: document.getElementById('check-mic-permission'),
   checkAudioDevice: document.getElementById('check-audio-device'),
@@ -217,8 +214,29 @@ function authHeaders() {
 // ── Event binding ─────────────────────────────────────────────────────────────
 
 function bindEventHandlers() {
-  elements.joinBooth.addEventListener('click', () => {
-    joinBooth()
+  elements.joinLeaveBtn.addEventListener('click', async () => {
+    if (!state.joined) {
+      joinBooth()
+    } else {
+      if (state.ingestConnected) {
+        await stopLiveIngest()
+      }
+      if (state.micStream) {
+        state.micStream.getTracks().forEach((t) => t.stop())
+        state.micStream = null
+        stopMicMeter()
+      }
+      if (state.joined && state.participantId) {
+        wsSend({ type: 'booth:leave' })
+        state.joined = false
+        state.participantId = null
+        state.participants = []
+        state.activeInterpreterId = null
+        state.chatMessages = []
+        leaveMonitoringFeed()
+        render()
+      }
+    }
   })
 
   elements.jitsiFrame.addEventListener('load', () => {
@@ -305,27 +323,7 @@ function bindEventHandlers() {
     })
   })
 
-  elements.leaveBooth.addEventListener('click', async () => {
-    if (state.ingestConnected) {
-      await stopLiveIngest()
-    }
-    // Release mic stream on explicit leave (stopLiveIngest keeps it for relay handoff)
-    if (state.micStream) {
-      state.micStream.getTracks().forEach((t) => t.stop())
-      state.micStream = null
-      stopMicMeter()
-    }
-    if (state.joined && state.participantId) {
-      wsSend({ type: 'booth:leave' })
-      state.joined = false
-      state.participantId = null
-    }
-    if (state.ws) {
-      state.ws.close(1000)
-      state.ws = null
-    }
-    window.location.reload()
-  })
+
 
   if (navigator.mediaDevices) {
     navigator.mediaDevices.addEventListener('devicechange', () => {
@@ -516,15 +514,8 @@ function applyBoothState(payload, { skipAutoStart = false } = {}) {
 // ── Booth actions ─────────────────────────────────────────────────────────────
 
 function joinBooth() {
-  const displayName = elements.displayName.value.trim()
-  state.language = elements.language.value.trim() || state.language
-  state.channelId = elements.channel.value.trim() || state.channelId
-
-  // The select value is the BOOTH role the user wants to join as.
-  // For roles like event_admin/super_admin, the select offers coordinator
-  // as default so admins don't accidentally take an interpreter slot.
-  // state.grantedRole is only used as fallback if the select has no value.
-  const requestedRole = elements.role.value || state.grantedRole || 'interpreter'
+  const displayName = portal.dataset.displayName || 'Interpreter'
+  const requestedRole = state.grantedRole || 'interpreter'
 
   wsSend({
     type: 'booth:join',
@@ -557,7 +548,7 @@ function joinMonitoringFeed() {
     })
     
     // Add user info to Jitsi URL config
-    const dName = elements.displayName ? elements.displayName.value.trim() : ''
+    const dName = portal.dataset.displayName || 'Interpreter'
     if (dName) {
       hashParams.set('userInfo.displayName', `"${dName}"`)
     }
@@ -1092,6 +1083,13 @@ function renderMicControls() {
 
   elements.goLive.classList.toggle('live', state.ingestConnected)
   if (elements.liveLabel) elements.liveLabel.textContent = state.ingestConnected ? 'STOP' : 'GO LIVE'
+
+  const isJoined = state.joined
+  elements.joinLeaveBtn.title = isJoined ? 'Leave booth' : 'Join booth'
+  elements.joinLeaveBtn.setAttribute('aria-label', isJoined ? 'Leave booth' : 'Join booth')
+  if (elements.joinLeaveLabel) elements.joinLeaveLabel.textContent = isJoined ? 'LEAVE' : 'JOIN'
+  elements.joinLeaveBtn.classList.toggle('ctrl-btn--danger', isJoined)
+  elements.joinLeaveBtn.classList.toggle('ctrl-btn--primary', !isJoined)
 
   elements.toggleMic.disabled = !joinedActiveInterpreter
   const preflightCriticalPass =

--- a/templates/interpreter_booth.html
+++ b/templates/interpreter_booth.html
@@ -19,6 +19,7 @@
   data-whip-url='{{ whip_url | default("") }}'
   data-whep-url='{{ whep_url | default("") }}'
   data-granted-role='{{ granted_role | default("") }}'
+  data-display-name='{{ display_name | default("") }}'
 >
   <!-- ── Main 2-Column Grid ────────────────────────────────────────────── -->
   <div class='booth-columns'>
@@ -68,10 +69,10 @@
               <svg class='ctrl-icon' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'><path d='M6.99 11 3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z'/></svg>
               <span class='ctrl-label'>RELAY</span>
             </button>
-            <!-- Leave -->
-            <button id='leave-booth-btn' type='button' class='ctrl-btn ctrl-btn--danger' title='Leave booth' aria-label='Leave booth'>
+            <!-- Join / Leave -->
+            <button id='join-leave-btn' type='button' class='ctrl-btn ctrl-btn--primary' title='Join booth' aria-label='Join booth'>
               <svg class='ctrl-icon' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'><path d='M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5c-1.11 0-2 .9-2 2v4h2V5h14v14H5v-4H3v4c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z'/></svg>
-              <span class='ctrl-label'>LEAVE</span>
+              <span class='ctrl-label' id='join-leave-label'>JOIN</span>
             </button>
           </div>
           <p class='ctrl-shortcut-hint'>Press <kbd>Space</kbd> to mute / unmute</p>
@@ -92,49 +93,14 @@
     <!-- RIGHT COLUMN: Sidebar (Collapsible Accordions) -->
     <div class='booth-sidebar-col sidebar-scrollable'>
       
-      <!-- Setup Panel (Collapsible) -->
-      <details class='panel panel-details' open>
-        <summary class='panel-header panel-header-details'>
-          <h2>Booth Setup</h2>
-          <span id='connection-status' class='status-badge'>Disconnected</span>
-        </summary>
-        <div class='panel-body setup-sidebar'>
-          <div class='setup-grid'>
-            <label>Name <input id='display-name' type='text' class='input input-sm' placeholder='Interpreter' value='{{ display_name | default("") }}' /></label>
-            <label>
-              Role
-              {% set gr = granted_role | default("") %}
-              <select id='participant-role' class='input input-sm'{% if gr %} disabled{% endif %}>
-                {% if not gr %}
-                  <option value='interpreter'>Interpreter</option>
-                  <option value='coordinator'>Coordinator</option>
-                  <option value='listener'>Listener</option>
-                {% elif gr == 'listener' %}
-                  <option value='listener' selected>Listener</option>
-                {% elif gr == 'interpreter' %}
-                  <option value='interpreter' selected>Interpreter</option>
-                {% elif gr in ('coordinator', 'event_admin', 'super_admin') %}
-                  <option value='coordinator'{% if gr == 'coordinator' %} selected{% endif %}>Coordinator</option>
-                  <option value='interpreter'>Interpreter</option>
-                  <option value='listener'>Listener</option>
-                {% endif %}
-              </select>
-              {% if gr %}
-                <input type='hidden' id='participant-role-hidden' value='{{ gr }}' />
-              {% endif %}
-            </label>
-            <label>Language <input id='booth-language' type='text' class='input input-sm' value='{{ booth_language }}' readonly /></label>
-            <label>Channel <input id='booth-channel' type='text' class='input input-sm' value='{{ booth_channel_id }}' readonly /></label>
-          </div>
-          <button id='join-booth' type='button' class='btn btn-primary btn-sm' style='margin-top: 0.8rem; width: 100%'>Join Booth</button>
-        </div>
-      </details>
-
       <!-- Participants (Collapsible, Open by default) -->
       <details class='panel panel-details' open>
         <summary class='panel-header panel-header-details'>
           <h2>Participants</h2>
-          <span id='active-indicator' class='status-badge'>No active interpreter</span>
+          <div style="display: flex; gap: 0.5rem; align-items: center;">
+            <span id='connection-status' class='status-badge'>Disconnected</span>
+            <span id='active-indicator' class='status-badge'>No active interpreter</span>
+          </div>
         </summary>
         <div class='panel-body'>
           <div id='participant-list' class='participant-list'></div>


### PR DESCRIPTION
This PR unifies the Join and Leave buttons into a single toggle button in the top bar. It also sets the default color of the Join button to blue (primary). Finally, it fixes an issue where users could not rejoin after leaving because the WebSocket connection was being prematurely closed by the server on a leave action.