### PR TITLE
Security: moved gemini api key from url query string to request header

### DIFF
--- a/portal/translations/worker.py
+++ b/portal/translations/worker.py
@@ -146,7 +146,8 @@ class TranslationWorker:
 
             elif provider == TranslationProviderEnum.GEMINI.value:
                 res = await client.post(
-                    f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}",
+                    f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent",
+                    headers={"x-goog-api-key": api_key},
                     json={
                         "systemInstruction": {"parts": [{"text": system_prompt}]},
                         "contents": [{"parts": [{"text": text}]}],


### PR DESCRIPTION
## Description

The Gemini API key is passed as a URL query parameter instead of using the HTTP header. API keys in URLs can be logged by intermediate proxies, load balancers, and access logs and hence passing in the request header is the best practice.

## Related Issue

Closes #240 

## Changes Made

- Changed a single file, added Gemini API key in the HTTP header and removed it from the URL query string.

## Testing

Describe how you tested these changes.

- [x] Tested locally
- [x] Existing tests pass
- [ ] Added/updated tests (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots or recordings here -->

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] My changes do not introduce new warnings or errors

## Additional Notes

<!-- Any extra context, concerns, or information -->

## Summary by Sourcery

Enhancements:
- Improve security of Gemini translation requests by sending the API key in the x-goog-api-key header rather than as a URL query string parameter.