### PR TITLE
perf: Reuse a shared httpx.AsyncClient instead of one per request

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -33,6 +33,7 @@ templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
 async def lifespan(app: FastAPI):
     import httpx
 
+    import portal.globals as g
     import portal.transcription as ts
     from portal.tts import demo_gen as dg
     from portal.tts.demo_gen import ensure_demo_generated
@@ -40,6 +41,7 @@ async def lifespan(app: FastAPI):
     settings.validate_production_secrets()
 
     ts.shared_http_client = httpx.AsyncClient(timeout=10.0)
+    g.shared_http_client = httpx.AsyncClient()
 
     # Generate landing page demo audio in the background on first startup.
     # Uses local Supertonic — no external API key needed.
@@ -59,6 +61,8 @@ async def lifespan(app: FastAPI):
     yield
     if ts.shared_http_client:
         await ts.shared_http_client.aclose()
+    if g.shared_http_client:
+        await g.shared_http_client.aclose()
 
 
 app = FastAPI(title="Voxbento", version="1.0.0", lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url=None)

--- a/portal/globals.py
+++ b/portal/globals.py
@@ -2,7 +2,26 @@ from __future__ import annotations
 
 import time
 
+import httpx
+
 from portal.booth_state import BoothRegistry
 
 booths = BoothRegistry()
 _JS_CACHE_BUST = str(int(time.time()))
+
+# Process-wide httpx client, started/closed by the FastAPI lifespan in
+# `fastapi_app.py`. Reused by hot paths (translation, TTS, MediaMTX/admin
+# calls) instead of opening a fresh connection pool and TLS context per
+# request. Callers should pass an explicit `timeout=` to individual requests
+# rather than relying on the client's own default, since a single shared
+# client is used for calls that previously had different per-call timeouts.
+shared_http_client: httpx.AsyncClient | None = None
+
+
+def get_http_client() -> httpx.AsyncClient:
+    """Return the shared httpx client, lazily creating one if the lifespan
+    hasn't started it yet (e.g. when called from tests or scripts)."""
+    global shared_http_client
+    if shared_http_client is None:
+        shared_http_client = httpx.AsyncClient()
+    return shared_http_client

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -9,7 +9,6 @@ import urllib.parse
 from datetime import timedelta
 from pathlib import Path
 
-import httpx
 import pycountry
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
 from fastapi.templating import Jinja2Templates
@@ -69,7 +68,7 @@ from portal.database import (
     update_user_active,
 )
 from portal.email import send_role_invite_email
-from portal.globals import _JS_CACHE_BUST, booths
+from portal.globals import _JS_CACHE_BUST, booths, get_http_client
 from portal.models import (
     BoothTranslationLanguage,
     RoomTranslationLanguage,
@@ -615,17 +614,17 @@ async def api_start_floor_transcription(room_id: int):
         else:
             jitsi_url = f"{settings.effective_jitsi_internal_base}/{room_id_str}"
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{settings.floor_bot_base}/start",
-                json={
-                    "event_slug": event_slug,
-                    "jitsi_url": jitsi_url,
-                    "mediamtx_rtsp_base": settings.mediamtx_rtsp_base,
-                },
-                timeout=10.0,
-            )
-            resp.raise_for_status()
+        client = get_http_client()
+        resp = await client.post(
+            f"{settings.floor_bot_base}/start",
+            json={
+                "event_slug": event_slug,
+                "jitsi_url": jitsi_url,
+                "mediamtx_rtsp_base": settings.mediamtx_rtsp_base,
+            },
+            timeout=10.0,
+        )
+        resp.raise_for_status()
     except Exception as e:
         logger.error(f"Failed to start floor-bot: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to start floor bot: {e}")
@@ -645,8 +644,8 @@ async def api_start_floor_transcription(room_id: int):
         )
     except Exception as e:
         logger.error(f"Failed to start transcription worker: {e}")
-        async with httpx.AsyncClient() as client:
-            await client.post(f"{settings.floor_bot_base}/stop", json={"event_slug": event_slug})
+        client = get_http_client()
+        await client.post(f"{settings.floor_bot_base}/stop", json={"event_slug": event_slug}, timeout=5.0)
         raise HTTPException(status_code=500, detail=f"Failed to start transcription worker: {e}")
     return {"status": "started"}
 
