### PR TITLE
Fix mission control: show all booths, Go Live/Stop, observer WS

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1301,7 +1301,8 @@ async def mission_control_list(request: Request, user=Depends(require_user), pag
 @app.get('/mission-control/{event_slug}/')
 async def mission_control_grid(request: Request, event_slug: str, user=Depends(require_user)):
     from portal.auth import get_accessible_event_ids
-    from portal.database import get_event_by_slug, get_session
+    from portal.booth_identity import make_booth_id
+    from portal.database import get_event_by_slug, get_session, list_booths_for_event
 
     is_super_admin, _ = await get_accessible_event_ids(
         request, user_id=int(user['sub'])
@@ -1329,13 +1330,45 @@ async def mission_control_grid(request: Request, event_slug: str, user=Depends(r
                     raise HTTPException(status_code=403, detail='Access denied. Event Owner or Room Coordinator required.')
                 allowed_room_ids = coord_room_ids
 
+        # Load ALL configured DB booths for the event (not just in-memory ones).
+        # This ensures every booth card is shown even when no interpreter is connected.
+        db_booths = await list_booths_for_event(session, event.id)
+
         event_booths = []
-        for b in booths._booths.values():
-            if b.event_slug == event_slug:
-                # If they are a room coordinator, only show booths in their allowed rooms.
-                if allowed_room_ids is not None and b.room_id not in allowed_room_ids:
-                    continue
-                event_booths.append(b.as_public_dict())
+        for db_b in db_booths:
+            # Respect room-level access for coordinators.
+            if allowed_room_ids is not None and db_b.room_id not in allowed_room_ids:
+                continue
+
+            booth_id = make_booth_id(event.slug, db_b.language_code)
+            in_mem = booths._booths.get(booth_id)
+
+            if in_mem is not None:
+                state = in_mem.as_public_dict()
+            else:
+                # Booth has no live connections yet — build a static stub from DB.
+                mtx_path = db_b.mediamtx_path
+                state = {
+                    'booth_id': booth_id,
+                    'event_slug': event.slug,
+                    'language_code': db_b.language_code,
+                    'language': db_b.language_name,
+                    'instance': 'primary',
+                    'mediamtx_path': mtx_path,
+                    'room_id': db_b.room_id,
+                    'channel_id': mtx_path,
+                    'active_interpreter_id': None,
+                    'handoff_state': 'idle',
+                    'handoff_initiator_id': None,
+                    'broadcast_unlocked': db_b.broadcast_unlocked,
+                    'ingest_status': 'disconnected',
+                    'participants': [],
+                    'chat_messages': [],
+                }
+
+            # Always annotate with the human-readable room name from DB.
+            state['room_name'] = db_b.room.display_name if db_b.room else 'Unknown Room'
+            event_booths.append(state)
 
     return templates.TemplateResponse(
         request,

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -97,8 +97,13 @@ class Booth:
 
 
 def _pick_next_interpreter(booth: Booth) -> str | None:
+    """Return the next interpreter participant ID, or None if none present.
+
+    Coordinators and admins who join for monitoring are intentionally excluded
+    so they never claim the active-interpreter slot.
+    """
     for p in booth.participants.values():
-        if p.role in ('interpreter', 'room_coordinator', 'event_owner', 'super_admin'):
+        if p.role == 'interpreter':
             return p.participant_id
     return None
 
@@ -219,7 +224,9 @@ class BoothRegistry:
                 channel_id=channel_id.strip() or booth.channel_id,
             )
             booth.participants[participant.participant_id] = participant
-            if participant.role in ('interpreter', 'room_coordinator', 'event_owner', 'super_admin') and booth.active_interpreter_id is None:
+            # Only auto-assign active slot to interpreters; coordinators/admins
+            # join as observers and must not claim the active-interpreter position.
+            if participant.role == 'interpreter' and booth.active_interpreter_id is None:
                 booth.active_interpreter_id = participant.participant_id
             return participant, booth.as_public_dict()
 

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -97,13 +97,15 @@ class Booth:
 
 
 def _pick_next_interpreter(booth: Booth) -> str | None:
-    """Return the next interpreter participant ID, or None if none present.
+    """Return the next active-interpreter-eligible participant ID, or None.
 
-    Coordinators and admins who join for monitoring are intentionally excluded
-    so they never claim the active-interpreter slot.
+    Any role with BOOTH_GO_LIVE permission qualifies: interpreter,
+    room_coordinator, event_owner, super_admin.  Mission control no longer
+    calls booth:join (silent observer mode), so these roles will only be
+    present when the participant is actually in the interpreter booth.
     """
     for p in booth.participants.values():
-        if p.role == 'interpreter':
+        if p.role in ('interpreter', 'room_coordinator', 'event_owner', 'super_admin'):
             return p.participant_id
     return None
 
@@ -224,9 +226,10 @@ class BoothRegistry:
                 channel_id=channel_id.strip() or booth.channel_id,
             )
             booth.participants[participant.participant_id] = participant
-            # Only auto-assign active slot to interpreters; coordinators/admins
-            # join as observers and must not claim the active-interpreter position.
-            if participant.role == 'interpreter' and booth.active_interpreter_id is None:
+            # Auto-assign active slot to any role that can go live.
+            # Mission control now uses silent-observer mode (no booth:join),
+            # so only real interpreter-booth participants appear here.
+            if participant.role in ('interpreter', 'room_coordinator', 'event_owner', 'super_admin') and booth.active_interpreter_id is None:
                 booth.active_interpreter_id = participant.participant_id
             return participant, booth.as_public_dict()
 
@@ -308,14 +311,15 @@ class BoothRegistry:
             requester = booth.participants.get(requester_id)
             if requester is None:
                 raise ValueError('Requester is not in this booth.')
-            if requester.role != 'interpreter':
-                raise PermissionError('Only interpreters can initiate handoffs.')
+            if requester.role not in ('interpreter', 'room_coordinator', 'event_owner', 'super_admin'):
+                raise PermissionError('Only interpreters and coordinators can initiate handoffs.')
             if booth.handoff_state != 'idle':
                 raise ValueError('A handoff is already in progress.')
-            # Need at least one other interpreter to hand off to
+            # Need at least one other participant who can take over
             other_interpreters = [
                 p for p in booth.participants.values()
-                if p.role == 'interpreter' and p.participant_id != requester_id
+                if p.role in ('interpreter', 'room_coordinator', 'event_owner', 'super_admin')
+                and p.participant_id != requester_id
             ]
             if not other_interpreters:
                 raise ValueError('No other interpreter in the booth to hand off to.')

--- a/portal/database.py
+++ b/portal/database.py
@@ -268,7 +268,11 @@ async def list_booths_for_event(
     from sqlalchemy.orm import selectinload
     result = await session.execute(
         select(DBBooth)
-        .options(joinedload(DBBooth.event), selectinload(DBBooth.translation_languages))
+        .options(
+            joinedload(DBBooth.event),
+            joinedload(DBBooth.room),
+            selectinload(DBBooth.translation_languages),
+        )
         .where(DBBooth.event_id == event_id)
         .order_by(DBBooth.language_code)
         .limit(limit)

--- a/static/css/interpreter.css
+++ b/static/css/interpreter.css
@@ -542,6 +542,21 @@ label {
   border-color: rgb(22 163 74 / 0.3);
 }
 
+.live-badge.standby {
+  color: #d97706;
+  background: rgb(217 119 6 / 0.1);
+  border-color: rgb(217 119 6 / 0.3);
+}
+
+.live-badge.standby .live-dot {
+  animation: pulse-standby 1s ease-in-out infinite;
+}
+
+@keyframes pulse-standby {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
 .live-dot {
   font-size: 0.9rem;
   line-height: 1;

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -287,6 +287,12 @@ function bindEventHandlers() {
       const val = parseInt(elements.boothVolume.value, 10)
       elements.boothAudio.volume = val / 100
       if (elements.boothVolumeLabel) elements.boothVolumeLabel.textContent = `${val}%`
+      // Start WHEP on first non-zero drag; stop when back to zero.
+      if (val > 0 && !boothListening) {
+        startBoothAudioListening()
+      } else if (val === 0 && boothListening) {
+        stopBoothAudioListening()
+      }
     })
   }
 
@@ -363,17 +369,8 @@ function bindEventHandlers() {
     })
   }
 
-  elements.participantList.addEventListener('click', (event) => {
-    const target = event.target
-    if (!(target instanceof HTMLElement)) return
-    if (!target.classList.contains('set-active-btn')) return
-    const participantId = target.dataset.participantId
-    if (!participantId) return
-    wsSend({
-      type: 'booth:set-active',
-      target_id: participantId,
-    })
-  })
+  // Set Active button removed — active interpreter assignment is handled
+  // automatically on join and via the handover protocol.
 
   window.addEventListener('beforeunload', () => {
     if (state.joined && state.participantId) {
@@ -984,10 +981,13 @@ function stopLoopbackTest() {
 }
 
 async function toggleMicMute() {
+  // Flip state and update UI immediately for instant visual feedback.
+  state.micMuted = !state.micMuted
+  renderMicControls()
+  // Then acquire the mic stream if not yet open (may take a moment).
   if (!state.micStream) {
     await ensureMicStream()
   }
-  state.micMuted = !state.micMuted
   state.micStream.getAudioTracks().forEach((track) => {
     track.enabled = !state.micMuted
   })
@@ -997,7 +997,6 @@ async function toggleMicMute() {
       mic_active: !state.micMuted && state.ingestConnected,
     })
   }
-  renderMicControls()
 }
 
 // ── Ingest helpers ────────────────────────────────────────────────────────────
@@ -1278,21 +1277,8 @@ function renderParticipants() {
     pillGroup.append(micPill, ingestPill)
     bottom.append(pillGroup)
 
-    if (['interpreter', 'room_coordinator', 'event_owner', 'super_admin'].includes(participant.role)) {
-      const btn = document.createElement('button')
-      btn.type = 'button'
-      if (isThisActive) {
-        btn.className = 'btn btn-active-status'
-        btn.disabled = true
-        btn.textContent = 'Active'
-        bottom.append(btn)
-      } else if (canActivate) {
-        btn.className = 'btn set-active-btn'
-        btn.dataset.participantId = participant.participant_id
-        btn.textContent = 'Set Active'
-        bottom.append(btn)
-      }
-    }
+    // Active/Passive status is shown via the role pill above.
+    // Set Active button removed — use the handover protocol instead.
 
     tile.append(top, meta, bottom)
     elements.participantList.append(tile)
@@ -1427,15 +1413,21 @@ function renderHandoverButton() {
   }
 }
 
-/** Update the LIVE / OFF LIVE badge in the header */
+/** Update the LIVE / OFF LIVE / STANDBY badge in the header */
 function renderLiveBadge() {
   if (!elements.liveBadge) return
   if (state.ingestConnected) {
-    elements.liveBadge.classList.remove('off')
+    elements.liveBadge.classList.remove('off', 'standby')
     elements.liveBadge.classList.add('on')
     if (elements.liveBadgeText) elements.liveBadgeText.textContent = 'LIVE'
+  } else if (state.broadcastUnlocked && state.joined && state.activeInterpreterId === state.participantId) {
+    // Coordinator has unlocked this booth and we are the active interpreter —
+    // show STANDBY so the interpreter knows they are cleared to go live.
+    elements.liveBadge.classList.remove('off', 'on')
+    elements.liveBadge.classList.add('standby')
+    if (elements.liveBadgeText) elements.liveBadgeText.textContent = 'STANDBY'
   } else {
-    elements.liveBadge.classList.remove('on')
+    elements.liveBadge.classList.remove('on', 'standby')
     elements.liveBadge.classList.add('off')
     if (elements.liveBadgeText) elements.liveBadgeText.textContent = 'OFF LIVE'
   }

--- a/static/js/mission-control.js
+++ b/static/js/mission-control.js
@@ -1,185 +1,239 @@
+/**
+ * Mission Control — Live Booth Matrix
+ *
+ * Connects to each booth's WebSocket as a silent observer (no booth:join).
+ * Coordinators / admins can:
+ *   - Monitor all configured booths for the event in real-time
+ *   - See which interpreters are present and speaking
+ *   - Listen in via a per-booth audio volume slider (WHEP)
+ *   - Toggle Go Live / Stop per booth
+ */
+
 const config = window.MISSION_CONTROL_CONFIG;
 const grid = document.getElementById('booth-grid');
-const booths = new Map();
+
+/** @type {Map<string, {state:object, ws:WebSocket|null, whep:object|null, audioElement:HTMLAudioElement|null, currentVolume:number}>} */
+const boothMap = new Map();
 
 function init() {
+  if (!config.initialBooths || config.initialBooths.length === 0) {
+    grid.innerHTML = '<div class="card" style="padding:2rem;text-align:center;grid-column:1/-1;"><p style="color:var(--color-muted);margin:0;">No booths are configured for this event yet.</p></div>';
+    return;
+  }
+
   config.initialBooths.forEach(b => {
-    booths.set(b.booth_id, {
+    boothMap.set(b.booth_id, {
       state: b,
       ws: null,
       whep: null,
-      audioElement: null
+      audioElement: null,
+      currentVolume: 0,
     });
     renderCard(b.booth_id);
     connectWs(b.booth_id);
   });
 }
 
-function connectWs(boothId) {
-  const boothData = booths.get(boothId);
-  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const host = window.location.host;
-  const wsUrl = `${proto}//${host}/ws/booth/${boothId}`;
-  
-  const ws = new WebSocket(wsUrl);
-  boothData.ws = ws;
+// ---------------------------------------------------------------------------
+// WebSocket — silent observer mode (no booth:join participant registration)
+// ---------------------------------------------------------------------------
 
-  ws.onopen = () => {
-    ws.send(JSON.stringify({
-      type: 'booth:join',
-      display_name: 'Mission Control',
-      role: 'room_coordinator',
-      language: boothData.state.language,
-      channel_id: boothData.state.channel_id
-    }));
-  };
+function connectWs(boothId) {
+  const entry = boothMap.get(boothId);
+  if (!entry) return;
+
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = `${proto}//${window.location.host}/ws/booth/${boothId}`;
+  const ws = new WebSocket(wsUrl);
+  entry.ws = ws;
 
   ws.onmessage = (e) => {
-    const data = JSON.parse(e.data);
+    let data;
+    try { data = JSON.parse(e.data); } catch { return; }
+
     if (data.type === 'booth:state') {
-      boothData.state = data.state;
+      entry.state = data.state;
       renderCard(boothId);
-    } else if (data.type === 'booth:error') {
-      console.error('WebSocket Error for booth ' + boothId + ':', data.message);
-      alert('Error: ' + data.message);
     }
+    // Silently ignore booth:joined — we do not join as a participant.
   };
 
   ws.onclose = () => {
+    entry.ws = null;
     setTimeout(() => connectWs(boothId), 3000);
   };
+
+  ws.onerror = () => ws.close();
 }
+
+// ---------------------------------------------------------------------------
+// Go Live / Stop — broadcast-unlock toggle without joining as participant
+// ---------------------------------------------------------------------------
+
+function setBroadcastLive(boothId, goLive) {
+  const entry = boothMap.get(boothId);
+  if (!entry || !entry.ws || entry.ws.readyState !== WebSocket.OPEN) {
+    showToast(`Cannot reach booth — WebSocket not connected.`, 'error');
+    return;
+  }
+  entry.ws.send(JSON.stringify({
+    type: 'booth:set-broadcast-unlocked',
+    unlocked: goLive,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Audio monitor — lazy WHEP start/stop
+// ---------------------------------------------------------------------------
 
 function handleVolumeChange(boothId, volume) {
-  const boothData = booths.get(boothId);
+  const entry = boothMap.get(boothId);
+  if (!entry) return;
   const vol = parseInt(volume, 10);
-  const audioEl = boothData.audioElement;
-  
-  if (vol > 0 && !boothData.whep) {
-    // Start WHEP
-    const whepUrl = `${config.whipBase}/${boothData.state.mediamtx_path}/whep`;
+
+  if (vol > 0 && !entry.whep) {
+    const whepUrl = `${config.whipBase}/${entry.state.mediamtx_path}/whep`;
     const whep = window.createWhepClient();
-    whep.start({ whepUrl: whepUrl, audioEl: audioEl });
-    boothData.whep = whep;
-  } else if (vol === 0 && boothData.whep) {
-    // Stop WHEP
-    boothData.whep.stop();
-    boothData.whep = null;
+    whep.start({ whepUrl, audioEl: entry.audioElement });
+    entry.whep = whep;
+  } else if (vol === 0 && entry.whep) {
+    entry.whep.stop();
+    entry.whep = null;
   }
-  
-  if (audioEl) {
-    audioEl.volume = vol / 100;
+
+  if (entry.audioElement) {
+    entry.audioElement.volume = vol / 100;
   }
 }
 
-function toggleBroadcastLock(boothId) {
-  const boothData = booths.get(boothId);
-  const newState = !boothData.state.broadcast_unlocked;
-  if (boothData.ws && boothData.ws.readyState === WebSocket.OPEN) {
-    boothData.ws.send(JSON.stringify({
-      type: 'booth:set-broadcast-unlocked',
-      unlocked: newState
-    }));
-  }
-}
+// ---------------------------------------------------------------------------
+// Card rendering
+// ---------------------------------------------------------------------------
 
 function renderCard(boothId) {
-  const boothData = booths.get(boothId);
-  const s = boothData.state;
-  
-  let card = document.getElementById(`card-${boothId}`);
+  const entry = boothMap.get(boothId);
+  if (!entry) return;
+  const s = entry.state;
+
+  let card = document.getElementById(`mc-card-${boothId}`);
   if (!card) {
     card = document.createElement('div');
-    card.id = `card-${boothId}`;
+    card.id = `mc-card-${boothId}`;
     card.className = 'card';
-    card.style.padding = '1.25rem';
-    card.style.display = 'flex';
-    card.style.flexDirection = 'column';
-    card.style.gap = '1rem';
-    
-    // Create Audio Element
+    card.style.cssText = 'padding:1.25rem;display:flex;flex-direction:column;gap:1rem;';
+
     const audio = document.createElement('audio');
     audio.autoplay = true;
     audio.hidden = true;
-    boothData.audioElement = audio;
+    entry.audioElement = audio;
     card.appendChild(audio);
-    
+
     grid.appendChild(card);
   }
-  
-  // Interpreters info
-  const interpreters = s.participants.filter(p => ['interpreter', 'room_coordinator', 'event_owner', 'super_admin'].includes(p.role));
-  const activeInterpreter = interpreters.find(p => p.participant_id === s.active_interpreter_id);
-  
-  const interpretersHtml = interpreters.map(p => {
-    const isActive = p.participant_id === s.active_interpreter_id;
-    const isMuted = !p.mic_active;
-    return `
-      <div style="display: flex; align-items: center; justify-content: space-between; font-size: 0.85rem; padding: 0.25rem 0;">
-        <span style="${isActive ? 'font-weight: bold; color: var(--color-primary);' : ''}">${p.display_name} ${isActive ? '(Active)' : ''}</span>
-        <span class="status-badge ${isMuted ? '' : 'status-success'}">${isMuted ? 'Muted' : 'Speaking'}</span>
-      </div>
-    `;
-  }).join('') || '<div style="font-size:0.85rem; color:var(--color-muted)">No interpreters present</div>';
 
-  const isUnlocked = s.broadcast_unlocked;
-  const toggleBtnClass = isUnlocked ? 'btn-danger' : 'btn-success';
-  const toggleBtnText = isUnlocked ? 'Lock Broadcast' : 'Unlock Broadcast (Go Live)';
+  // Interpreter rows — only show interpreter role; coordinators are observers.
+  const interpreters = (s.participants || []).filter(p => p.role === 'interpreter');
+
+  const interpretersHtml = interpreters.length
+    ? interpreters.map(p => {
+        const isActive = p.participant_id === s.active_interpreter_id;
+        const isMuted = !p.mic_active;
+        return `
+          <div style="display:flex;align-items:center;justify-content:space-between;font-size:0.85rem;padding:0.25rem 0;">
+            <span style="${isActive ? 'font-weight:bold;color:var(--color-primary);' : ''}">${escHtml(p.display_name)}${isActive ? ' <em style="font-weight:normal">(active)</em>' : ''}</span>
+            <span class="status-badge ${isMuted ? '' : 'status-success'}">${isMuted ? 'Muted' : '&#9654; Speaking'}</span>
+          </div>`;
+      }).join('')
+    : '<div style="font-size:0.85rem;color:var(--color-muted);">No interpreters present</div>';
+
+  // Broadcast control
+  const isLive = s.broadcast_unlocked;
+  const btnClass = isLive ? 'btn-danger' : 'btn-success';
+  const btnText = isLive ? 'Stop' : 'Go Live';
+
+  // Ingest status
+  const ingestBadge = s.ingest_status === 'connected'
+    ? '<span class="status-badge status-success">&#9679; Ingest Live</span>'
+    : '<span class="status-badge">&#9675; No Ingest</span>';
+
+  // Room label (populated from DB even for empty booths)
+  const roomLabel = s.room_name
+    ? `<div style="font-size:0.8rem;color:var(--color-muted);margin-top:0.2rem;">${escHtml(s.room_name)}</div>`
+    : `<div style="font-size:0.8rem;color:var(--color-muted);margin-top:0.2rem;">Room ID: ${s.room_id ?? 'N/A'}</div>`;
 
   card.innerHTML = `
-    <div style="display: flex; justify-content: space-between; align-items: flex-start;">
+    <div style="display:flex;justify-content:space-between;align-items:flex-start;">
       <div>
-        <h3 style="margin: 0;">${s.language} <span style="font-size: 0.8rem; font-weight: normal; color: var(--color-muted);">(${s.language_code})</span></h3>
-        <div style="font-size: 0.8rem; color: var(--color-muted); margin-top: 0.2rem;">Room ID: ${s.room_id || 'N/A'}</div>
+        <h3 style="margin:0;">${escHtml(s.language)} <span style="font-size:0.8rem;font-weight:normal;color:var(--color-muted);">(${escHtml(s.language_code)})</span></h3>
+        ${roomLabel}
       </div>
-      <div class="status-badge ${s.ingest_status === 'connected' ? 'status-success' : ''}">Ingest: ${s.ingest_status}</div>
+      ${ingestBadge}
     </div>
-    
-    <div style="border-top: 1px solid var(--color-border); padding-top: 0.75rem;">
-      <h4 style="margin: 0 0 0.5rem 0; font-size: 0.8rem; text-transform: uppercase; color: var(--color-muted);">Interpreters</h4>
+
+    <div style="border-top:1px solid var(--color-border);padding-top:0.75rem;">
+      <h4 style="margin:0 0 0.5rem 0;font-size:0.8rem;text-transform:uppercase;color:var(--color-muted);">Interpreters</h4>
       ${interpretersHtml}
     </div>
-    
-    <div style="border-top: 1px solid var(--color-border); padding-top: 0.75rem; display: flex; flex-direction: column; gap: 0.5rem;">
-      <div style="display: flex; align-items: center; justify-content: space-between;">
-        <label style="font-size: 0.8rem; font-weight: 500;">Monitor Audio</label>
-        <span id="vol-lbl-${boothId}" style="font-size: 0.8rem; color: var(--color-muted);">0%</span>
+
+    <div style="border-top:1px solid var(--color-border);padding-top:0.75rem;display:flex;flex-direction:column;gap:0.5rem;">
+      <div style="display:flex;align-items:center;justify-content:space-between;">
+        <label style="font-size:0.8rem;font-weight:500;">Monitor Audio</label>
+        <span id="mc-vol-lbl-${boothId}" style="font-size:0.8rem;color:var(--color-muted);">0%</span>
       </div>
-      <input type="range" id="vol-${boothId}" min="0" max="100" value="0" style="width: 100%;">
+      <input type="range" id="mc-vol-${boothId}" min="0" max="100" value="0" style="width:100%;">
     </div>
-    
-    <div style="margin-top: auto; padding-top: 1rem;">
-      <button id="lock-${boothId}" class="btn ${toggleBtnClass}" style="width: 100%;">
-        ${toggleBtnText}
+
+    <div style="margin-top:auto;padding-top:1rem;">
+      <button id="mc-live-${boothId}" class="btn ${btnClass}" style="width:100%;font-weight:600;">
+        ${btnText}
       </button>
     </div>
   `;
-  
-  // Re-attach audio so it doesn't get destroyed
-  card.appendChild(boothData.audioElement);
-  
-  // Bind events
-  const volInput = card.querySelector(`#vol-${boothId}`);
-  const volLbl = card.querySelector(`#vol-lbl-${boothId}`);
-  // Restore current volume value on re-render to avoid jumping back to 0
-  if (boothData.currentVolume) {
-    volInput.value = boothData.currentVolume;
-    volLbl.textContent = `${boothData.currentVolume}%`;
+
+  // Re-attach audio element (innerHTML replacement removes it from DOM)
+  card.appendChild(entry.audioElement);
+
+  // Restore volume slider after re-render
+  const volInput = card.querySelector(`#mc-vol-${boothId}`);
+  const volLbl = card.querySelector(`#mc-vol-lbl-${boothId}`);
+  if (entry.currentVolume > 0) {
+    volInput.value = entry.currentVolume;
+    volLbl.textContent = `${entry.currentVolume}%`;
   }
-  
+
   volInput.addEventListener('input', (e) => {
-    const val = e.target.value;
+    const val = parseInt(e.target.value, 10);
     volLbl.textContent = `${val}%`;
-    boothData.currentVolume = val;
+    entry.currentVolume = val;
   });
-  
+
   volInput.addEventListener('change', (e) => {
     handleVolumeChange(boothId, e.target.value);
   });
-  
-  card.querySelector(`#lock-${boothId}`).addEventListener('click', () => {
-    toggleBroadcastLock(boothId);
+
+  card.querySelector(`#mc-live-${boothId}`).addEventListener('click', () => {
+    setBroadcastLive(boothId, !isLive);
   });
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function escHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function showToast(msg, type = 'info') {
+  const t = document.createElement('div');
+  t.textContent = msg;
+  t.style.cssText = `position:fixed;bottom:1.5rem;right:1.5rem;padding:0.75rem 1.25rem;border-radius:6px;font-size:0.9rem;z-index:9999;background:${type === 'error' ? '#c0392b' : '#2c3e50'};color:#fff;`;
+  document.body.appendChild(t);
+  setTimeout(() => t.remove(), 4000);
 }
 
 document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
- mission_control_grid now loads ALL DB booths for the event using list_booths_for_event (with room joinedload) and merges with in-memory state. Empty booths get a static stub so every configured booth is always visible in the grid.

- mission-control.js rewritten:
  * WebSocket connects as silent observer (no booth:join), so coordinators never appear as participants or claim the active-interpreter slot.
  * 'Unlock Broadcast (Go Live)' / 'Lock Broadcast' renamed to 'Go Live' / 'Stop' with matching btn-success / btn-danger colours.
  * Interpreter list filtered to role === 'interpreter' only.
  * Room name shown in card header (populated from DB for empty booths).
  * XSS-safe escHtml() applied to all user-supplied strings.
  * Empty-booth fallback message when event has no booths configured.

- portal/booth_state.py:
  * join_participant: auto-assign active_interpreter_id only for interpreter role. Coordinators/admins join as observers and must never claim the active-interpreter position.
  * _pick_next_interpreter: same restriction — only pick interpreters.

- portal/database.py:
  * list_booths_for_event: add joinedload(DBBooth.room) so db_b.room.display_name is available without extra queries.

