### PR TITLE
fix: gracefully catch exceptions when cancelling transcription task

### DIFF
--- a/portal/transcription.py
+++ b/portal/transcription.py
@@ -114,8 +114,8 @@ async def stop_transcription_worker(booth_id: str):
         task.cancel()
         try:
             await task
-        except asyncio.CancelledError:
-            pass
+        except Exception as e:
+            logger.debug(f"Task finished with exception: {e}")
     
     # Also kill the ffmpeg process immediately if still lingering
     process = active_processes.get(booth_id)


### PR DESCRIPTION
## What this PR does

If the transcription worker crashes (e.g. `FileNotFoundError` if ffmpeg isn't installed in the environment), the `stop_transcription_worker` function would crash because `await task` re-raised the background exception during the stop request.

This PR wraps the `await task` in a broader `try/except Exception` block so that if the background worker died for any reason, the backend server doesn't crash when someone tries to turn the setting off or when the booth shuts down.

## Summary by Sourcery

Handle exceptions raised when awaiting cancellation of transcription worker tasks to prevent server crashes during shutdown or setting changes.

Bug Fixes:
- Prevent backend crashes when stopping a transcription worker whose task has already failed with an exception.
- Log unexpected exceptions raised when awaiting cancelled transcription tasks instead of propagating them.