### PR TITLE
chore: add missing from __future__ import annotations to 7+ files

### DIFF
--- a/portal/globals.py
+++ b/portal/globals.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from portal.booth_state import BoothRegistry

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import math

--- a/portal/routers/api.py
+++ b/portal/routers/api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy import select

--- a/portal/routers/auth.py
+++ b/portal/routers/auth.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Annotated
 

--- a/portal/routers/interpreter.py
+++ b/portal/routers/interpreter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any
 

--- a/portal/routers/listener.py
+++ b/portal/routers/listener.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import time

--- a/portal/routers/public.py
+++ b/portal/routers/public.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 # We assume templates is initialized in fastapi_app and imported here, or

--- a/portal/websockets/handlers.py
+++ b/portal/websockets/handlers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect

--- a/portal/websockets/manager.py
+++ b/portal/websockets/manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 from dataclasses import dataclass


### PR DESCRIPTION
Adds the project-standard future annotations import to files that were missing it, per AGENTS.md rule #8.

Fixes #241

## Description

Adds the project-standard `from __future__ import annotations` import to 9 Python files under `portal/` that were missing it, per AGENTS.md rule #8. This is a mechanical, behavior-preserving change.

## Related Issue

Closes #241

## Changes Made

- Added `from __future__ import annotations` as the first line of `portal/websockets/manager.py`
- Added `from __future__ import annotations` as the first line of `portal/websockets/handlers.py`
- Added `from __future__ import annotations` as the first line of `portal/globals.py`
- Added `from __future__ import annotations` as the first line of `portal/routers/admin.py`, `api.py`, `auth.py`, `interpreter.py`, `listener.py`, and `public.py

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [ ] Added/updated tests (if applicable)

Ran:
uv run pytest tests/ -v
node --check static/js/interpreter-booth.js

All 27 tests pass; no behaviour changes expected since this only affects annotation evaluation.

## Screenshots (if applicable)
N/A — no visual changes.

<!-- Add screenshots or recordings here -->

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] My changes do not introduce new warnings or errors

## Additional Notes

No new tests added since this is a non-functional, mechanical change (adding a future-annotations import) with no behaviour change to verify.

## Summary by Sourcery

Enhancements:
- Add from __future__ import annotations to globals, router, and websocket modules under portal to align with project-wide typing conventions.