### PR TITLE
Refactor home page inline scripts and styles into static assets

### DIFF
--- a/static/css/home.css
+++ b/static/css/home.css
@@ -1,0 +1,9 @@
+@keyframes demoWave {
+  from {
+    transform: scaleY(0.4);
+  }
+
+  to {
+    transform: scaleY(1);
+  }
+}

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -1,0 +1,107 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const capabilities = [
+    "Interpretation",
+    "Live Translation",
+    "AI Captions",
+    "Speech-to-Text",
+    "Text-to-Speech",
+    "Voice Translation",
+    "Real-Time Transcription",
+    "Multilingual Subtitles",
+    "AI Dubbing",
+    "Meeting Translation",
+    "Conference Interpretation",
+    "Voice Cloning",
+    "Accessibility Services",
+    "Audio Translation",
+  ];
+
+  const audiences = [
+    "Enterprise",
+    "Global Teams",
+    "Meetings",
+    "Webinars",
+    "Conferences",
+    "Events",
+    "Town Halls",
+    "Training Programs",
+    "Customer Support",
+    "Sales Teams",
+    "Healthcare Organizations",
+    "Educational Institutions",
+    "Government Agencies",
+    "International Summits",
+    "Hybrid Events",
+  ];
+
+  const prefersReducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+
+  function setupRotator(containerId, words, interval) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+
+    let currentIndex = 0;
+
+    setInterval(() => {
+      container.classList.remove("opacity-100", "translate-y-0", "blur-0");
+      container.classList.add("opacity-0");
+
+      if (!prefersReducedMotion) {
+        container.classList.add("-translate-y-4", "blur-sm");
+      }
+
+      setTimeout(() => {
+        currentIndex = (currentIndex + 1) % words.length;
+        container.innerText = words[currentIndex];
+
+        if (!prefersReducedMotion) {
+          container.classList.remove("-translate-y-4");
+          container.classList.add("translate-y-4");
+        }
+
+        void container.offsetWidth;
+
+        container.classList.remove("opacity-0", "translate-y-4", "blur-sm");
+        container.classList.add("opacity-100");
+
+        if (!prefersReducedMotion) {
+          container.classList.add("translate-y-0", "blur-0");
+        }
+      }, 700);
+    }, interval);
+  }
+
+  function setupNavbarShadow() {
+    const navbar = document.getElementById("navbar");
+    if (!navbar) return;
+
+    const updateNavbar = () => {
+      if (window.scrollY > 20) {
+        navbar.classList.add("shadow-md");
+        navbar.classList.remove("border-transparent");
+        navbar.classList.add("border-slate-200/50");
+      } else {
+        navbar.classList.remove("shadow-md");
+        navbar.classList.remove("border-slate-200/50");
+        navbar.classList.add("border-transparent");
+      }
+    };
+
+    updateNavbar();
+    window.addEventListener("scroll", updateNavbar);
+  }
+
+  if (document.getElementById("rotator-capability")) {
+    setupRotator("rotator-capability", capabilities, 3500);
+  }
+
+  if (document.getElementById("rotator-audience")) {
+    setTimeout(() => {
+      setupRotator("rotator-audience", audiences, 3500);
+    }, 1750);
+  }
+
+  setupNavbarShadow();
+});

--- a/templates/home.html
+++ b/templates/home.html
@@ -10,8 +10,8 @@
     <script src="https://cdn.tailwindcss.com"></script>
     
     <!-- Custom CSS for animations and overrides -->