@@ -662,8 +661,8 @@ async def api_stop_floor_transcription(room_id: int):
             raise HTTPException(status_code=400, detail="Event not found")
         event_slug = event.slug
     try:
-        async with httpx.AsyncClient() as client:
-            await client.post(f"{settings.floor_bot_base}/stop", json={"event_slug": event_slug}, timeout=15.0)
+        client = get_http_client()
+        await client.post(f"{settings.floor_bot_base}/stop", json={"event_slug": event_slug}, timeout=15.0)
     except Exception as e:
         logger.error(f"Failed to stop floor-bot: {e}")
     await stop_transcription_worker(f"{event_slug}-floor")
@@ -684,10 +683,10 @@ async def api_floor_transcription_status(room_id: int):
     stage = "stopped"
     bot_reachable = True
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(f"{settings.floor_bot_base}/status", timeout=5.0)
-            resp.raise_for_status()
-            data = resp.json()
+        client = get_http_client()
+        resp = await client.get(f"{settings.floor_bot_base}/status", timeout=5.0)
+        resp.raise_for_status()
+        data = resp.json()
         info = (data.get("active_rooms") or {}).get(event_slug)
         if info:
             stage = info.get("stage", info.get("state", "unknown"))

--- a/portal/translations/worker.py
+++ b/portal/translations/worker.py
@@ -126,54 +126,57 @@ class TranslationWorker:
             logger.error(f"[{booth_id_str}] Translation failed for {lang_code}: {e}")
 
     async def _call_llm(self, provider: str, model: str, api_key: str, text: str, target_lang_name: str) -> str | None:
-        import httpx
+        from portal.globals import get_http_client
 
         system_prompt = f"You are a professional interpreter. Translate the following text into {target_lang_name}. Output ONLY the translated text, nothing else."
 
-        timeout = httpx.Timeout(10.0)
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            if provider in OPENAI_COMPATIBLE_ENDPOINTS:
-                res = await client.post(
-                    OPENAI_COMPATIBLE_ENDPOINTS[provider],
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    json={
-                        "model": model,
-                        "messages": [{"role": "system", "content": system_prompt}, {"role": "user", "content": text}],
-                    },
-                )
-                res.raise_for_status()
-                return res.json()["choices"][0]["message"]["content"].strip()
+        timeout = 10.0
+        client = get_http_client()
+        if provider in OPENAI_COMPATIBLE_ENDPOINTS:
+            res = await client.post(
+                OPENAI_COMPATIBLE_ENDPOINTS[provider],
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={
+                    "model": model,
+                    "messages": [{"role": "system", "content": system_prompt}, {"role": "user", "content": text}],
+                },
+                timeout=timeout,
+            )
+            res.raise_for_status()
+            return res.json()["choices"][0]["message"]["content"].strip()
 
-            elif provider == TranslationProviderEnum.GEMINI.value:
-                res = await client.post(
-                    f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent",
-                    headers={"x-goog-api-key": api_key},
-                    json={
-                        "systemInstruction": {"parts": [{"text": system_prompt}]},
-                        "contents": [{"parts": [{"text": text}]}],
-                    },
-                )
-                res.raise_for_status()
-                return res.json()["candidates"][0]["content"]["parts"][0]["text"].strip()
+        elif provider == TranslationProviderEnum.GEMINI.value:
+            res = await client.post(
+                f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent",
+                headers={"x-goog-api-key": api_key},
+                json={
+                    "systemInstruction": {"parts": [{"text": system_prompt}]},
+                    "contents": [{"parts": [{"text": text}]}],
+                },
+                timeout=timeout,
+            )
+            res.raise_for_status()
+            return res.json()["candidates"][0]["content"]["parts"][0]["text"].strip()
 
