### PR TITLE
ui: Extract base.html footer inline styles to CSS class

### DIFF
--- a/static/css/interpreter.css
+++ b/static/css/interpreter.css
@@ -879,3 +879,41 @@ label {
     gap: 0.5rem;
   }
 }
+
+/* ===== Portal Footer ===== */
+.portal-footer {
+  padding: 20px;
+  text-align: center;
+  border-top: 1px solid #e2e8f0;
+  margin-top: 40px;
+  font-family: Inter, sans-serif;
+  font-size: 0.875rem;
+  color: #718096;
+  background: #fff;
+}
+
+.portal-footer .footer-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.portal-footer .footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+}
+
+.portal-footer .footer-links a {
+  color: #4a5568;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.portal-footer .footer-links a:hover {
+  text-decoration: underline;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{% block title %}Voxbento Interpreter Booth{% endblock %}</title>
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='img/favicon.ico') }}" />
-    <link rel="stylesheet" href="{{ url_for('static', path='css/interpreter.css') }}?v=3" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/interpreter.css') }}?v=4" />
     {% block head %}{% endblock %}
   </head>
   <body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,12 +12,12 @@
 
     <main style="min-height: calc(100vh - 60px);">{% block content %}{% endblock %}</main>
     
-    <footer style="padding: 20px; text-align: center; border-top: 1px solid #e2e8f0; margin-top: 40px; font-family: Inter, sans-serif; font-size: 0.875rem; color: #718096; background: #fff;">
-        <div style="max-width: 1200px; margin: 0 auto; display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: 10px;">
+    <footer class="portal-footer">
+        <div class="footer-inner">
             <div>&copy; 2026 VoxBento.</div>
-            <div style="display: flex; flex-wrap: wrap; gap: 15px;">
-                <a href="/research" style="color: #4a5568; text-decoration: none; font-weight: 500;">Research & Benchmarks</a>
-                <a href="/llms.txt" style="color: #4a5568; text-decoration: none; font-weight: 500;">LLM Index</a>
+            <div class="footer-links">
+                <a href="/research">Research & Benchmarks</a>
+                <a href="/llms.txt">LLM Index</a>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Hey folks! 👋

So I noticed the footer in `templates/base.html` was packing like 8+ inline style attributes — felt a bit messy and hard to maintain, especially when the admin panel already has a neat `.admin-footer` class doing things right.

Figured I'd clean it up, keep things consistent.

## What changed?

**`templates/base.html`**
- Swapped out all those inline `style=` bloats for clean CSS classes
- `<footer style="padding: 20px; text-align: center; ...">` → `<footer class="portal-footer">`
- Inner divs and links now use `.footer-inner` and `.footer-links` — zero inline styles left in the footer block

**`static/css/interpreter.css`**
- Added `.portal-footer` with the original styling carried over (padding, border, font, colors, all that jazz)
- `.portal-footer .footer-inner` for the flex layout wrapper
- `.portal-footer .footer-links` for the link row
- `.portal-footer .footer-links a:hover` — subtle underline on hover, cause why not

## Did I break anything?

Tested it locally and:
- ✅ Looks exactly the same — colors, spacing, layout all intact
- ✅ Footer is fully responsive, wraps nicely on mobile
- ✅ No inline style attributes in the footer block at all
- ✅ Follows the same pattern as `.admin-footer` in the admin panel

Closes #248

Would love some eyes on this before it gets merged! Let me know if anything looks off or if there's a better naming convention I should follow. 🙏