### PR TITLE
fix: Added an in-process per-IP rate limiter (10 failed attempts / 60s)

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -83,6 +83,10 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
             return templates.TemplateResponse(
                 request, "404.html", {"request": request, "detail": exc.detail}, status_code=404
             )
+        if exc.status_code == 429:
+            return templates.TemplateResponse(
+                request, "429.html", {"request": request, "detail": exc.detail}, status_code=429
+            )
         if exc.status_code >= 500:
             return templates.TemplateResponse(
                 request, "500.html", {"request": request, "detail": exc.detail}, status_code=exc.status_code

--- a/plans/README.md
+++ b/plans/README.md
@@ -27,7 +27,7 @@ conditions, run every verification command, and update your row when done.
 | [013](013-dedupe-translation-key.md) | De-duplicate translation API-key + LLM call helpers | P2 | S | — | DONE |
 | [014](014-route-tests.md) | Add route tests for `demo.py` and `listener.py` | P2 | M | 012 | TODO |
 | [015](015-debug-default-false.md) | Default `debug` False; gate SQL echo in prod | P2 | S | 005 | DONE |
-| [016](016-listener-rate-limit.md) | Rate-limit listener join-code validation | P3 | M | — | TODO |
+| [016](016-listener-rate-limit.md) | Rate-limit listener join-code validation | P3 | M | — | DONE |
 
 Status values: `TODO` | `IN PROGRESS` | `DONE` | `BLOCKED` (one-line reason) | `REJECTED` (one-line rationale)
 

--- a/portal/routers/listener.py
+++ b/portal/routers/listener.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import time
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,32 @@ templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
 
 router = APIRouter()
 
+_JOIN_CODE_RATE_LIMIT = 10
+_JOIN_CODE_RATE_WINDOW_SECONDS = 60
+_join_code_attempts: dict[str, tuple[int, float]] = {}
+
+
+def _register_failed_attempt(client_ip: str) -> bool:
+    """Record a failed join-code attempt for `client_ip`.
+
+    Returns True if the client has exceeded the allowed attempts within the window.
+    """
+    now = time.monotonic()
+    count, window_start = _join_code_attempts.get(client_ip, (0, now))
+    if now - window_start > _JOIN_CODE_RATE_WINDOW_SECONDS:
+        count, window_start = 0, now
+    count += 1
+    _join_code_attempts[client_ip] = (count, window_start)
+    return count > _JOIN_CODE_RATE_LIMIT
+
+
+def _reset_attempts(client_ip: str) -> None:
+    _join_code_attempts.pop(client_ip, None)
+
+
+def _client_ip(request: Request) -> str:
+    return request.client.host if request.client else "unknown"
+
 
 def has_listener_access(request: Request, event_slug: str, listener_join_code: str | None, code: str | None) -> bool:
     payload = get_booth_session(request)
@@ -31,7 +58,10 @@ def has_listener_access(request: Request, event_slug: str, listener_join_code: s
 
     cookie_code = request.cookies.get(f"listener_code_{event_slug}")
     active_code = code or cookie_code
-    return bool(listener_join_code and active_code == listener_join_code)
+    if bool(listener_join_code and active_code == listener_join_code):
+        _reset_attempts(_client_ip(request))
+        return True
+    return False
 
 
 @router.get("/listener/{event_slug}")
@@ -43,6 +73,10 @@ async def listen_event_page(request: Request, event_slug: str, code: str | None 
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
 
         if not has_listener_access(request, event_slug, ev.listener_join_code, code):
+            if _register_failed_attempt(_client_ip(request)):
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many join attempts. Please try again later."
+                )
             return templates.TemplateResponse(
                 request, "listener_join.html", {"event": ev, "error": "Invalid join code." if code else None}
             )
@@ -132,6 +166,10 @@ async def listener_room_audio_delay(
         if not ev:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
         if not has_listener_access(request, event_slug, ev.listener_join_code, code):
+            if _register_failed_attempt(_client_ip(request)):
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many join attempts. Please try again later."
+                )
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Listener access required")
         room = await get_room_by_id(session, room_id)
         if room is None or room.event_id != ev.id:

--- a/templates/429.html
+++ b/templates/429.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}Too Many Requests - VoxBento{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/landing.css') }}" />
+{% endblock %}
+
+{% block content %}
+<div class="lobby-container" style="justify-content: center; align-items: center; text-align: center; height: 100vh; display: flex; flex-direction: column;">
+  <img src="{{ url_for('static', path='img/wordmark.png') }}" alt="VoxBento" style="height: 48px; margin-bottom: 2rem;" />
+  <div class="card" style="padding: 3rem; max-width: 500px; width: 100%;">
+    <h1 style="margin-top: 0; color: var(--color-danger, #ef4444); font-size: 1.5rem;">Too Many Attempts (429)</h1>
+    <p style="color: var(--color-muted); margin-bottom: 2rem;">
+      {{ detail | default("Too many attempts. Please wait a minute and try again.") }}
+    </p>
+    <a href="/" class="btn btn-primary" style="display: inline-block; padding: 0.75rem 1.5rem;">Return to Homepage</a>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_listener_rate_limit.py
+++ b/tests/test_listener_rate_limit.py
@@ -1,0 +1,131 @@
+"""Tests for listener join-code rate limiting (Plan 016).
+
+Covers:
+- Repeated bad join codes from one client get throttled with 429
+- A valid join code succeeds and is not throttled
+- A client holding a valid session cookie is never throttled
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ["BOOTH_ACCESS_TOKEN"] = ""
+os.environ["ADMIN_PASSWORD"] = "test-admin-pass"
+
+import pytest
+
+from portal.routers import listener as listener_router
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    """Set up an in-memory database for the FastAPI app."""
+    from portal.database import configure, dispose, init_db
+
+    configure("sqlite+aiosqlite://")
+    await init_db()
+    yield
+    await dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limit_state():
+    """Rate-limit state is a module-level dict shared across tests/clients."""
+    listener_router._join_code_attempts.clear()
+    yield
+    listener_router._join_code_attempts.clear()
+
+
+@pytest.fixture
+async def seed_event():
+    """Seed an event with a known join code."""
+    from portal.database import create_event, create_room, get_session
+
+    async with get_session() as s:
+        event = await create_event(s, slug="testcon", display_name="TestCon 2026")
+        room = await create_room(s, event_id=event.id, display_name="Main Hall")
+        event.listener_join_code = "ROOM42"
+    return event, room
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _client(client_ip: str = "10.0.0.1"):
+    from httpx import ASGITransport, AsyncClient
+
+    from fastapi_app import app
+
+    return AsyncClient(transport=ASGITransport(app=app, client=(client_ip, 123)), base_url="http://test")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestListenerRateLimit:
+    @pytest.mark.anyio
+    async def test_repeated_bad_codes_get_throttled(self, seed_event):
+        event, _ = seed_event
+        async with _client() as c:
+            for _ in range(10):
+                resp = await c.get(f"/listener/{event.slug}?code=WRONGCODE")
+                assert resp.status_code == 200
+                assert b"Invalid join code." in resp.content
+
+            resp = await c.get(f"/listener/{event.slug}?code=WRONGCODE")
+            assert resp.status_code == 429
+
+    @pytest.mark.anyio
+    async def test_valid_code_succeeds_and_is_not_throttled(self, seed_event):
+        event, _ = seed_event
+        async with _client() as c:
+            for _ in range(10):
+                resp = await c.get(f"/listener/{event.slug}?code=WRONGCODE")
+                assert resp.status_code == 200
+
+            resp = await c.get(f"/listener/{event.slug}?code=ROOM42")
+            assert resp.status_code == 200
+            assert b"Invalid join code." not in resp.content
+
+    @pytest.mark.anyio
+    async def test_cookie_holder_is_never_throttled(self, seed_event):
+        event, _ = seed_event
+        async with _client() as c:
+            resp = await c.get(f"/listener/{event.slug}?code=ROOM42")
+            assert resp.status_code == 200
+            assert "listener_code_testcon" in resp.cookies
+
+            for _ in range(15):
+                resp = await c.get(f"/listener/{event.slug}")
+                assert resp.status_code == 200
+                assert b"Invalid join code." not in resp.content
+
+    @pytest.mark.anyio
+    async def test_different_clients_are_throttled_independently(self, seed_event):
+        event, _ = seed_event
+        async with _client("10.0.0.2") as c1, _client("10.0.0.3") as c2:
+            for _ in range(11):
+                await c1.get(f"/listener/{event.slug}?code=WRONGCODE")
+
+            resp = await c2.get(f"/listener/{event.slug}?code=WRONGCODE")
+            assert resp.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_audio_delay_endpoint_is_throttled(self, seed_event):
+        event, room = seed_event
+        async with _client() as c:
+            for _ in range(10):
+                resp = await c.get(f"/listener/{event.slug}/rooms/{room.id}/audio-delay?code=WRONGCODE")
+                assert resp.status_code == 403
+
+            resp = await c.get(f"/listener/{event.slug}/rooms/{room.id}/audio-delay?code=WRONGCODE")
+            assert resp.status_code == 429

--- a/tests/test_listener_rate_limit.py
+++ b/tests/test_listener_rate_limit.py
@@ -85,6 +85,17 @@ class TestListenerRateLimit:
             assert resp.status_code == 429
 
     @pytest.mark.anyio
+    async def test_throttled_browser_request_renders_429_page(self, seed_event):
+        event, _ = seed_event
+        async with _client() as c:
+            for _ in range(10):
+                await c.get(f"/listener/{event.slug}?code=WRONGCODE")
+
+            resp = await c.get(f"/listener/{event.slug}?code=WRONGCODE", headers={"accept": "text/html"})
+            assert resp.status_code == 429
+            assert b"Too Many Attempts" in resp.content
+
+    @pytest.mark.anyio
     async def test_valid_code_succeeds_and_is_not_throttled(self, seed_event):
         event, _ = seed_event
         async with _client() as c:


### PR DESCRIPTION
Fixes #218

## Description

Briefly describe the purpose of this PR and the changes made.

## Related Issue

Closes #

## Changes Made

- 
- 
- 

## Testing

Describe how you tested these changes.

- [ ] Tested locally
- [ ] Existing tests pass
- [ ] Added/updated tests (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots or recordings here -->

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have tested my changes
- [ ] I have updated documentation where necessary
- [ ] My changes do not introduce new warnings or errors

## Additional Notes

<!-- Any extra context, concerns, or information -->

---

Added an in-process per-IP rate limiter (10 failed attempts / 60s) to portal/routers/listener.py, wired into both listener routes before rendering/raising on bad join codes; successful code/cookie checks reset the counter so cookie holders are never throttled. Added tests/test_listener_rate_limit.py covering throttling, valid-code success, cookie bypass, per-client isolation, and the audio-delay route.

**How this was tested:** `uv run pytest tests/ -v`