### PR TITLE
Fix public auth pages to use base layout instead of admin styles

### DIFF
--- a/static/css/auth.css
+++ b/static/css/auth.css
@@ -1,0 +1,134 @@
+/* ── Auth & Account pages ──────────────────────────────────────────────────
+   Extracted from admin.css. Deliberately excludes :root, body, .btn,
+   .btn-primary, .btn-sm — those now come from interpreter.css via base.html.
+   Missing custom properties are scoped locally below so they don't leak
+   into or override interpreter.css's global :root variables. */
+
+.login-page,
+.account-card,
+.portal-home-header {
+  --color-primary-hover: #1d4ed8;
+  --color-danger-hover: #b91c1c;
+  --color-text-secondary: var(--color-muted);
+  --color-surface: #ffffff;
+  --color-live: #16a34a;
+  --color-offline: #9ca3af;
+  --radius: 8px;
+  --radius-sm: 4px;
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+/* ── Header (used on account.html) ──────────────────────────────────────── */
+
+.portal-home-header {
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  padding: 12px 24px;
+  min-height: 56px;
+  height: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+.portal-home-header .brand { font-size: 1.25rem; font-weight: 700; color: var(--color-primary); text-decoration: none; }
+.header-nav { display: flex; gap: 20px; align-items: center; flex-wrap: wrap; }
+.header-nav a { font-size: 0.875rem; color: var(--color-text-secondary); text-decoration: none; }
+.header-nav a:hover { color: var(--color-primary); }
+.nav-logout { color: var(--color-danger) !important; }
+
+/* ── Admin-style main wrapper (used on account.html) ────────────────────── */
+
+.admin-main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+  width: 100%;
+  min-width: 0;
+  flex: 1;
+}
+
+/* ── Account card ────────────────────────────────────────────────────────── */
+
+.account-card {
+  max-width: 600px;
+  margin: 0 auto;
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  padding: 32px;
+  box-shadow: var(--shadow-sm);
+}
+.account-card h1 { margin-bottom: 24px; }
+.account-info { margin-top: 24px; }
+.account-info h3 { margin-bottom: 8px; }
+
+/* ── Tables (used on account.html) ──────────────────────────────────────── */
+
+.data-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+.data-table th, .data-table td { padding: 10px 12px; border-bottom: 1px solid var(--color-border); vertical-align: middle; text-align: left; }
+.data-table thead th { border-bottom: 2px solid var(--color-border); font-weight: 600; color: var(--color-text-secondary); font-size: 0.8125rem; text-transform: uppercase; letter-spacing: 0.04em; }
+.data-table tbody th { font-weight: 600; color: var(--color-text-secondary); font-size: 0.8125rem; text-transform: uppercase; letter-spacing: 0.04em; }
+.data-table tbody tr:hover { background: #f8f9fa; }
+.data-table.compact th, .data-table.compact td { padding: 8px 10px; }
+
+/* ── Status + badges (used on account.html) ─────────────────────────────── */
+
+.status-live { color: var(--color-live); font-weight: 600; white-space: nowrap; }
+.status-offline { color: var(--color-offline); }
+
+.badge { display: inline-block; font-size: 0.75rem; font-weight: 600; padding: 2px 8px; border-radius: 12px; }
+.badge-role { text-transform: capitalize; }
+.badge-interpreter { background: #dbeafe; color: #1e40af; }
+.badge-coordinator { background: #fef3c7; color: #92400e; }
+.badge-listener { background: #e0e7ff; color: #4338ca; }
+.badge-event_admin { background: #fce7f3; color: #9d174d; }
+.badge-super_admin { background: #fecaca; color: #991b1b; }
+
+.muted { color: var(--color-text-secondary); font-size: 0.875rem; }
+
+/* ── Login / Register pages ─────────────────────────────────────────────── */
+
+.login-page {
+  min-height: calc(100vh - 60px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.login-card {
+  width: 100%;
+  max-width: 400px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 40px 32px;
+  box-shadow: var(--shadow-md);
+}
+.login-brand { text-align: center; margin-bottom: 28px; }
+.login-subtitle { font-size: 0.875rem; color: var(--color-text-secondary); display: block; margin-top: 4px; }
+.login-form { display: flex; flex-direction: column; gap: 16px; }
+.login-form label { font-size: 0.875rem; font-weight: 600; color: var(--color-text-secondary); }
+.login-form input { padding: 10px 14px; font-size: 1rem; border: 1px solid var(--color-border); border-radius: var(--radius-sm); }
+.login-form input:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15); }
+.login-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  margin-top: 16px;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+.login-footer a { color: var(--color-primary); }
+.alert-error { background: #fef2f2; color: var(--color-danger); border: 1px solid #fecaca; padding: 10px 14px; border-radius: var(--radius-sm); font-size: 0.875rem; margin-bottom: 8px; }
+.error-list { margin: 0; padding-left: 18px; text-align: left; }
+
+@media (max-width: 768px) {
+  .portal-home-header { padding: 12px 16px; }
+  .admin-main { padding: 16px; }
+  .header-nav { gap: 12px; }
+}

--- a/templates/account.html
+++ b/templates/account.html
@@ -16,7 +16,7 @@
   </nav>
 </header>
 
-<main class="admin-main">
+<div class="admin-main">
   <div class="account-card">
     <h1>My Account</h1>
     <table class="data-table">
@@ -74,5 +74,5 @@
       {% endif %}
     </div>
   </div>
-</main>
+</div>
 {% endblock %}

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,82 +1,78 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>My Account — Voxbento</title>
-    <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='img/favicon.ico') }}" />
-    <link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}" />
-  </head>
-  <body>
-    <header class="portal-home-header">
-      <a class="brand" href="/"><img src="{{ url_for('static', path='img/wordmark.png') }}" alt="Voxbento" style="height: 32px; vertical-align: middle;" /></a>
-      <nav class="header-nav">
-        <a href="/account">My Account</a>
-        <a href="/admin/">Admin Panel</a>
-        <a href="/logout">Logout</a>
-      </nav>
-    </header>
+{% extends "base.html" %}
 
-    <main class="admin-main">
-      <div class="account-card">
-        <h1>My Account</h1>
-        <table class="data-table">
-          <tbody>
-            <tr>
-              <th>Email</th>
-              <td>{{ user.email }}</td>
-            </tr>
-            <tr>
-              <th>Display Name</th>
-              <td>{{ user.display_name }}</td>
-            </tr>
-            <tr>
-              <th>Joined</th>
-              <td>{{ user.created_at.strftime('%Y-%m-%d %H:%M UTC') if user.created_at else '—' }}</td>
-            </tr>
-            <tr>
-              <th>Status</th>
-              <td>
-                {% if user.is_active %}
-                <span class="status-live">● Active</span>
-                {% else %}
-                <span class="status-offline">○ Deactivated</span>
-                {% endif %}
-              </td>
-            </tr>
-            {% if user.is_admin %}
-            <tr>
-              <th>System Role</th>
-              <td><span class="badge badge-role badge-super_admin" style="background:var(--color-danger)">Super Admin</span><br><small class="muted">You have global admin panel and event access.</small></td>
-            </tr>
+{% block title %}My Account — Voxbento{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/auth.css') }}" />
+{% endblock %}
+
+{% block content %}
+<header class="portal-home-header">
+  <a class="brand" href="/"><img src="{{ url_for('static', path='img/wordmark.png') }}" alt="Voxbento" style="height: 32px; vertical-align: middle;" /></a>
+  <nav class="header-nav">
+    <a href="/account">My Account</a>
+    <a href="/admin/">Admin Panel</a>
+    <a href="/logout">Logout</a>
+  </nav>
+</header>
+
+<main class="admin-main">
+  <div class="account-card">
+    <h1>My Account</h1>
+    <table class="data-table">
+      <tbody>
+        <tr>
+          <th>Email</th>
+          <td>{{ user.email }}</td>
+        </tr>
+        <tr>
+          <th>Display Name</th>
+          <td>{{ user.display_name }}</td>
+        </tr>
+        <tr>
+          <th>Joined</th>
+          <td>{{ user.created_at.strftime('%Y-%m-%d %H:%M UTC') if user.created_at else '—' }}</td>
+        </tr>
+        <tr>
+          <th>Status</th>
+          <td>
+            {% if user.is_active %}
+            <span class="status-live">● Active</span>
+            {% else %}
+            <span class="status-offline">○ Deactivated</span>
             {% endif %}
-          </tbody>
-        </table>
+          </td>
+        </tr>
+        {% if user.is_admin %}
+        <tr>
+          <th>System Role</th>
+          <td><span class="badge badge-role badge-super_admin" style="background:var(--color-danger)">Super Admin</span><br><small class="muted">You have global admin panel and event access.</small></td>
+        </tr>
+        {% endif %}
+      </tbody>
+    </table>
 
-        <div class="account-info">
-          <h3>Your Event Roles</h3>
-          {% if memberships %}
-          <table class="data-table compact">
-            <thead>
-              <tr><th>Event</th><th>Role</th><th>Since</th></tr>
-            </thead>
-            <tbody>
-              {% for m in memberships %}
-              <tr>
-                <td>{{ m.event.display_name if m.event else '—' }}</td>
-                <td><span class="badge badge-role badge-{{ m.role }}">{{ m.role }}</span></td>
-                <td>{{ m.created_at.strftime('%Y-%m-%d') if m.created_at else '—' }}</td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% else %}
-          <p class="muted">You have not been assigned a role for any event yet. An admin can assign roles on a per-event basis.</p>
-          {% endif %}
-        </div>
-      </div>
-    </main>
-
-
-  </body>
-</html>
+    <div class="account-info">
+      <h3>Your Event Roles</h3>
+      {% if memberships %}
+      <table class="data-table compact">
+        <thead>
+          <tr><th>Event</th><th>Role</th><th>Since</th></tr>
+        </thead>
+        <tbody>
+          {% for m in memberships %}
+          <tr>
+            <td>{{ m.event.display_name if m.event else '—' }}</td>
+            <td><span class="badge badge-role badge-{{ m.role }}">{{ m.role }}</span></td>
+            <td>{{ m.created_at.strftime('%Y-%m-%d') if m.created_at else '—' }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p class="muted">You have not been assigned a role for any event yet. An admin can assign roles on a per-event basis.</p>
+      {% endif %}
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,37 +1,35 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sign In — Voxbento</title>
-    <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='img/favicon.ico') }}" />
-    <link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}" />
-  </head>
-  <body>
-    <div class="login-page">
-      <div class="login-card">
-        <div class="login-brand">
-          <img src="{{ url_for('static', path='img/wordmark.png') }}" alt="Voxbento" class="brand-text" style="height: 48px; margin: 0 auto;" />
-          <span class="login-subtitle">Sign in to your account</span>
-        </div>
-        {% if error %}
-        <div class="alert alert-error">{{ error }}</div>
-        {% endif %}
-        <form method="post" action="/login" class="login-form">
-          <input type="hidden" name="next_url" value="{{ next_url|default('', true) }}" />
-          <label for="email">Email</label>
-          <input type="email" id="email" name="email" placeholder="you@example.com" value="{{ email|default('', true) }}" required autofocus />
+{% extends "base.html" %}
 
-          <label for="password">Password</label>
-          <input type="password" id="password" name="password" placeholder="Enter your password" required />
+{% block title %}Sign In — Voxbento{% endblock %}
 
-          <button type="submit" class="btn btn-primary">Sign In</button>
-        </form>
-        <div class="login-footer">
-          <span>Don't have an account? <a href="/register">Register</a></span>
-          <a href="/">← Back to Portal Home</a>
-        </div>
-      </div>
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/auth.css') }}" />
+{% endblock %}
+
+{% block content %}
+<div class="login-page">
+  <div class="login-card">
+    <div class="login-brand">
+      <img src="{{ url_for('static', path='img/wordmark.png') }}" alt="Voxbento" class="brand-text" style="height: 48px; margin: 0 auto;" />
+      <span class="login-subtitle">Sign in to your account</span>
     </div>
-  </body>
-</html>
+    {% if error %}
+    <div class="alert alert-error">{{ error }}</div>
+    {% endif %}
+    <form method="post" action="/login" class="login-form">
+      <input type="hidden" name="next_url" value="{{ next_url|default('', true) }}" />
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" placeholder="you@example.com" value="{{ email|default('', true) }}" required autofocus />
+
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" placeholder="Enter your password" required />
+
+      <button type="submit" class="btn btn-primary">Sign In</button>
+    </form>
+    <div class="login-footer">
+      <span>Don't have an account? <a href="/register">Register</a></span>
+      <a href="/">← Back to Portal Home</a>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,48 +1,46 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Register — Voxbento</title>
-    <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='img/favicon.ico') }}" />
-    <link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}" />
-  </head>
-  <body>
-    <div class="login-page">
-      <div class="login-card">
-        <div class="login-brand">
-          <img src="{{ url_for('static', path='img/wordmark.png') }}" alt="Voxbento" class="brand-text" style="height: 48px; margin: 0 auto;" />
-          <span class="login-subtitle">Create your account</span>
-        </div>
-        {% if errors %}
-        <div class="alert alert-error">
-          <ul class="error-list">
-            {% for err in errors %}
-            <li>{{ err }}</li>
-            {% endfor %}
-          </ul>
-        </div>
-        {% endif %}
-        <form method="post" action="/register" class="login-form">
-          <label for="email">Email</label>
-          <input type="email" id="email" name="email" placeholder="you@example.com" value="{{ email|default('', true) }}" required autofocus />
+{% extends "base.html" %}
 
