### PR TITLE
fix(auth): drop all cookies on logout and fix delete_cookie kwargs

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1215,8 +1215,9 @@ async def user_login_submit(request: Request):
 @app.get('/logout')
 async def user_logout(request: Request):
     response = safe_redirect(url='/', status_code=status.HTTP_303_SEE_OTHER)
-    response.delete_cookie('user_token', httponly=True, samesite='lax')
-    response.delete_cookie('session_token', httponly=True, samesite='lax')
+    response.delete_cookie('user_token')
+    response.delete_cookie('session_token')
+    response.delete_cookie('admin_token')
     return response
 
 
@@ -1393,7 +1394,9 @@ async def admin_login_submit(request: Request):
 @app.get('/admin/logout')
 async def admin_logout():
     response = safe_redirect(url='/admin/login', status_code=status.HTTP_303_SEE_OTHER)
-    response.delete_cookie('admin_token', httponly=True, samesite='lax')
+    response.delete_cookie('admin_token')
+    response.delete_cookie('user_token')
+    response.delete_cookie('session_token')
     return response
 
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure user and admin logout endpoints delete all relevant auth cookies, including admin_token, user_token, and session_token, with correct delete_cookie usage.