-            elif provider == TranslationProviderEnum.ANTHROPIC.value:
-                res = await client.post(
-                    "https://api.anthropic.com/v1/messages",
-                    headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
-                    json={
-                        "model": model,
-                        "max_tokens": 1024,
-                        "system": system_prompt,
-                        "messages": [{"role": "user", "content": text}],
-                    },
-                )
-                res.raise_for_status()
-                return res.json()["content"][0]["text"].strip()
+        elif provider == TranslationProviderEnum.ANTHROPIC.value:
+            res = await client.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
+                json={
+                    "model": model,
+                    "max_tokens": 1024,
+                    "system": system_prompt,
+                    "messages": [{"role": "user", "content": text}],
+                },
+                timeout=timeout,
+            )
+            res.raise_for_status()
+            return res.json()["content"][0]["text"].strip()
 
-            elif provider == TranslationProviderEnum.LOCAL.value:
-                # Placeholder for local model inference.
-                # In a real environment, you'd route this to an internal LLM endpoint like Ollama/vLLM.
-                logger.warning("Local translation not fully implemented. Echoing text.")
-                return f"[{target_lang_name}] {text}"
+        elif provider == TranslationProviderEnum.LOCAL.value:
+            # Placeholder for local model inference.
+            # In a real environment, you'd route this to an internal LLM endpoint like Ollama/vLLM.
+            logger.warning("Local translation not fully implemented. Echoing text.")
+            return f"[{target_lang_name}] {text}"
 
         return None

--- a/portal/tts/worker.py
+++ b/portal/tts/worker.py
@@ -5,8 +5,6 @@ import json
 import logging
 import time
 
-import httpx
-
 from portal.crypto import decrypt_val
 from portal.database import get_session
 from portal.models import Event, Room
@@ -349,28 +347,31 @@ class TTSWorker:
 
         endpoint = OPENAI_COMPATIBLE_ENDPOINTS[provider]
 
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            async with client.stream(
-                "POST",
-                endpoint,
-                headers={"Authorization": f"Bearer {api_key}"},
-                json={
-                    "model": model,
-                    "messages": [{"role": "system", "content": system_prompt}, {"role": "user", "content": text}],
-                    "stream": True,
-                },
-            ) as response:
-                response.raise_for_status()
-                async for line in response.aiter_lines():
-                    if line.startswith("data: "):
-                        data_str = line[6:].strip()
-                        if data_str == "[DONE]":
-                            break
-                        try:
-                            data = json.loads(data_str)
-                            delta = data["choices"][0].get("delta", {})
-                            content = delta.get("content", "")
-                            if content:
-                                yield content
-                        except (json.JSONDecodeError, KeyError, IndexError):
-                            pass
+        from portal.globals import get_http_client
+
+        client = get_http_client()
+        async with client.stream(
+            "POST",
+            endpoint,
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "model": model,
+                "messages": [{"role": "system", "content": system_prompt}, {"role": "user", "content": text}],
+                "stream": True,
+            },
+            timeout=10.0,
+        ) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                if line.startswith("data: "):
+                    data_str = line[6:].strip()
+                    if data_str == "[DONE]":
+                        break
+                    try:
+                        data = json.loads(data_str)
+                        delta = data["choices"][0].get("delta", {})
+                        content = delta.get("content", "")
+                        if content:
+                            yield content
+                    except (json.JSONDecodeError, KeyError, IndexError):
+                        pass

--- a/portal/utils.py
+++ b/portal/utils.py
@@ -11,7 +11,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 
 from portal.auth import decode_token
 from portal.config import settings
-from portal.globals import booths
+from portal.globals import booths, get_http_client
 
 
 def safe_redirect(url: str, status_code: int = status.HTTP_303_SEE_OTHER) -> RedirectResponse:
@@ -61,8 +61,8 @@ async def _check_mediamtx() -> bool:
         _mediamtx_cache = (now + _MEDIAMTX_CACHE_TTL, False)
         return False
     try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            r = await client.get(f"{base}/v3/paths/list")
+        client = get_http_client()
+        r = await client.get(f"{base}/v3/paths/list", timeout=2.0)
         ok = r.status_code < 500
         _mediamtx_cache = (now + _MEDIAMTX_CACHE_TTL, ok)
         return ok
