### PR TITLE
chore: Configure bandit to ignore tests directory

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -33,13 +33,12 @@ jobs:
       - name: Bandit Scan
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
         with: # optional argument
-          skips: B101
           # exit with 0, even with results found
           exit_zero: true # optional, default is DEFAULT
           # Github token of the repository (automatically created by Github)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
-          excluded_paths: tests
-          
+          ini_path: pyproject.toml
+
           # File or directory to run bandit on
           # path: # optional, default is .
           # Report only issues of a given severity level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,8 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["F401"]  # allow unused imports in test files (fixtures, re-exports)
 "alembic/*" = ["F401", "E402"]
+
+[tool.bandit]
+exclude_dirs = ["tests", ".venv"]
+skips = ["B101"]
+


### PR DESCRIPTION
Configured bandit via pyproject.toml to correctly ignore the `tests` directory and removed redundant config from github action workflow.