### PR TITLE
docs: fix .env.example drift and add missing mediamtx_internal_base field

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 HOST=127.0.0.1
 PORT=8000
 SECRET_KEY=change-me
+# Set to false in production. Default is true (enables debug error pages).
+DEBUG=false
 # [CRITICAL] 32-character minimum string for encrypting API keys at rest.
 # To rotate keys, provide a comma-separated list. The first key is used for encryption,
 # all keys are used for decryption.
@@ -20,7 +22,6 @@ JWT_EXPIRY_SECONDS=86400
 JITSI_BASE_URL=https://jitsi.voxbento.com
 DEFAULT_JITSI_ROOM=eventyay-stage-room
 JITSI_DOMAIN=localhost:8080
-JITSI_PUBLIC_URL=http://localhost:8080
 
 # Jitsi internal auth (change in production — use long random passwords)
 JVB_AUTH_PASSWORD=changeme
@@ -71,3 +72,7 @@ DATABASE_URL=sqlite+aiosqlite:///./interpretation.db
 # Supertonic TTS (self-hosted, in-process ONNX) — optional sidecar URL for the
 # Voice Builder import API. Leave empty to use the in-process engine (no sidecar).
 # SUPERTONIC_BASE_URL=
+
+# ── NVIDIA Riva (optional transcription provider) ────────────────────────────
+# Required only when using the 'nvidia' transcription provider.
+# NVIDIA_FUNCTION_ID=<your-nvidia-cloud-function-id>

--- a/plans/README.md
+++ b/plans/README.md
@@ -17,7 +17,7 @@ conditions, run every verification command, and update your row when done.
 | [003](003-ruff-linter.md) | Add ruff linter and pre-commit hook | P1 | S | — | DONE |
 | [004](004-js-instructions-applyto.md) | Fix `js.instructions.md` applyTo glob | P1 | S | — | DONE |
 | [005](005-secret-key-startup-guard.md) | Add startup guard for weak default `secret_key` | P1 | S | — | DONE |
-| [006](006-env-example-drift.md) | Fix `.env.example` drift (dead var, missing vars, latent AttributeError) | P1 | S | — | TODO |
+| [006](006-env-example-drift.md) | Fix `.env.example` drift (dead var, missing vars, latent AttributeError) | P1 | S | — | DONE |
 | [007](007-transcription-characterization-tests.md) | Add characterization tests for transcription providers and caption aggregator | P1 | M | — | DONE |
 | [008](008-admin-access-control-dedup.md) | Extract duplicated admin access-control logic into a shared helper | P2 | M | 007 | DONE |
 | [009](009-n1-booth-queries.md) | Fix N+1 queries in admin and home page route handlers | P2 | M | 007 | DONE |

--- a/portal/config.py
+++ b/portal/config.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     # paths with alwaysAvailable so WHEP readers survive publisher handoffs.
     mediamtx_api_base: str = "http://localhost:9997"
     mediamtx_rtsp_base: str = "rtsp://mediamtx:8554"
+    # Optional internal MediaMTX base URL. When empty, falls back to
+    # mediamtx_api_base. docker-compose sets this to http://mediamtx:8888.
+    mediamtx_internal_base: str = ""
     floor_bot_base: str = "http://floor-bot:8080"
 
     @property

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,15 @@
+"""Unit tests for portal.config.Settings derived properties."""
+
+from __future__ import annotations
+
+from portal.config import Settings
+
+
+def test_effective_mediamtx_internal_base_fallback():
+    s = Settings(mediamtx_internal_base="", mediamtx_api_base="http://localhost:9997")
+    assert s.effective_mediamtx_internal_base == "http://localhost:9997"
+
+
+def test_effective_mediamtx_internal_base_override():
+    s = Settings(mediamtx_internal_base="http://mediamtx:8888")
+    assert s.effective_mediamtx_internal_base == "http://mediamtx:8888"


### PR DESCRIPTION
## Summary by Sourcery

Align configuration and documentation with .env.example by introducing a configurable internal MediaMTX base URL and validating its effective value.

New Features:
- Add mediamtx_internal_base configuration option for an internal MediaMTX base URL with fallback to mediamtx_api_base.

Documentation:
- Mark plan 006 for fixing `.env.example` drift as completed in the plans README.

Tests:
- Add unit tests for Settings.effective_mediamtx_internal_base to cover default fallback and explicit override behavior.