### PR TITLE
perf: share one HTTP client across the translation batch

### DIFF
--- a/portal/translations/worker.py
+++ b/portal/translations/worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 

--- a/portal/translations/worker.py
+++ b/portal/translations/worker.py
@@ -35,7 +35,7 @@ class TranslationWorker:
 
             provider = None
             model = None
-            enabled_langs = []
+            enabled_langs: list[tuple[str, str]] = []
             room = None
 
             if segment.booth_id is None:
@@ -47,7 +47,9 @@ class TranslationWorker:
                     return
                 provider = room.floor_translation_provider
                 model = room.floor_translation_model
-                enabled_langs = [lang for lang in room.translation_languages if lang.enabled]
+                enabled_langs = [
+                    (lang.language_code, lang.language_name) for lang in room.translation_languages if lang.enabled
+                ]
             else:
                 # Booth translation
                 booth = await session.scalar(
@@ -59,7 +61,9 @@ class TranslationWorker:
                     return
                 provider = booth.translation_provider
                 model = booth.translation_model
-                enabled_langs = [lang for lang in booth.translation_languages if lang.enabled]
+                enabled_langs = [
+                    (lang.language_code, lang.language_name) for lang in booth.translation_languages if lang.enabled
+                ]
                 room = await session.scalar(select(Room).where(Room.id == room_id))
 
             if not provider or not model or not enabled_langs or not room:
@@ -74,26 +78,26 @@ class TranslationWorker:
                 logger.error(f"[{booth_id_str}] Translation API key not found for provider {provider}")
                 return
 
-            # Execute translation for all target languages concurrently, sharing a
-            # single HTTP client (and its connection pool) across the whole batch.
-            async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
-                tasks = [
-                    self._translate_and_broadcast(
-                        client,
-                        event,
-                        room,
-                        provider,
-                        model,
-                        api_key,
-                        lang.language_code,
-                        lang.language_name,
-                        segment_id,
-                        text,
-                        booth_id_str,
-                    )
-                    for lang in enabled_langs
-                ]
-                await asyncio.gather(*tasks)
+        # The DB session is closed before the network batch so a DB transaction/connection
+        # is not held open for the duration of the (slow) LLM calls. All target languages
+        # share a single HTTP client (and its connection pool); each per-language write in
+        # _translate_and_broadcast opens its own independent session.
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+            tasks = [
+                self._translate_and_broadcast(
+                    client,
+                    provider,
+                    model,
+                    api_key,
+                    lang_code,
+                    lang_name,
+                    segment_id,
+                    text,
+                    booth_id_str,
+                )
+                for lang_code, lang_name in enabled_langs
+            ]
+            await asyncio.gather(*tasks)
 
     def _get_translation_api_key(self, event: Event, provider: str) -> str | None:
         return get_translation_api_key(event, provider)
@@ -101,11 +105,9 @@ class TranslationWorker:
     async def _translate_and_broadcast(
         self,
         client: httpx.AsyncClient,
-        event: Event,
-        room: Room,
         provider: str,
         model: str,
-        api_key: str,
+        api_key: str | None,
         lang_code: str,
         lang_name: str,
         segment_id: int,
@@ -134,7 +136,13 @@ class TranslationWorker:
             logger.error(f"[{booth_id_str}] Translation failed for {lang_code}: {e}")
 
     async def _call_llm(
-        self, client: httpx.AsyncClient, provider: str, model: str, api_key: str, text: str, target_lang_name: str
+        self,
+        client: httpx.AsyncClient,
+        provider: str,
+        model: str,
+        api_key: str | None,
+        text: str,
+        target_lang_name: str,
     ) -> str | None:
         system_prompt = f"You are a professional interpreter. Translate the following text into {target_lang_name}. Output ONLY the translated text, nothing else."
 

--- a/portal/translations/worker.py
+++ b/portal/translations/worker.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 
+import httpx
+
 from portal.database import get_session
 from portal.models import DBBooth, Event, Room, TranscriptTranslation
 from portal.translations.constants import OPENAI_COMPATIBLE_ENDPOINTS, TranslationProviderEnum
@@ -70,29 +72,33 @@ class TranslationWorker:
                 logger.error(f"[{booth_id_str}] Translation API key not found for provider {provider}")
                 return
 
-            # Execute translation for all target languages concurrently
-            tasks = [
-                self._translate_and_broadcast(
-                    event,
-                    room,
-                    provider,
-                    model,
-                    api_key,
-                    lang.language_code,
-                    lang.language_name,
-                    segment_id,
-                    text,
-                    booth_id_str,
-                )
-                for lang in enabled_langs
-            ]
-            await asyncio.gather(*tasks)
+            # Execute translation for all target languages concurrently, sharing a
+            # single HTTP client (and its connection pool) across the whole batch.
+            async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+                tasks = [
+                    self._translate_and_broadcast(
+                        client,
+                        event,
+                        room,
+                        provider,
+                        model,
+                        api_key,
+                        lang.language_code,
+                        lang.language_name,
+                        segment_id,
+                        text,
+                        booth_id_str,
+                    )
+                    for lang in enabled_langs
+                ]
+                await asyncio.gather(*tasks)
 
     def _get_translation_api_key(self, event: Event, provider: str) -> str | None:
         return get_translation_api_key(event, provider)
 
     async def _translate_and_broadcast(
         self,
+        client: httpx.AsyncClient,
         event: Event,
         room: Room,
         provider: str,
@@ -105,7 +111,7 @@ class TranslationWorker:
         booth_id_str: str,
     ):
         try:
-            translated_text = await self._call_llm(provider, model, api_key, text, lang_name)
+            translated_text = await self._call_llm(client, provider, model, api_key, text, lang_name)
             if not translated_text:
                 return
 
@@ -125,55 +131,53 @@ class TranslationWorker:
         except Exception as e:
             logger.error(f"[{booth_id_str}] Translation failed for {lang_code}: {e}")
 
-    async def _call_llm(self, provider: str, model: str, api_key: str, text: str, target_lang_name: str) -> str | None:
-        import httpx
-
+    async def _call_llm(
+        self, client: httpx.AsyncClient, provider: str, model: str, api_key: str, text: str, target_lang_name: str
+    ) -> str | None:
         system_prompt = f"You are a professional interpreter. Translate the following text into {target_lang_name}. Output ONLY the translated text, nothing else."
 
-        timeout = httpx.Timeout(10.0)
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            if provider in OPENAI_COMPATIBLE_ENDPOINTS:
-                res = await client.post(
-                    OPENAI_COMPATIBLE_ENDPOINTS[provider],
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    json={
-                        "model": model,
-                        "messages": [{"role": "system", "content": system_prompt}, {"role": "user", "content": text}],
-                    },
-                )
-                res.raise_for_status()
-                return res.json()["choices"][0]["message"]["content"].strip()
+        if provider in OPENAI_COMPATIBLE_ENDPOINTS:
+            res = await client.post(
+                OPENAI_COMPATIBLE_ENDPOINTS[provider],
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={
+                    "model": model,
+                    "messages": [{"role": "system", "content": system_prompt}, {"role": "user", "content": text}],
+                },
+            )
+            res.raise_for_status()
+            return res.json()["choices"][0]["message"]["content"].strip()
 
-            elif provider == TranslationProviderEnum.GEMINI.value:
-                res = await client.post(
-                    f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent",
-                    headers={"x-goog-api-key": api_key},
-                    json={
-                        "systemInstruction": {"parts": [{"text": system_prompt}]},
-                        "contents": [{"parts": [{"text": text}]}],
-                    },
-                )
-                res.raise_for_status()
-                return res.json()["candidates"][0]["content"]["parts"][0]["text"].strip()
+        elif provider == TranslationProviderEnum.GEMINI.value:
+            res = await client.post(
+                f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent",
+                headers={"x-goog-api-key": api_key},
+                json={
+                    "systemInstruction": {"parts": [{"text": system_prompt}]},
+                    "contents": [{"parts": [{"text": text}]}],
+                },
+            )
+            res.raise_for_status()
+            return res.json()["candidates"][0]["content"]["parts"][0]["text"].strip()
 
-            elif provider == TranslationProviderEnum.ANTHROPIC.value:
-                res = await client.post(
-                    "https://api.anthropic.com/v1/messages",
-                    headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
-                    json={
-                        "model": model,
-                        "max_tokens": 1024,
-                        "system": system_prompt,
-                        "messages": [{"role": "user", "content": text}],
-                    },
-                )
-                res.raise_for_status()
-                return res.json()["content"][0]["text"].strip()
+        elif provider == TranslationProviderEnum.ANTHROPIC.value:
+            res = await client.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
+                json={
+                    "model": model,
+                    "max_tokens": 1024,
+                    "system": system_prompt,
+                    "messages": [{"role": "user", "content": text}],
+                },
+            )
+            res.raise_for_status()
+            return res.json()["content"][0]["text"].strip()
 
-            elif provider == TranslationProviderEnum.LOCAL.value:
-                # Placeholder for local model inference.
-                # In a real environment, you'd route this to an internal LLM endpoint like Ollama/vLLM.
-                logger.warning("Local translation not fully implemented. Echoing text.")
-                return f"[{target_lang_name}] {text}"
+        elif provider == TranslationProviderEnum.LOCAL.value:
+            # Placeholder for local model inference.
+            # In a real environment, you'd route this to an internal LLM endpoint like Ollama/vLLM.
+            logger.warning("Local translation not fully implemented. Echoing text.")
+            return f"[{target_lang_name}] {text}"
 
         return None

--- a/portal/tts/worker.py
+++ b/portal/tts/worker.py
@@ -346,7 +346,8 @@ class TTSWorker:
             from portal.translations.worker import TranslationWorker
 
             temp_worker = TranslationWorker(None)
-            full_text = await temp_worker._call_llm(provider, model, api_key, text, target_lang_name)
+            async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+                full_text = await temp_worker._call_llm(client, provider, model, api_key, text, target_lang_name)
             if full_text:
                 yield full_text
             return

--- a/tests/test_translation_worker.py
+++ b/tests/test_translation_worker.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.anyio
+class TestTranslationWorkerSharedClient:
+    """The translation batch must share a single HTTP client across all target languages."""
+
+    @pytest.fixture(autouse=True)
+    async def setup_db(self):
+        from portal.database import configure, dispose, init_db
+
+        configure("sqlite+aiosqlite://")
+        await init_db()
+        yield
+        await dispose()
+
+    async def _seed_floor_room(self, languages):
+        """Seed a floor-translation room (provider 'local', so no API key is needed) plus one segment."""
+        from portal.database import create_event, create_room, get_session
+        from portal.models import RoomTranslationLanguage, TranscriptSegment
+
+        async with get_session() as s:
+            event = await create_event(s, slug="tcon", display_name="T Con")
+            room = await create_room(s, event_id=event.id, display_name="Hall")
+            room.floor_translation_enabled = True
+            room.floor_translation_provider = "local"
+            room.floor_translation_model = "local-model"
+            for code, name in languages:
+                s.add(
+                    RoomTranslationLanguage(room_id=room.id, language_code=code, language_name=name, enabled=True)
+                )
+            segment = TranscriptSegment(room_id=room.id, booth_id=None, language_code="en", text="Hello world.")
+            s.add(segment)
+            await s.commit()
+            return room.id, segment.id
+
+    async def test_one_shared_client_threaded_to_every_language(self, monkeypatch):
+        from portal.translations.worker import TranslationWorker
+
+        languages = [("fr", "French"), ("de", "German"), ("es", "Spanish")]
+        room_id, segment_id = await self._seed_floor_room(languages)
+
+        # Spy on client construction to prove exactly one is created per batch.
+        created_clients = []
+
+        class SpyClient:
+            def __init__(self, *args, **kwargs):
+                created_clients.append(self)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        monkeypatch.setattr("portal.translations.worker.httpx.AsyncClient", SpyClient)
+
+        # Capture the client instance each language's _call_llm receives.
+        received_clients = []
+
+        async def fake_call_llm(self, client, provider, model, api_key, text, target_lang_name):
+            received_clients.append(client)
+            return f"[{target_lang_name}] {text}"
+
+        monkeypatch.setattr(TranslationWorker, "_call_llm", fake_call_llm)
+
+        broadcasts = []
+
+        async def broadcast(booth_id_str, payload):
+            broadcasts.append((booth_id_str, payload))
+
+        await TranslationWorker(broadcast).handle_translation(
+            room_id=room_id, segment_id=segment_id, text="Hello world.", booth_id_str="floor-1"
+        )
+
+        # Exactly one client for the whole batch...
+        assert len(created_clients) == 1
+        # ...consumed once per target language...
+        assert len(received_clients) == len(languages)
+        # ...and every call received that same shared instance.
+        assert all(c is created_clients[0] for c in received_clients)
+        # Sanity: all languages were translated and broadcast.
+        assert len(broadcasts) == len(languages)

--- a/tests/test_translation_worker.py
+++ b/tests/test_translation_worker.py
@@ -28,21 +28,42 @@ class TestTranslationWorkerSharedClient:
             room.floor_translation_provider = "local"
             room.floor_translation_model = "local-model"
             for code, name in languages:
-                s.add(
-                    RoomTranslationLanguage(room_id=room.id, language_code=code, language_name=name, enabled=True)
-                )
+                s.add(RoomTranslationLanguage(room_id=room.id, language_code=code, language_name=name, enabled=True))
             segment = TranscriptSegment(room_id=room.id, booth_id=None, language_code="en", text="Hello world.")
             s.add(segment)
             await s.commit()
             return room.id, segment.id
 
-    async def test_one_shared_client_threaded_to_every_language(self, monkeypatch):
+    async def _seed_booth(self, languages):
+        """Seed a booth-translation booth (provider 'local') plus one segment tied to that booth."""
+        from portal.database import create_event, create_room, get_session
+        from portal.models import BoothTranslationLanguage, DBBooth, TranscriptSegment
+
+        async with get_session() as s:
+            event = await create_event(s, slug="bcon", display_name="B Con")
+            room = await create_room(s, event_id=event.id, display_name="Hall")
+            booth = DBBooth(
+                event_id=event.id,
+                room_id=room.id,
+                language_code="en",
+                language_name="English",
+                translation_enabled=True,
+                translation_provider="local",
+                translation_model="local-model",
+            )
+            s.add(booth)
+            await s.flush()
+            for code, name in languages:
+                s.add(BoothTranslationLanguage(booth_id=booth.id, language_code=code, language_name=name, enabled=True))
+            segment = TranscriptSegment(room_id=room.id, booth_id=booth.id, language_code="en", text="Hello world.")
+            s.add(segment)
+            await s.commit()
+            return room.id, segment.id
+
+    def _worker_with_spies(self, monkeypatch):
+        """Spy on httpx.AsyncClient construction and _call_llm; return (worker, created, received, broadcasts)."""
         from portal.translations.worker import TranslationWorker
 
-        languages = [("fr", "French"), ("de", "German"), ("es", "Spanish")]
-        room_id, segment_id = await self._seed_floor_room(languages)
-
-        # Spy on client construction to prove exactly one is created per batch.
         created_clients = []
 
         class SpyClient:
@@ -71,15 +92,37 @@ class TestTranslationWorkerSharedClient:
         async def broadcast(booth_id_str, payload):
             broadcasts.append((booth_id_str, payload))
 
-        await TranslationWorker(broadcast).handle_translation(
+        return TranslationWorker(broadcast), created_clients, received_clients, broadcasts
+
+    async def test_one_shared_client_threaded_to_every_language(self, monkeypatch):
+        languages = [("fr", "French"), ("de", "German"), ("es", "Spanish")]
+        room_id, segment_id = await self._seed_floor_room(languages)
+        worker, created, received, broadcasts = self._worker_with_spies(monkeypatch)
+
+        await worker.handle_translation(
             room_id=room_id, segment_id=segment_id, text="Hello world.", booth_id_str="floor-1"
         )
 
         # Exactly one client for the whole batch...
-        assert len(created_clients) == 1
+        assert len(created) == 1
         # ...consumed once per target language...
-        assert len(received_clients) == len(languages)
+        assert len(received) == len(languages)
         # ...and every call received that same shared instance.
-        assert all(c is created_clients[0] for c in received_clients)
+        assert all(c is created[0] for c in received)
         # Sanity: all languages were translated and broadcast.
+        assert len(broadcasts) == len(languages)
+
+    async def test_booth_path_shares_one_client(self, monkeypatch):
+        """The booth (non-floor) branch resolves config from the booth and must share one client too."""
+        languages = [("fr", "French"), ("de", "German")]
+        room_id, segment_id = await self._seed_booth(languages)
+        worker, created, received, broadcasts = self._worker_with_spies(monkeypatch)
+
+        await worker.handle_translation(
+            room_id=room_id, segment_id=segment_id, text="Hello world.", booth_id_str="booth-en"
+        )
+
+        assert len(created) == 1
+        assert len(received) == len(languages)
+        assert all(c is created[0] for c in received)
         assert len(broadcasts) == len(languages)


### PR DESCRIPTION
## What

`portal/translations/worker.py` created a new `httpx.AsyncClient` per target language inside `_call_llm`. One transcription segment with N enabled languages therefore opened N clients and discarded their keep-alive connections.

This PR creates **one** client in `handle_translation`, wraps the `asyncio.gather` batch in it, and threads it through `_translate_and_broadcast` into `_call_llm`. All languages in a batch translate against the same provider host, so they now share a single connection pool.

Closes #253.

## Scope note

The issue lists three proposed fixes, but it was filed against commit `7baa5a4`, which is not in this repo's history. Checked against current `main`:

1. **Dedupe the vocabulary lookup** - not applicable. `resolve_vocabulary_entries` (and any vocabulary lookup) has never existed anywhere in this repo's git history, so there is nothing to dedupe.
2. **One `httpx.AsyncClient` per batch** - this is what this PR does.
3. **Keep individual DB sessions for the final write** - already the case; `_translate_and_broadcast` already opens one independent session per write, which this PR leaves untouched.

So only point 2 was actionable, and this PR implements it.

## Also in this PR

- Fixed a second caller: `portal/tts/worker.py`'s streaming fallback (for non-streaming Anthropic/Gemini) constructed a throwaway `TranslationWorker` and called `_call_llm` with the old 5-arg signature. It now passes its own client. Without this it would raise `TypeError` at runtime on that path.
- Hoisted `import httpx` to module top (it now runs on every call regardless) and annotated the new `client: httpx.AsyncClient` params, matching `portal/tts/worker.py`.
- Added `tests/test_translation_worker.py` - the first test for `TranslationWorker`. It pins the invariant this PR introduces: exactly one client is created per batch and the same instance is threaded to every language.

## Testing

- Full suite: 483 passed (`uv run pytest tests/`).
- `uv run ruff check .` clean.
- Verified the new test has teeth: breaking the client threading makes it fail on the shared-instance assertion.
