### PR TITLE
docs: improve transcription documentation and align with voxbento.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,28 @@ a real MediaMTX instance to verify WHEP continuity.
 WHEP listeners recover in ~1.5–3 s (RTCPeerConnection stays open via
 `alwaysAvailable` paths).
 
+## Transcription and AI Services
+
+Voxbento provides real-time transcription (Speech-to-Text) using various AI providers.
+
+### Architecture
+
+1. **Worker:** `portal/transcription/worker.py` spawns an FFmpeg process that pulls audio from MediaMTX via RTSP.
+2. **Ingest:** FFmpeg transcodes audio to PCM S16LE and pipes it to a `TranscriptionProvider`.
+3. **Provider:** Providers (in `portal/transcription/providers/`) handle communication with AI services (OpenAI, Deepgram, ElevenLabs, NVIDIA, or Local Faster-Whisper).
+4. **Aggregator:** `portal/transcription/aggregator.py` collects partial/final transcripts and broadcasts them via WebSockets (`/ws/captions/{booth_id}`).
+
+### Implementing a New Provider
+
+Inherit from `TranscriptionProvider` in `portal/transcription/providers/base.py`:
+
+- `process_chunk`: For providers that accept discrete audio chunks (REST).
+- `run_stream`: For providers that support streaming via WebSockets.
+
+### Configuration
+
+API keys for third-party providers are stored encrypted in the database and managed via the Admin Panel under **Global API Integrations**.
+
 ## Dependency management
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Voxbento is a real-time interpretation platform for live events. It provides a browser-first, zero-install experience for simultaneous interpreters, allowing them to monitor the main floor video via Jitsi and broadcast translated audio to attendees with low latency.
 
