### PR TITLE
fix: Fixed a self-review finding: the lifespan startup change had moved

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -43,7 +43,8 @@ async def lifespan(app: FastAPI):
 
     # Generate landing page demo audio in the background on first startup.
     # Uses local Supertonic — no external API key needed.
-    dg._generating = True
+    async with dg._generation_lock:
+        dg._generating = True
 
     async def _gen():
         try:
@@ -52,7 +53,7 @@ async def lifespan(app: FastAPI):
             dg._generating = False
 
     import asyncio
-    asyncio.create_task(_gen())
+    dg.track_task(asyncio.create_task(_gen()))
 
     yield
     if ts.shared_http_client:

--- a/plans/README.md
+++ b/plans/README.md
@@ -23,7 +23,7 @@ conditions, run every verification command, and update your row when done.
 | [009](009-n1-booth-queries.md) | Fix N+1 queries in admin and home page route handlers | P2 | M | 007 | DONE |
 | [010](010-tts-config-cache.md) | Cache per-room TTS config to stop per-segment DB+decrypt | P2 | M | — | DONE |
 | [011](011-tts-pipeline-cleanup.md) | Stop leaking `_RoomTTSPipeline` consumer tasks | P2 | M | — | DONE |
-| [012](012-demo-generation-race.md) | Serialize demo regen + track background tasks | P3 | S | — | TODO |
+| [012](012-demo-generation-race.md) | Serialize demo regen + track background tasks | P3 | S | — | DONE |
 | [013](013-dedupe-translation-key.md) | De-duplicate translation API-key + LLM call helpers | P2 | S | — | DONE |
 | [014](014-route-tests.md) | Add route tests for `demo.py` and `listener.py` | P2 | M | 012 | TODO |
 | [015](015-debug-default-false.md) | Default `debug` False; gate SQL echo in prod | P2 | S | 005 | DONE |

--- a/portal/routers/demo.py
+++ b/portal/routers/demo.py
@@ -17,8 +17,9 @@ async def demo_manifest() -> JSONResponse:
     """Return the pre-baked demo manifest.
 
     ``status`` is ``"ready"`` when audio files exist, ``"generating"`` when the
-    background task is still running, or ``"pending"`` before first generation.
-    The frontend polls until status xis ``"ready"``.
+    background task is still running, ``"failed"`` if the last generation
+    attempt raised, or ``"pending"`` before first generation.
+    The frontend polls until status is ``"ready"``.
     """
     from portal.tts.demo_gen import DEMO_VIDEO_URL, load_manifest
 
@@ -26,12 +27,18 @@ async def demo_manifest() -> JSONResponse:
     if manifest is not None:
         return JSONResponse({**manifest, "status": "ready"})
 
-    # Not generated yet — check if a generation task is running.
+    # Not generated yet — check if a generation task is running or failed.
     from portal.tts import demo_gen as dg
 
-    generating = getattr(dg, "_generating", False)
+    if getattr(dg, "_generating", False):
+        status = "generating"
+    elif getattr(dg, "_generation_error", None):
+        status = "failed"
+    else:
+        status = "pending"
+
     return JSONResponse({
-        "status": "generating" if generating else "pending",
+        "status": status,
         "video_url": DEMO_VIDEO_URL,
         "languages": [],
     })
@@ -45,17 +52,22 @@ async def regenerate_demo() -> JSONResponse:
     from portal.tts import demo_gen as dg
     from portal.tts.demo_gen import MANIFEST_PATH, generate_demo_assets
 
-    if getattr(dg, "_generating", False):
-        return JSONResponse({"ok": False, "detail": "Already generating"})
+    async with dg._generation_lock:
+        if dg._generating:
+            return JSONResponse({"ok": False, "detail": "Already generating"})
+        dg._generating = True
 
     MANIFEST_PATH.unlink(missing_ok=True)
 
     async def _run() -> None:
-        dg._generating = True
         try:
             await generate_demo_assets()
+            dg._generation_error = None
+        except Exception as exc:
+            logger.exception("[Demo] Regeneration failed")
+            dg._generation_error = str(exc)
         finally:
             dg._generating = False
 
-    asyncio.create_task(_run())
+    dg.track_task(asyncio.create_task(_run()))
     return JSONResponse({"ok": True, "detail": "Generation started"})

--- a/portal/tts/demo_gen.py
+++ b/portal/tts/demo_gen.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import struct
@@ -11,6 +12,25 @@ logger = logging.getLogger(__name__)
 # Where pre-baked demo audio lives. Served by FastAPI StaticFiles.
 DEMO_DIR = Path(__file__).resolve().parent.parent.parent / "static" / "audio" / "demo"
 MANIFEST_PATH = DEMO_DIR / "manifest.json"
+
+# Generation state, shared with portal.routers.demo and fastapi_app's lifespan.
+_generating = False
+_generation_error: str | None = None
+_generation_lock = asyncio.Lock()
+_tasks: set[asyncio.Task] = set()
+
+
+def track_task(task: asyncio.Task) -> None:
+    """Keep a strong reference to a background task so it isn't garbage
+    collected mid-run, and log any exception it raises once it completes."""
+    _tasks.add(task)
+
+    def _on_done(t: asyncio.Task) -> None:
+        _tasks.discard(t)
+        if not t.cancelled() and t.exception() is not None:
+            logger.error("[Demo] Background task failed", exc_info=t.exception())
+
+    task.add_done_callback(_on_done)
 
 # ---------------------------------------------------------------------------
 # Demo content — scripts pre-written in each language so no translation API
