### PR TITLE
refactor: replace hard-coded role checks with permission-based validation for booth participants

### DIFF
--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -445,9 +445,11 @@ class BoothRegistry:
             participant = booth.participants.get(participant_id)
             if participant is None:
                 raise ValueError('Participant does not exist in booth.')
+            from portal.roles import Permission, has_permission
+
             wants_publisher_state = mic_active is True or ingest_connected is True
-            if wants_publisher_state and participant.role != 'interpreter':
-                raise PermissionError('Only interpreter role can publish audio.')
+            if wants_publisher_state and not has_permission(participant.role, Permission.BOOTH_GO_LIVE):
+                raise PermissionError('Your role does not permit publishing audio.')
             if wants_publisher_state and booth.active_interpreter_id != participant_id:
                 raise PermissionError('Only the active interpreter can mark mic or ingest active.')
             if mic_active is not None:
@@ -472,16 +474,18 @@ class BoothRegistry:
         """Raise PermissionError if participant may not publish audio.
 
         Checks two conditions (Layer 1 enforcement):
-        1. Participant must have the ``interpreter`` role.
+        1. Participant's role must carry BOOTH_GO_LIVE permission.
         2. Participant must be the booth's active interpreter.
         """
+        from portal.roles import Permission, has_permission
+
         async with self._lock:
             booth = self._get_or_create_booth(booth_id, language, channel_id)
             participant = booth.participants.get(participant_id)
             if participant is None:
                 raise ValueError('Participant does not exist in booth.')
-            if participant.role != 'interpreter':
-                raise PermissionError('Only interpreter role can publish audio.')
+            if not has_permission(participant.role, Permission.BOOTH_GO_LIVE):
+                raise PermissionError('Your role does not permit publishing audio.')
             if booth.active_interpreter_id != participant_id:
                 raise PermissionError('Only the active interpreter can publish audio.')
 

--- a/tests/test_booth_state.py
+++ b/tests/test_booth_state.py
@@ -354,13 +354,13 @@ async def test_as_public_dict_includes_room_id():
 # ── Layer 1: active-interpreter enforcement tests ─────────────────────────────
 
 @pytest.mark.anyio
-async def test_coordinator_cannot_set_mic_active():
-    """Coordinator role must not be allowed to mark mic or ingest active."""
+async def test_coordinator_cannot_set_mic_active_when_not_active():
+    """A non-active coordinator must not mark mic active (active-interpreter guard)."""
     registry = BoothRegistry()
-    await join(registry, 'Interpreter A')
+    await join(registry, 'Interpreter A')  # becomes active
     coordinator = await join(registry, 'Coordinator', role='room_coordinator')
 
-    with pytest.raises(PermissionError, match='Only interpreter role'):
+    with pytest.raises(PermissionError, match='active interpreter'):
         await registry.update_participant_state(
             'hall-a-fr',
             coordinator.participant_id,
@@ -371,16 +371,16 @@ async def test_coordinator_cannot_set_mic_active():
 
 
 @pytest.mark.anyio
-async def test_room_coordinator_cannot_set_ingest_connected():
-    """Room coordinator role must not be allowed to mark ingest connected."""
+async def test_room_coordinator_cannot_set_ingest_connected_when_not_active():
+    """A non-active coordinator must not mark ingest connected (active-interpreter guard)."""
     registry = BoothRegistry()
-    await join(registry, 'Interpreter A')
-    listener = await join(registry, 'Listener', role='room_coordinator')
+    await join(registry, 'Interpreter A')  # becomes active
+    coordinator = await join(registry, 'Coordinator', role='room_coordinator')
 
-    with pytest.raises(PermissionError, match='Only interpreter role'):
+    with pytest.raises(PermissionError, match='active interpreter'):
         await registry.update_participant_state(
             'hall-a-fr',
-            listener.participant_id,
+            coordinator.participant_id,
             'French',
             'hall-a-fr-audio',
             ingest_connected=True,
@@ -413,12 +413,24 @@ async def test_check_publish_permission_standby_interpreter_rejected():
 
 
 @pytest.mark.anyio
-async def test_check_publish_permission_coordinator_rejected():
-    """Coordinator role fails the publish permission check."""
+async def test_check_publish_permission_active_coordinator_passes():
+    """An active coordinator (BOOTH_GO_LIVE permission) passes the publish check."""
     registry = BoothRegistry()
     coordinator = await join(registry, 'Coordinator', role='room_coordinator')
+    # Coordinator is auto-assigned active on first join
+    await registry.check_publish_permission(
+        'hall-a-fr', coordinator.participant_id, 'French', 'hall-a-fr-audio',
+    )  # must not raise
 
-    with pytest.raises(PermissionError, match='Only interpreter role'):
+
+@pytest.mark.anyio
+async def test_check_publish_permission_standby_coordinator_rejected():
+    """A non-active coordinator fails the publish check (active-interpreter guard)."""
+    registry = BoothRegistry()
+    await join(registry, 'Interpreter A')  # becomes active
+    coordinator = await join(registry, 'Coordinator', role='room_coordinator')
+
+    with pytest.raises(PermissionError, match='active interpreter'):
         await registry.check_publish_permission(
             'hall-a-fr', coordinator.participant_id, 'French', 'hall-a-fr-audio',
         )


### PR DESCRIPTION
refactor: replace hard-coded role checks with permission-based validation for booth participants

## Summary by Sourcery

Replace role-based booth publish checks with permission-based validation and update tests to reflect active-interpreter and permission semantics.

Enhancements:
- Use BOOTH_GO_LIVE permission instead of hard-coded interpreter role checks when allowing participants to publish or activate mic/ingest.
- Refine active-interpreter enforcement by distinguishing active vs standby coordinators in publish and state update flows.

Tests:
- Update booth permission tests to cover coordinators with and without BOOTH_GO_LIVE permission and to assert new permission error messages.