-    <link rel="stylesheet" href="{{ url_for('static', path='css/landing.css') }}" />
-    <link rel="stylesheet" href="{{ url_for('static', path='css/home.css') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/landing.css') }}?v={{ js_version }}" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/home.css') }}?v={{ js_version }}" />
     
     <script>
         tailwind.config = {
@@ -666,7 +666,7 @@
             </div>
         </div>
     </footer>
-    <script type="module" src="{{ url_for('static', path='js/home.js') }}"></script>
-    <script type="module" src="{{ url_for('static', path='js/demo-player.js') }}"></script>
+    <script type="module" src="{{ url_for('static', path='js/home.js') }}?v={{ js_version }}"></script>
+    <script type="module" src="{{ url_for('static', path='js/demo-player.js') }}?v={{ js_version }}"></script>
 </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -11,12 +11,7 @@
     
     <!-- Custom CSS for animations and overrides -->
     <link rel="stylesheet" href="{{ url_for('static', path='css/landing.css') }}" />
-    <style>
-        @keyframes demoWave {
-            from { transform: scaleY(0.4); }
-            to   { transform: scaleY(1.0); }
-        }
-    </style>
+    <link rel="stylesheet" href="{{ url_for('static', path='css/home.css') }}" />
     
     <script>
         tailwind.config = {
@@ -671,89 +666,7 @@
             </div>
         </div>
     </footer>
-
-    <!-- Script to handle rotating hero text -->
-    <script>
-        document.addEventListener("DOMContentLoaded", () => {
-            const capabilities = [
-                "Interpretation", "Live Translation", "AI Captions", "Speech-to-Text", 
-                "Text-to-Speech", "Voice Translation", "Real-Time Transcription", 
-                "Multilingual Subtitles", "AI Dubbing", "Meeting Translation", 
-                "Conference Interpretation", "Voice Cloning", "Accessibility Services", 
-                "Audio Translation"
-            ];
-
-            const audiences = [
-                "Enterprise", "Global Teams", "Meetings", "Webinars", "Conferences", 
-                "Events", "Town Halls", "Training Programs", "Customer Support", 
-                "Sales Teams", "Healthcare Organizations", "Educational Institutions", 
-                "Government Agencies", "International Summits", "Hybrid Events"
-            ];
-
-            const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-            function setupRotator(containerId, words, interval) {
-                const container = document.getElementById(containerId);
-                if (!container) return;
-                
-                let currentIndex = 0;
-                
-                setInterval(() => {
-                    // Outgoing animation
-                    container.classList.remove('opacity-100', 'translate-y-0', 'blur-0');
-                    container.classList.add('opacity-0');
-                    if (!prefersReducedMotion) {
-                        container.classList.add('-translate-y-4', 'blur-sm');
-                    }
-                    
-                    setTimeout(() => {
-                        // Swap text
-                        currentIndex = (currentIndex + 1) % words.length;
-                        container.innerText = words[currentIndex];
-                        
-                        // Reset starting position for incoming animation
-                        if (!prefersReducedMotion) {
-                            container.classList.remove('-translate-y-4');
-                            container.classList.add('translate-y-4');
-                        }
-                        
-                        // Force a reflow so the browser registers the starting position
-                        void container.offsetWidth;
-                        
-                        // Incoming animation
-                        container.classList.remove('opacity-0', 'translate-y-4', 'blur-sm');
-                        container.classList.add('opacity-100');
-                        if (!prefersReducedMotion) {
-                            container.classList.add('translate-y-0', 'blur-0');
-                        }
-                    }, 700); // Wait for the 700ms CSS transition to finish
-                    
-                }, interval);
-            }
-
-            // Start rotators with staggered timing
-            setupRotator('rotator-capability', capabilities, 3500);
-            setTimeout(() => {
-                setupRotator('rotator-audience', audiences, 3500);
-            }, 1750);
-        });
-    </script>
-
-    <!-- Script to handle sticky navbar background -->
-    <script>
-        window.addEventListener('scroll', () => {
-            const navbar = document.getElementById('navbar');
-            if (window.scrollY > 20) {
-                navbar.classList.add('shadow-md');
-                navbar.classList.remove('border-transparent');
-                navbar.classList.add('border-slate-200/50');
-            } else {
-                navbar.classList.remove('shadow-md');
-                navbar.classList.remove('border-slate-200/50');
-                navbar.classList.add('border-transparent');
-            }
-        });
-    </script>
+    <script type="module" src="{{ url_for('static', path='js/home.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='js/demo-player.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Description

Refactors the homepage template by moving inline frontend assets out of `templates/home.html` and into dedicated static files.

This PR extracts the homepage rotator and navbar scroll logic into `static/js/home.js`, moves the inline `demoWave` keyframes into `static/css/home.css`, and updates `home.html` to load these assets as static files instead of embedding them inline.

## Related Issue

Closes #254 

## Changes Made

* moved the homepage rotating hero text script from `templates/home.html` to `static/js/home.js`
* moved the sticky navbar scroll/shadow logic from `templates/home.html` to `static/js/home.js`
* moved the inline `@keyframes demoWave` block into `static/css/home.css`
* updated `templates/home.html` to remove the extracted inline `<style>` / `<script>` blocks and load `home.css` + `home.js`

## Testing

* [x] Tested locally
* [x] Existing tests pass
* [ ] Added/updated tests (if applicable)

### Manual verification

* ran `node --check static/js/home.js`
* verified the hero text rotator still works on the homepage
* verified the navbar shadow appears correctly on scroll
* verified the demo waveform animation still works after moving `demoWave` into `home.css`

## Screenshots (if applicable)

<!-- Add screenshots or recordings here -->

## Checklist

* [x] My code follows the project's coding standards
* [x] I have tested my changes
* [ ] I have updated documentation where necessary
* [x] My changes do not introduce new warnings or errors

## Additional Notes

The inline Tailwind config block in `home.html` was intentionally left unchanged, since Tailwind CDN cleanup is tracked separately and is outside the scope of this PR.