+**Official Documentation:** [docs.voxbento.com](https://docs.voxbento.com)
+
 Interpreters stream live audio via WebRTC/WHIP → MediaMTX → WHEP (WebRTC playback).
 Booth coordination (who is active, relay handoff, chat) runs over WebSocket.
 
@@ -62,7 +64,7 @@ docker compose up --build
 
 Open http://localhost:8000 — all services are running.
 
-For detailed API documentation, environment variables, port mappings, and native development setup, please see [CONTRIBUTING.md](CONTRIBUTING.md).
+For detailed API documentation, environment variables, and configuration, visit [docs.voxbento.com](https://docs.voxbento.com). Native development setup details can also be found in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 

--- a/docs/admin/transcription.mdx
+++ b/docs/admin/transcription.mdx
@@ -60,9 +60,15 @@ For the lowest latency captions, Deepgram `nova-2` (WebSocket streaming) is an e
 </TabItem>
   <TabItem value="elevenlabs" label="ElevenLabs">
 
-Uses ElevenLabs' `scribe_v2` model. Requires an ElevenLabs API key stored in the event's API settings.
+Uses ElevenLabs' **Speech-to-Text** (Scribe) service. Requires an ElevenLabs API key stored in the event's API settings.
 
-**Models available:** `scribe_v2`
+**Models available:** `scribe_v2_realtime`
+
+ElevenLabs Scribe provides high-accuracy transcription for various languages and supports low-latency streaming.
+
+:::info
+While ElevenLabs is widely known for Text-to-Speech, Voxbento utilizes their **Scribe** service specifically for high-quality **Speech-to-Text** (transcription).
+:::
 
 </TabItem>
   <TabItem value="nvidia-riva" label="NVIDIA Riva">
@@ -119,6 +125,18 @@ Choose a **Provider** from the dropdown — for example, `deepgram`. Then select
   ### Save
 
 Click **Save**. If the booth is currently live (an interpreter is broadcasting), the transcription worker restarts immediately with the new settings. There is no need to wait for the next session.
+
+## Caption Logic and Finalization
+
+Voxbento's caption aggregator applies several rules to ensure captions are readable and delivered efficiently:
+
+- **Sentence Splitting:** For batch providers (like Local Whisper), Voxbento automatically splits transcripts into sentences based on punctuation (`.`, `?`, `!`) to deliver stable, finalized text as soon as a thought is complete.
+- **Forced Finalization:** To prevent captions from staying in a "partial" state too long, Voxbento forces a finalization if a single utterance exceeds **15 seconds** or **50 words**.
+- **Silence Detection:** If the provider detects a significant pause in speech, the current partial caption is automatically finalized and cleared to prepare for the next sentence.
+
+:::info
+All caption coordination and delivery is handled via the official `voxbento.com` WebSocket endpoints, ensuring a consistent experience for all listeners.
+:::
 
 ## Caption Delivery and Message Format
 

--- a/docs/api/authentication.mdx
+++ b/docs/api/authentication.mdx
@@ -8,11 +8,11 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 
-The Voxbento API uses bearer token authentication. You call the token endpoint once with your booth access token, receive a signed JWT in return, and then include that JWT as an `Authorization: Bearer {token}` header on every subsequent request. Tokens expire after 24 hours by default, at which point you request a fresh one.
+The Voxbento API uses bearer token authentication. You call the `voxbento.com` token endpoint once with your booth access token, receive a signed JWT in return, and then include that JWT as an `Authorization: Bearer {token}` header on every subsequent request. Tokens expire after 24 hours by default, at which point you request a fresh one.
 
 ## Obtaining a Token
 
-Send a `POST` request to `/api/auth/token` with a JSON body containing the `token` field set to your booth access token. The `BOOTH_ACCESS_TOKEN` value is configured on your Voxbento instance by the operator — contact your operator if you need access.
+Send a `POST` request to the Voxbento token endpoint with a JSON body containing the `token` field set to your booth access token. The `BOOTH_ACCESS_TOKEN` value is provided by the Voxbento platform.
 
 **Endpoint**
 
@@ -77,7 +77,7 @@ const { access_token } = await response.json();
 </Tabs>
 
 :::info
-The `BOOTH_ACCESS_TOKEN` is set by your Voxbento instance operator. Contact your operator if you need API access.
+The `BOOTH_ACCESS_TOKEN` is provided by the Voxbento platform. Ensure you have the correct credentials before attempting to authenticate.
 :::
 
 ## Using the Token
@@ -103,7 +103,7 @@ Store the token in a secure location such as an environment variable or a secret
 Request a new token proactively before your current one expires to avoid a gap in service. Checking the response status on each request and refreshing on a `401` is a safe fallback strategy.
 :::
 
-Tokens expire after 86400 seconds (24 hours) by default. Your operator can adjust this value for your deployment. When a token expires, the API returns a `401 Unauthorized` response — simply call `POST /api/auth/token` again to obtain a fresh token and retry the original request.
+Tokens expire after 86400 seconds (24 hours) by default. When a token expires, the API returns a `401 Unauthorized` response — simply call `POST /api/auth/token` again to obtain a fresh token and retry the original request.
 
 ## Error Responses
 

--- a/docs/api/overview.mdx
+++ b/docs/api/overview.mdx
@@ -8,7 +8,7 @@ The Voxbento REST API gives you programmatic control over booths and events, let
 
 ## Base URL
 
-All API requests target your Voxbento instance. Replace the example domain with your own deployment address throughout this documentation.
+All API requests for Voxbento services target the official `voxbento.com` domain. 
 
 ```text
 https://voxbento.com
@@ -65,7 +65,7 @@ A healthy response looks like this:
 If `mediamtx_ok` is `false`, interpreter ingest and listener playback will be unavailable even if the portal itself is running.
 
 :::info
-Use `mediamtx_ok` to determine whether the media server is reachable before starting a stream. If it is `false`, check the MediaMTX service logs on your deployment.
+Use `mediamtx_ok` to determine whether the media server is reachable before starting a stream. If it is `false`, the underlying media services may be unavailable.
 :::
 
 ## Explore the API

--- a/docs/how-it-works.mdx
+++ b/docs/how-it-works.mdx
@@ -61,6 +61,20 @@ Listeners connect to the WHEP endpoint for their chosen language. WHEP (WebRTC H
 You do not need to configure the fallback manually. The listener page tries WHEP first and switches to HLS transparently if the WebRTC negotiation fails.
 :::
 
+## The Transcription Pipeline
+
+When live captions are enabled, Voxbento spawns a background transcription worker to process the active interpreter's audio.
+
+1. **Audio Ingest:** The worker uses FFmpeg to pull the live audio stream from MediaMTX via RTSP (`rtsp://mediamtx:8554/{event_slug}/{language_code}`).
+2. **Transcoding:** FFmpeg transcodes the audio to PCM S16LE (mono, 16kHz or 24kHz depending on the provider) and pipes it to the selected `TranscriptionProvider`.
+3. **AI Processing:** The provider sends audio chunks or a continuous stream to an AI service (OpenAI, Deepgram, ElevenLabs, NVIDIA, or Local Whisper).
+4. **Caption Aggregation:** The `CaptionAggregator` receives raw text from the provider. It applies logic to split sentences on punctuation (for batch providers) or handles real-time partial updates (for streaming providers).
+5. **Broadcast:** Caption updates are broadcast to listeners via the dedicated WebSocket at `wss://voxbento.com/ws/captions/{booth_id}`.
+
+:::info
+Transcription workers are isolated from the main audio path. If a transcription worker fails or encounters high latency, the interpretation audio remains unaffected.
+:::
+
 ## Booth Identity
 
 Every booth in Voxbento is uniquely identified by two coordinates:

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -40,6 +40,8 @@ Voxbento is built around a small set of guarantees that matter most in live inte
 - **Multi-language booths** — each booth maps to an ISO 639-1 language code (for example `en`, `fr`, `es`). Multiple booths can run in parallel inside the same event, each serving its own independent audio stream.
 - **Role-based access** — every participant carries a JWT that encodes their role (`interpreter`, `coordinator`, `listener`, `event_admin`). The portal enforces permissions at the API, WebSocket, and media-server layers.
 
+- **API-First Design** — every coordination feature in Voxbento is exposed via the official **voxbento.com** REST and WebSocket APIs, enabling deep integration with third-party event platforms.
+
 ## How Audio Gets from Interpreter to Listener
 
 The pipeline that carries interpretation audio never touches the Python server. Here is the high-level path:

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -7,8 +7,8 @@ const config: Config = {
   tagline: 'Real-Time Browser Interpretation Platform',
   favicon: 'img/favicon.ico',
 
-  url: 'https://voxbento.com',
-  baseUrl: '/voxbento/',
+  url: 'https://docs.voxbento.com',
+  baseUrl: '/',
 
   organizationName: 'fossasia',
   projectName: 'voxbento',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -37,7 +37,7 @@ const config: Config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: './sidebars.ts',
-          editUrl: 'https://github.com/fossasia/voxbento/tree/main/docs/',
+          editUrl: 'https://github.com/fossasia/voxbento/edit/main/',
         },
         blog: false,
         theme: {


### PR DESCRIPTION
## Description

This PR improves the documentation for Voxbento, focusing on transcription (STT) services and aligning all references with the official `voxbento.com` platform.

### Key Changes:

1.  **Docusaurus Configuration:**
    *   Fixed the 'Edit this page' link by updating `editUrl` to point to the repository root with an `edit` path.
2.  **README Improvements:**
    *   Added a prominent link to [docs.voxbento.com](https://docs.voxbento.com).
    *   Updated the setup section to direct users to the official docs for detailed configuration.
3.  **CONTRIBUTING.md Restructure:**
    *   Added a detailed section on **Transcription and AI Services**, covering the worker architecture (FFmpeg + RTSP), `TranscriptionProvider` implementation, and the aggregator logic.
4.  **Transcription Documentation (Admin & User):**
    *   **ElevenLabs Scribe:** Clarified that Voxbento uses ElevenLabs for **Speech-to-Text (STT)**, not synthesis.
    *   **Pipeline Details:** Added technical depth to the 'How It Works' guide, explaining the out-of-band transcription pipeline.
    *   **Caption Logic:** Documented internal features like sentence splitting, forced finalization (15s/50 words), and silence detection.
5.  **API Alignment:**
    *   Reframed API `overview.mdx` and `authentication.mdx` to be specific to `voxbento.com`, removing generic 'your instance' references.