### PR TITLE
fix(coordinator): prevent 500 by loading event rooms explicitly

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1330,7 +1330,9 @@ async def mission_control_grid(request: Request, event_slug: str, user=Depends(r
             coord_room_ids = {rm.room_id for rm in room_memberships if rm.role == 'room_coordinator'}
             
             if event.id not in event_owner_ids:
-                event_room_ids = {r.id for r in event.rooms}
+                from portal.database import list_rooms_for_event
+                rooms = await list_rooms_for_event(session, event.id)
+                event_room_ids = {r.id for r in rooms}
                 if not coord_room_ids.intersection(event_room_ids):
                     raise HTTPException(status_code=403, detail='Access denied. Event Owner or Room Coordinator required.')
                 allowed_room_ids = coord_room_ids


### PR DESCRIPTION
## Description

Briefly describe the purpose of this PR and the changes made.

## Related Issue

Closes #

## Changes Made

fixed bug related to missions control

## Testing

Describe how you tested these changes.

- [x ] Tested locally
- [ x] Existing tests pass
- [ ] Added/updated tests (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots or recordings here -->

## Checklist

- [x ] My code follows the project's coding standards
- [x ] I have tested my changes
- [x ] I have updated documentation where necessary
- [x ] My changes do not introduce new warnings or errors

## Additional Notes

<!-- Any extra context, concerns, or information -->

## Summary by Sourcery

Bug Fixes:
- Prevent 500 errors in mission control grid by loading event rooms from the database before performing room coordinator access checks.