@@ -159,13 +179,16 @@ async def generate_demo_assets() -> dict[str, Any]:
 
 async def ensure_demo_generated() -> None:
     """Generate demo assets if they don't already exist. Safe to call at startup."""
+    global _generation_error
     if MANIFEST_PATH.exists():
         return
     logger.info("[Demo] No manifest found — generating demo audio (first run)...")
     try:
         await generate_demo_assets()
-    except Exception:
+        _generation_error = None
+    except Exception as exc:
         logger.exception("[Demo] Background demo generation failed")
+        _generation_error = str(exc)
 
 
 def load_manifest() -> dict[str, Any] | None:

--- a/tests/test_demo_routes.py
+++ b/tests/test_demo_routes.py
@@ -1,0 +1,101 @@
+"""Tests for demo asset generation concurrency and status reporting.
+
+Covers:
+- /api/demo/manifest reports "pending" before first generation
+- Two near-simultaneous /admin/demo/regenerate calls are serialized: only one
+  starts generation, the other is told generation is already in progress
+- The background task is tracked and status transitions generating -> ready
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+os.environ["BOOTH_ACCESS_TOKEN"] = ""
+os.environ["ADMIN_PASSWORD"] = "test-admin-pass"
+
+import pytest
+
+from portal.config import settings
+
+settings.admin_password = "test-admin-pass"
+
+
+@pytest.fixture(autouse=True)
+def demo_state(tmp_path, monkeypatch):
+    """Isolate demo generation module state and manifest path between tests."""
+    from portal.tts import demo_gen as dg
+
+    monkeypatch.setattr(dg, "_generating", False)
+    monkeypatch.setattr(dg, "_generation_error", None)
+    monkeypatch.setattr(dg, "MANIFEST_PATH", tmp_path / "manifest.json")
+    dg._tasks.clear()
+    yield dg
+    for task in list(dg._tasks):
+        task.cancel()
+    dg._tasks.clear()
+
+
+@pytest.mark.anyio
+async def test_manifest_pending_before_first_generation(demo_state):
+    from portal.routers.demo import demo_manifest
+
+    resp = await demo_manifest()
+    assert json.loads(resp.body)["status"] == "pending"
+
+
+@pytest.mark.anyio
+async def test_regenerate_marks_generating_then_ready(demo_state, monkeypatch):
+    from portal.routers.demo import demo_manifest, regenerate_demo
+
+    dg = demo_state
+
+    async def fake_generate():
+        dg.MANIFEST_PATH.write_text(json.dumps({"video_url": "x", "languages": []}))
+        return {"video_url": "x", "languages": []}
+
+    monkeypatch.setattr(dg, "generate_demo_assets", fake_generate)
+
+    resp = await regenerate_demo()
+    assert json.loads(resp.body) == {"ok": True, "detail": "Generation started"}
+
+    # The task is scheduled but hasn't run yet: regenerate_demo() sets the
+    # flag synchronously, so the status already reflects "generating".
+    status_resp = await demo_manifest()
+    assert json.loads(status_resp.body)["status"] == "generating"
+
+    (task,) = dg._tasks
+    await task
+
+    status_resp = await demo_manifest()
+    assert json.loads(status_resp.body)["status"] == "ready"
+
+
+@pytest.mark.anyio
+async def test_concurrent_regenerate_is_serialized(demo_state, monkeypatch):
+    """Two near-simultaneous regenerate calls must not both start generation.
+
+    Regression test: previously `_generating` was only set inside the
+    scheduled task body (not before `asyncio.create_task()` was called), so a
+    second request arriving before the event loop ran the first task's body
+    would also pass the "already generating" check and start a second,
+    overlapping generation.
+    """
+    from portal.routers.demo import regenerate_demo
+
+    dg = demo_state
+
+    async def fake_generate():
+        await asyncio.sleep(0.01)
+        return {"video_url": "x", "languages": []}
+
+    monkeypatch.setattr(dg, "generate_demo_assets", fake_generate)
+
+    first, second = await asyncio.gather(regenerate_demo(), regenerate_demo())
+    oks = sorted(json.loads(r.body)["ok"] for r in (first, second))
+    assert oks == [False, True]
+
+    for task in list(dg._tasks):
+        await task


### PR DESCRIPTION
Fixes #214

## Description

Briefly describe the purpose of this PR and the changes made.

## Related Issue

Closes #

## Changes Made

- 
- 
- 

## Testing

Describe how you tested these changes.

- [ ] Tested locally
- [ ] Existing tests pass
- [ ] Added/updated tests (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots or recordings here -->

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have tested my changes
- [ ] I have updated documentation where necessary
- [ ] My changes do not introduce new warnings or errors

## Additional Notes

<!-- Any extra context, concerns, or information -->

---

Fixed a self-review finding: the lifespan startup change had moved `dg._generating = True` from a synchronous set (before task creation) into the deferred task body, reintroducing a timing gap the fix was meant to close. Restored the synchronous set (now under `_generation_lock` for consistency) before `_gen()` is defined/scheduled, keeping `dg.track_task()` for GC-safety and exception logging.

**How this was tested:** `uv run pytest tests/ -v`