@@ -98,21 +98,23 @@ async def _ensure_mediamtx_path(channel_id: str) -> None:
         "overridePublisher": True,
     }
     try:
-        async with httpx.AsyncClient(timeout=3.0) as client:
-            r = await client.post(
-                f"{api_base}/v3/config/paths/add/{channel_id}",
+        client = get_http_client()
+        r = await client.post(
+            f"{api_base}/v3/config/paths/add/{channel_id}",
+            json=body,
+            timeout=3.0,
+        )
+        if r.status_code == 200:
+            _created_paths.add(channel_id)
+        elif r.status_code == 400 and "already exists" in r.text.lower():
+            # Path exists but may lack alwaysAvailable — patch it
+            r2 = await client.patch(
+                f"{api_base}/v3/config/paths/patch/{channel_id}",
                 json=body,
+                timeout=3.0,
             )
-            if r.status_code == 200:
+            if r2.status_code == 200:
                 _created_paths.add(channel_id)
-            elif r.status_code == 400 and "already exists" in r.text.lower():
-                # Path exists but may lack alwaysAvailable — patch it
-                r2 = await client.patch(
-                    f"{api_base}/v3/config/paths/patch/{channel_id}",
-                    json=body,
-                )
-                if r2.status_code == 200:
-                    _created_paths.add(channel_id)
     except (httpx.ConnectError, httpx.TimeoutException, httpx.RequestError):
         pass  # Non-fatal; path will use all_others defaults
 

--- a/tests/test_globals_http_client.py
+++ b/tests/test_globals_http_client.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+import portal.globals as g
+
+
+@pytest.mark.anyio
+class TestSharedHttpClient:
+    async def test_lazily_creates_a_client_when_none_is_set(self):
+        g.shared_http_client = None
+        try:
+            client = g.get_http_client()
+            assert client is not None
+            assert g.shared_http_client is client
+        finally:
+            await g.shared_http_client.aclose()
+            g.shared_http_client = None
+
+    async def test_reuses_the_same_client_across_calls(self):
+        """The whole point of `get_http_client` is to avoid opening a fresh
+        connection pool per request, so repeated calls must return the exact
+        same client instance rather than constructing a new one each time."""
+        g.shared_http_client = None
+        try:
+            first = g.get_http_client()
+            second = g.get_http_client()
+            assert first is second
+        finally:
+            await g.shared_http_client.aclose()
+            g.shared_http_client = None
+
+    async def test_returns_the_lifespan_managed_client_when_already_set(self):
+        sentinel = object()
+        g.shared_http_client = sentinel
+        try:
+            assert g.get_http_client() is sentinel
+        finally:
+            g.shared_http_client = None


### PR DESCRIPTION
## Description

The translation worker, TTS worker, MediaMTX helpers in `portal/utils.py`, and the floor-bot helpers in `portal/routers/admin.py` each opened a fresh `httpx.AsyncClient` (and therefore a new connection pool and TLS handshake) for every single outgoing request. Since a transcription segment can trigger several concurrent LLM calls, this adds unnecessary connection churn on these hot paths.

This adds a process-wide client to `portal/globals.py`, started and closed by the FastAPI lifespan in `fastapi_app.py`, mirroring the pattern already used for `portal.transcription.shared_http_client`. All 8 call sites that used to construct their own `httpx.AsyncClient()` now reuse this shared client:

- `portal/translations/worker.py` (`_call_llm`)
- `portal/tts/worker.py` (streaming LLM translation)
- `portal/utils.py` (`_check_mediamtx`, `_ensure_mediamtx_path`)
- `portal/routers/admin.py` (4 floor-bot start/stop/status calls)

Each request now passes its previous timeout explicitly (e.g. `client.get(url, timeout=2.0)`) instead of relying on the client constructor's timeout, since the client is now shared across call sites that previously used different timeouts.

Fixes #245

## Testing

- Added `tests/test_globals_http_client.py` covering the lazy-creation and reuse behavior of `get_http_client()`.
- `uv run pytest tests/ -v`: 475 passed
- `uv run ruff check .`: clean