### PR TITLE
fix: Resolve 500 Error and Allow Event Admins to Manage Events

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1442,7 +1442,6 @@ async def admin_transcription_settings(
 ):
     from portal.database import get_session, get_booth_by_id, get_event_by_id
     from portal.booth_identity import make_booth_id
-    from portal.booth_state import booths
     from portal.transcription import start_transcription_worker, stop_transcription_worker
 
     async with get_session() as session:

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1465,8 +1465,8 @@ async def admin_transcription_settings(
         bid = make_booth_id(event.slug, db_booth.language_code)
         
         # Check if booth is live
-        state = booths.get(bid)
-        is_live = state is not None and state.active_publisher_id is not None
+        state = booths.get_booth_sync(bid)
+        is_live = state is not None and state.active_interpreter_id is not None
         
         if is_live:
             if not transcription_enabled:

--- a/portal/auth.py
+++ b/portal/auth.py
@@ -101,12 +101,23 @@ async def require_admin(request: Request) -> None:
     ``admin=True`` claim. Also accepts a valid ``user_token`` with
     ``is_admin=True``. Returns None on success; raises HTTP 403 on failure.
     """
+    event_id_str = request.path_params.get('event_id')
+    event_id = int(event_id_str) if event_id_str and event_id_str.isdigit() else None
+
     user_cookie = request.cookies.get('user_token', '')
     if user_cookie:
         try:
             payload = decode_token(user_cookie)
-            if payload.get('user') and payload.get('is_admin'):
-                return
+            if payload.get('user'):
+                if payload.get('is_admin'):
+                    return
+                if event_id is not None and payload.get('sub'):
+                    from portal.database import get_session, list_memberships_for_user
+                    async with get_session() as db_session:
+                        memberships = await list_memberships_for_user(db_session, int(payload['sub']))
+                        for m in memberships:
+                            if m.event_id == event_id and m.role == 'event_admin':
+                                return
         except jwt.InvalidTokenError:
             pass
 


### PR DESCRIPTION
## What this PR does

This PR introduces two critical fixes to the administrative panel and permissions system:

1. **Fixes 500 Internal Server Error in Transcription Settings**: Resolves an issue where saving transcription settings would throw an `AttributeError` by replacing `booths.get(bid)` with the proper `booths.get_booth_sync(bid)` method.
2. **Event Admin Permission Expansion**: Previously, all `/admin/*` routes were strictly locked behind global Super Admin privileges. This PR intelligently checks the `event_id` in the path parameters and gracefully allows Event Admins to access and manage the admin dashboard, rooms, booths, and members specifically for their assigned events.