### PR TITLE
chore: remove uvicorn --reload flag for production optimization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,9 +57,9 @@ jobs:
             echo "--- docker compose up -d ---"
             docker compose up -d --remove-orphans
 
-            # ── Restart portal (uvicorn --reload picks up code changes) ────
-            # Just in case 'up -d' didn't recreate the container, restart it
-            # so the FastAPI app fully reloads.
+            # ── Restart portal (loads fresh code since --reload is disabled) ────
+            # Because we disabled uvicorn --reload for production performance,
+            # this explicit restart is required for the FastAPI app to load new code.
             echo "--- docker compose restart portal ---"
             docker compose restart portal
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,9 @@ services:
     depends_on:
       - mediamtx
     restart: unless-stopped
-    # --reload watches for file changes and restarts uvicorn automatically.
+    # In production, --reload is omitted to prevent high CPU usage and extra processes.
     # Alembic migration runs first to ensure the database schema is current.
-    command: ["sh", "-c", "uv run alembic upgrade head && uv run uvicorn fastapi_app:app --host 0.0.0.0 --port 8000 --reload"]
+    command: ["sh", "-c", "uv run alembic upgrade head && uv run uvicorn fastapi_app:app --host 0.0.0.0 --port 8000"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz', timeout=3)"]
       interval: 10s


### PR DESCRIPTION
## Summary by Sourcery

Remove the uvicorn --reload flag from the Docker Compose production service command to reduce CPU usage and process overhead.