### PR TITLE
feat: add rename room  and booth language metadata in admin interface

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1534,6 +1534,7 @@ async def admin_edit_room(request: Request, event_id: int, room_id: int):
     import pycountry
 
     form = await request.form()
+    display_name = form.get('display_name', '').strip()
     jitsi_url = form.get('jitsi_url', '').strip()
     relay_booth_id_str = form.get('relay_booth_id', '').strip()
     relay_booth_id = int(relay_booth_id_str) if relay_booth_id_str and relay_booth_id_str.lower() != 'none' else None
@@ -1552,6 +1553,8 @@ async def admin_edit_room(request: Request, event_id: int, room_id: int):
     async with get_session() as session:
         room = await get_room_by_id(session, room_id)
         if room and room.event_id == event_id:
+            if display_name:
+                room.display_name = display_name
             room.jitsi_url = jitsi_url if jitsi_url else None
             room.relay_booth_id = relay_booth_id
             room.floor_transcription_enabled = floor_transcription_enabled
@@ -1982,6 +1985,28 @@ async def admin_booth_translation_settings(
         url=f'/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/',
         status_code=status.HTTP_303_SEE_OTHER,
     )
+
+@app.post('/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/edit', dependencies=[Depends(require_admin)])
+async def admin_edit_booth(request: Request, event_id: int, room_id: int, booth_id: int):
+    from portal.database import get_session, get_booth_by_id
+    form = await request.form()
+    language_name = form.get('language_name', '').strip()
+    language_code = form.get('language_code', '').strip()
+    
+    async with get_session() as session:
+        booth = await get_booth_by_id(session, booth_id)
+        if booth and booth.event_id == event_id and booth.room_id == room_id:
+            if language_name:
+                booth.language_name = language_name
+            if language_code:
+                booth.language_code = language_code
+        await session.commit()
+        
+    return safe_redirect(
+        url=f'/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/',
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
 
 
 @app.post(

--- a/templates/admin/booth_detail.html
+++ b/templates/admin/booth_detail.html
@@ -91,6 +91,26 @@
   </div>
 </div>
 
+<!-- Booth Settings Form -->
+<form method="post" action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/edit" class="token-form">
+  <div class="token-form-card" style="margin-bottom: 2rem;">
+    <h3>Booth Settings</h3>
+    <div class="form-row">
+      <div class="form-group" style="flex: 1;">
+        <label for="language_name">Language Name</label>
+        <input type="text" id="language_name" name="language_name" class="input" value="{{ booth.language_name }}" required>
+      </div>
+      <div class="form-group" style="flex: 1;">
+        <label for="language_code">Language Code</label>
+        <input type="text" id="language_code" name="language_code" class="input" value="{{ booth.language_code }}" required>
+      </div>
+      <div class="form-group form-group-btn" style="flex: 0; align-self: flex-end;">
+        <button type="submit" class="btn btn-primary">Save Settings</button>
+      </div>
+    </div>
+  </div>
+</form>
+
 <!-- Transcription Settings Form -->
 <form method="post" action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/transcription-settings" class="token-form">
   <div class="token-form-card" style="margin-bottom: 2rem;">

--- a/templates/admin/room_detail.html
+++ b/templates/admin/room_detail.html
@@ -26,8 +26,15 @@
     <h3>Room Settings</h3>
     <div class="form-row">
       <div class="form-group" style="flex: 1;">
+        <label for="display_name">Room Name</label>
+        <input type="text" id="display_name" name="display_name" class="input" value="{{ room.display_name }}" required>
+      </div>
+      <div class="form-group" style="flex: 2;">
         <label for="jitsi_url">Jitsi Room URL (Floor Audio Source)</label>
         <input type="url" id="jitsi_url" name="jitsi_url" class="input" value="{{ room.jitsi_url or fallback_jitsi_url }}" placeholder="e.g. https://jitsi.voxbento.com/Room-Event-TrackA">
+      </div>
+      <div class="form-group form-group-btn" style="flex: 0; align-self: flex-end;">
+        <button type="submit" class="btn btn-primary">Save Settings</button>
       </div>
     </div>
     <p class="form-help" style="margin-top: 0.5rem; font-size: 0.85rem; color: #666;">Interpreters in all booths for this room will automatically join this Jitsi URL for floor monitoring.</p>


### PR DESCRIPTION
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/643da027-c566-4488-96da-13b5601ece5c" />
<img width="5088" height="3352" alt="image" src="https://github.com/user-attachments/assets/81c54416-135c-4c99-b2c6-6a8e764ee2fd" />


fixes #168

## Summary by Sourcery

Allow admins to edit room names and booth language metadata from the admin interface.

New Features:
- Support updating a room's display name in the room admin settings.
- Add an admin endpoint and form to edit a booth's language name and language code.

Enhancements:
- Improve room and booth detail pages with dedicated settings sections and save actions for metadata changes.