### PR TITLE
Extract shared translation API-key lookup and endpoint map

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -24,7 +24,7 @@ conditions, run every verification command, and update your row when done.
 | [010](010-tts-config-cache.md) | Cache per-room TTS config to stop per-segment DB+decrypt | P2 | M | — | TODO |
 | [011](011-tts-pipeline-cleanup.md) | Stop leaking `_RoomTTSPipeline` consumer tasks | P2 | M | — | TODO |
 | [012](012-demo-generation-race.md) | Serialize demo regen + track background tasks | P3 | S | — | TODO |
-| [013](013-dedupe-translation-key.md) | De-duplicate translation API-key + LLM call helpers | P2 | S | — | TODO |
+| [013](013-dedupe-translation-key.md) | De-duplicate translation API-key + LLM call helpers | P2 | S | — | DONE |
 | [014](014-route-tests.md) | Add route tests for `demo.py` and `listener.py` | P2 | M | 012 | TODO |
 | [015](015-debug-default-false.md) | Default `debug` False; gate SQL echo in prod | P2 | S | 005 | TODO |
 | [016](016-listener-rate-limit.md) | Rate-limit listener join-code validation | P3 | M | — | TODO |

--- a/portal/translations/constants.py
+++ b/portal/translations/constants.py
@@ -27,3 +27,13 @@ TRANSLATION_MODELS: Dict[str, List[str]] = {
         "qwen-2.5-7b-instruct",
     ],  # Placeholder for local models
 }
+
+
+# OpenAI-compatible chat-completions endpoints. These providers share the same
+# request/response shape, so both the translation worker (blocking) and the TTS
+# worker (streaming) select an endpoint from this single map.
+OPENAI_COMPATIBLE_ENDPOINTS: Dict[str, str] = {
+    TranslationProviderEnum.OPENAI.value: "https://api.openai.com/v1/chat/completions",
+    TranslationProviderEnum.OPENROUTER.value: "https://openrouter.ai/api/v1/chat/completions",
+    TranslationProviderEnum.GROQ.value: "https://api.groq.com/openai/v1/chat/completions",
+}

--- a/portal/translations/keys.py
+++ b/portal/translations/keys.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from portal.crypto import decrypt_val
+from portal.models import Event
+from portal.translations.constants import TranslationProviderEnum
+
+
+def get_translation_api_key(event: Event, provider: str) -> str | None:
+    """Return the decrypted translation API key for ``provider`` on ``event``.
+
+    Returns ``None`` when no key is stored for the provider. This is the single
+    source of truth shared by the translation and TTS workers.
+    """
+    key_map = {
+        TranslationProviderEnum.OPENAI.value: event.encrypted_translation_openai_api_key,
+        TranslationProviderEnum.OPENROUTER.value: event.encrypted_openrouter_api_key,
+        TranslationProviderEnum.GEMINI.value: event.encrypted_gemini_api_key,
+        TranslationProviderEnum.ANTHROPIC.value: event.encrypted_anthropic_api_key,
+        TranslationProviderEnum.GROQ.value: event.encrypted_groq_api_key,
+    }
+    encrypted = key_map.get(provider)
+    return decrypt_val(encrypted) if encrypted else None

--- a/portal/translations/worker.py
+++ b/portal/translations/worker.py
@@ -1,10 +1,10 @@
 import asyncio
 import logging
 
-from portal.crypto import decrypt_val
 from portal.database import get_session
 from portal.models import DBBooth, Event, Room, TranscriptTranslation
-from portal.translations.constants import TranslationProviderEnum
+from portal.translations.constants import OPENAI_COMPATIBLE_ENDPOINTS, TranslationProviderEnum
+from portal.translations.keys import get_translation_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -89,15 +89,7 @@ class TranslationWorker:
             await asyncio.gather(*tasks)
 
     def _get_translation_api_key(self, event: Event, provider: str) -> str | None:
-        key_map = {
-            TranslationProviderEnum.OPENAI.value: event.encrypted_translation_openai_api_key,
-            TranslationProviderEnum.OPENROUTER.value: event.encrypted_openrouter_api_key,
-            TranslationProviderEnum.GEMINI.value: event.encrypted_gemini_api_key,
-            TranslationProviderEnum.ANTHROPIC.value: event.encrypted_anthropic_api_key,
-            TranslationProviderEnum.GROQ.value: event.encrypted_groq_api_key,
-        }
-        encrypted = key_map.get(provider)
-        return decrypt_val(encrypted) if encrypted else None
+        return get_translation_api_key(event, provider)
 
     async def _translate_and_broadcast(
         self,
@@ -140,33 +132,9 @@ class TranslationWorker:
 
         timeout = httpx.Timeout(10.0)
         async with httpx.AsyncClient(timeout=timeout) as client:
-            if provider == TranslationProviderEnum.OPENAI.value:
+            if provider in OPENAI_COMPATIBLE_ENDPOINTS:
                 res = await client.post(
-                    "https://api.openai.com/v1/chat/completions",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    json={
-                        "model": model,
-                        "messages": [{"role": "system", "content": system_prompt}, {"role": "user", "content": text}],
-                    },
-                )
-                res.raise_for_status()
-                return res.json()["choices"][0]["message"]["content"].strip()
-
-            elif provider == TranslationProviderEnum.OPENROUTER.value:
-                res = await client.post(
-                    "https://openrouter.ai/api/v1/chat/completions",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    json={
-                        "model": model,
-                        "messages": [{"role": "system", "content": system_prompt}, {"role": "user", "content": text}],
-                    },
-                )
-                res.raise_for_status()
-                return res.json()["choices"][0]["message"]["content"].strip()
-
-            elif provider == TranslationProviderEnum.GROQ.value:
-                res = await client.post(
-                    "https://api.groq.com/openai/v1/chat/completions",
+                    OPENAI_COMPATIBLE_ENDPOINTS[provider],
                     headers={"Authorization": f"Bearer {api_key}"},
                     json={
                         "model": model,

--- a/portal/tts/worker.py
+++ b/portal/tts/worker.py
@@ -9,7 +9,8 @@ import httpx
 from portal.crypto import decrypt_val
 from portal.database import get_session
 from portal.models import Event, Room
-from portal.translations.constants import TranslationProviderEnum
+from portal.translations.constants import OPENAI_COMPATIBLE_ENDPOINTS, TranslationProviderEnum
+from portal.translations.keys import get_translation_api_key
 from portal.tts.providers.base import TTSProviderEnum, get_tts_provider
 
 logger = logging.getLogger(__name__)
@@ -255,15 +256,7 @@ class TTSWorker:
         await asyncio.gather(*[_one(code, translated) for code, translated in items])
 
     def _get_translation_api_key(self, event: Event, provider: str) -> str | None:
-        key_map = {
-            TranslationProviderEnum.OPENAI.value: event.encrypted_translation_openai_api_key,
-            TranslationProviderEnum.OPENROUTER.value: event.encrypted_openrouter_api_key,
-            TranslationProviderEnum.GEMINI.value: event.encrypted_gemini_api_key,
-            TranslationProviderEnum.ANTHROPIC.value: event.encrypted_anthropic_api_key,
-            TranslationProviderEnum.GROQ.value: event.encrypted_groq_api_key,
-        }
-        encrypted = key_map.get(provider)
-        return decrypt_val(encrypted) if encrypted else None
+        return get_translation_api_key(event, provider)
 
     async def _translate_full(
         self, provider: str, model: str, api_key: str, text: str, lang_name: str
@@ -298,11 +291,7 @@ class TTSWorker:
                 yield full_text
             return
 
-        endpoint = "https://api.openai.com/v1/chat/completions"
-        if provider == TranslationProviderEnum.OPENROUTER.value:
-            endpoint = "https://openrouter.ai/api/v1/chat/completions"
-        elif provider == TranslationProviderEnum.GROQ.value:
-            endpoint = "https://api.groq.com/openai/v1/chat/completions"
+        endpoint = OPENAI_COMPATIBLE_ENDPOINTS[provider]
 
         async with httpx.AsyncClient(timeout=10.0) as client:
             async with client.stream(

--- a/tests/test_translation_keys.py
+++ b/tests/test_translation_keys.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import portal.crypto
+from portal.crypto import encrypt_val
+from portal.models import Event
+from portal.translations.constants import TranslationProviderEnum
+from portal.translations.keys import get_translation_api_key
+
+_TEST_KEY = "unit-test-encryption-key-at-least-32-chars"
+
+# provider value -> Event encrypted attribute name
+_PROVIDER_FIELDS = {
+    TranslationProviderEnum.OPENAI.value: "encrypted_translation_openai_api_key",
+    TranslationProviderEnum.OPENROUTER.value: "encrypted_openrouter_api_key",
+    TranslationProviderEnum.GEMINI.value: "encrypted_gemini_api_key",
+    TranslationProviderEnum.ANTHROPIC.value: "encrypted_anthropic_api_key",
+    TranslationProviderEnum.GROQ.value: "encrypted_groq_api_key",
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_fernet():
+    portal.crypto._fernet = None
+    yield
+    portal.crypto._fernet = None
+
+
+@pytest.mark.parametrize("provider,field", list(_PROVIDER_FIELDS.items()))
+def test_returns_decrypted_key_for_each_provider(provider, field):
+    with patch("portal.config.settings.api_key_encryption_key", _TEST_KEY):
+        plaintext = f"sk-{provider}-secret"
+        event = Event(**{field: encrypt_val(plaintext)})
+        assert get_translation_api_key(event, provider) == plaintext
+
+
+@pytest.mark.parametrize("provider", list(_PROVIDER_FIELDS))
+def test_returns_none_when_key_unset(provider):
+    with patch("portal.config.settings.api_key_encryption_key", _TEST_KEY):
+        event = Event()
+        assert get_translation_api_key(event, provider) is None
+
+
+def test_returns_none_for_provider_without_key_field():
+    with patch("portal.config.settings.api_key_encryption_key", _TEST_KEY):
+        event = Event(encrypted_groq_api_key=encrypt_val("sk-groq-secret"))
+        # LOCAL has no key field; an unmapped provider yields None.
+        assert get_translation_api_key(event, TranslationProviderEnum.LOCAL.value) is None
+        assert get_translation_api_key(event, "nonexistent-provider") is None
+
+
+def test_only_requested_provider_key_is_returned():
+    with patch("portal.config.settings.api_key_encryption_key", _TEST_KEY):
+        event = Event(encrypted_groq_api_key=encrypt_val("groq-key"))
+        assert get_translation_api_key(event, TranslationProviderEnum.GROQ.value) == "groq-key"
+        assert get_translation_api_key(event, TranslationProviderEnum.OPENAI.value) is None


### PR DESCRIPTION
Extract shared translation API-key lookup and endpoint map
Fixes #215 

## Summary by Sourcery

Centralize translation API key lookup and OpenAI-compatible endpoint selection shared between translation and TTS workers.

Enhancements:
- Introduce a shared get_translation_api_key helper for decrypting provider-specific API keys from Event.
- Add a shared OPENAI_COMPATIBLE_ENDPOINTS map used by both translation and TTS workers for chat-completions calls.
- Refactor translation and TTS workers to rely on the new shared key helper and endpoint map instead of duplicating logic.

Documentation:
- Mark plan 013 (de-duplicate translation API-key and LLM helpers) as completed in plans README.

Tests:
- Add unit tests for get_translation_api_key covering all providers, unset keys, unmapped providers, and provider-specific key selection.