### PR TITLE
security: fail fast on weak default secret_key in production

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -37,6 +37,8 @@ async def lifespan(app: FastAPI):
     from portal.tts import demo_gen as dg
     from portal.tts.demo_gen import ensure_demo_generated
 
+    settings.validate_production_secrets()
+
     ts.shared_http_client = httpx.AsyncClient(timeout=10.0)
 
     # Generate landing page demo audio in the background on first startup.

--- a/plans/README.md
+++ b/plans/README.md
@@ -16,7 +16,7 @@ conditions, run every verification command, and update your row when done.
 | [002](002-pagination-list-queries.md) | Add pagination to unbounded list query helpers | P1 | S | — | DONE |
 | [003](003-ruff-linter.md) | Add ruff linter and pre-commit hook | P1 | S | — | DONE |
 | [004](004-js-instructions-applyto.md) | Fix `js.instructions.md` applyTo glob | P1 | S | — | DONE |
-| [005](005-secret-key-startup-guard.md) | Add startup guard for weak default `secret_key` | P1 | S | — | TODO |
+| [005](005-secret-key-startup-guard.md) | Add startup guard for weak default `secret_key` | P1 | S | — | DONE |
 | [006](006-env-example-drift.md) | Fix `.env.example` drift (dead var, missing vars, latent AttributeError) | P1 | S | — | TODO |
 | [007](007-transcription-characterization-tests.md) | Add characterization tests for transcription providers and caption aggregator | P1 | M | — | DONE |
 | [008](008-admin-access-control-dedup.md) | Extract duplicated admin access-control logic into a shared helper | P2 | M | 007 | DONE |

--- a/portal/config.py
+++ b/portal/config.py
@@ -68,6 +68,22 @@ class Settings(BaseSettings):
     def effective_jwt_secret(self) -> str:
         return self.jwt_secret or self.secret_key
 
+    def validate_production_secrets(self) -> None:
+        """Refuse to start with a known-weak default secret outside debug mode.
+
+        Called once at application startup. No-op in debug mode so local
+        development works without configuring a SECRET_KEY.
+        """
+        if self.debug:
+            return
+        weak_defaults = {"change-me", "", "secret", "your-secret-key"}
+        if self.effective_jwt_secret in weak_defaults:
+            raise RuntimeError(
+                "SECRET_KEY (or JWT_SECRET) is set to a known-weak default value. "
+                "Set a strong random value before running in production. "
+                "Generate one with: openssl rand -hex 32"
+            )
+
     # Transcription Settings
     nvidia_function_id: str = ""
 

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -1179,3 +1179,28 @@ def test_full_isolation_flow():
         # fest2 listing must not show fest1 booths
         listing2 = client.get("/api/events/fest2/booths").json()
         assert all(b["event_slug"] == "fest2" for b in listing2["booths"])
+
+
+# --- Secret guard tests ---
+
+
+def test_weak_secret_raises_in_production():
+    from portal.config import Settings
+
+    s = Settings(debug=False, secret_key="change-me", jwt_secret="")
+    with pytest.raises(RuntimeError, match="SECRET_KEY"):
+        s.validate_production_secrets()
+
+
+def test_weak_secret_allowed_in_debug_mode():
+    from portal.config import Settings
+
+    s = Settings(debug=True, secret_key="change-me", jwt_secret="")
+    s.validate_production_secrets()  # must not raise
+
+
+def test_strong_secret_passes_production():
+    from portal.config import Settings
+
+    s = Settings(debug=False, secret_key="a-strong-random-secret-0123456789abcdef", jwt_secret="")
+    s.validate_production_secrets()  # must not raise


### PR DESCRIPTION
## Summary by Sourcery

Add a startup safeguard that prevents running in production with a known-weak default secret key or JWT secret.

New Features:
- Introduce a Settings.validate_production_secrets helper to enforce strong secrets outside debug mode.

Enhancements:
- Invoke production secret validation during FastAPI app startup to fail fast on insecure configuration.

Documentation:
- Update the plans tracker to mark the secret key startup guard task as completed.

Tests:
- Add tests covering weak secrets in production, allowed weak secrets in debug mode, and strong secrets in production.