-          <label for="display_name">Display Name</label>
-          <input type="text" id="display_name" name="display_name" placeholder="Your name" value="{{ display_name|default('', true) }}" required />
+{% block title %}Register — Voxbento{% endblock %}
 
-          <label for="password">Password</label>
-          <input type="password" id="password" name="password" placeholder="Min. 8 characters" required minlength="8" />
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/auth.css') }}" />
+{% endblock %}
 
-          <label for="password_confirm">Confirm Password</label>
-          <input type="password" id="password_confirm" name="password_confirm" placeholder="Repeat password" required minlength="8" />
-
-          <button type="submit" class="btn btn-primary">Create Account</button>
-        </form>
-        <div class="login-footer">
-          <span>Already have an account? <a href="/login">Sign in</a></span>
-          <a href="/">← Back to Portal Home</a>
-        </div>
-      </div>
+{% block content %}
+<div class="login-page">
+  <div class="login-card">
+    <div class="login-brand">
+      <img src="{{ url_for('static', path='img/wordmark.png') }}" alt="Voxbento" class="brand-text" style="height: 48px; margin: 0 auto;" />
+      <span class="login-subtitle">Create your account</span>
     </div>
-  </body>
-</html>
+    {% if errors %}
+    <div class="alert alert-error">
+      <ul class="error-list">
+        {% for err in errors %}
+        <li>{{ err }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+    <form method="post" action="/register" class="login-form">
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" placeholder="you@example.com" value="{{ email|default('', true) }}" required autofocus />
+
+      <label for="display_name">Display Name</label>
+      <input type="text" id="display_name" name="display_name" placeholder="Your name" value="{{ display_name|default('', true) }}" required />
+
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" placeholder="Min. 8 characters" required minlength="8" />
+
+      <label for="password_confirm">Confirm Password</label>
+      <input type="password" id="password_confirm" name="password_confirm" placeholder="Repeat password" required minlength="8" />
+
+      <button type="submit" class="btn btn-primary">Create Account</button>
+    </form>
+    <div class="login-footer">
+      <span>Already have an account? <a href="/login">Sign in</a></span>
+      <a href="/">← Back to Portal Home</a>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

This PR fixes the styling collision described in #251 by moving the public authentication pages away from `admin.css`.

### Changes made

- Updated `login.html` to extend `base.html`
- Updated `register.html` to extend `base.html`
- Updated `account.html` to extend `base.html`
- Added `static/css/auth.css` containing authentication and account-specific styles
- Removed dependency on `admin.css` for public-facing pages

### Testing

- Verified `/login` loads `interpreter.css` and `auth.css` only
- Verified `/register` loads `interpreter.css` and `auth.css` only
- Verified `/account` loads `interpreter.css` and `auth.css` only
- Confirmed `admin.css` is no longer loaded on these public pages
- Tested the login, register, and account pages locally

Fixes #251