### PR TITLE
dx: fix js.instructions.md applyTo glob to match static/js/

### DIFF
--- a/.github/instructions/js.instructions.md
+++ b/.github/instructions/js.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: 'JavaScript development standards'
-applyTo: 'app/**/*.{js,ts,vue}'
+applyTo: 'static/**/*.js'
 ---
 
 ## Development Standards

--- a/plans/README.md
+++ b/plans/README.md
@@ -15,7 +15,7 @@ conditions, run every verification command, and update your row when done.
 | [001](001-agents-context-docs.md) | Create the missing `.github/.agents` context and skills directories | P1 | M | — | DONE |
 | [002](002-pagination-list-queries.md) | Add pagination to unbounded list query helpers | P1 | S | — | DONE |
 | [003](003-ruff-linter.md) | Add ruff linter and pre-commit hook | P1 | S | — | DONE |
-| [004](004-js-instructions-applyto.md) | Fix `js.instructions.md` applyTo glob | P1 | S | — | TODO |
+| [004](004-js-instructions-applyto.md) | Fix `js.instructions.md` applyTo glob | P1 | S | — | DONE |
 | [005](005-secret-key-startup-guard.md) | Add startup guard for weak default `secret_key` | P1 | S | — | TODO |
 | [006](006-env-example-drift.md) | Fix `.env.example` drift (dead var, missing vars, latent AttributeError) | P1 | S | — | TODO |
 | [007](007-transcription-characterization-tests.md) | Add characterization tests for transcription providers and caption aggregator | P1 | M | — | TODO |


### PR DESCRIPTION
## Summary by Sourcery

Update JavaScript development standards scope and mark corresponding planning item as completed.

Documentation:
- Restrict `js.instructions.md` application scope to JavaScript files under `static/`.

Chores:
- Mark planning item 004 for fixing the JS instructions applyTo glob as DONE in the plans tracker.