### PR TITLE
feat: Member Role Invitations and Interpreter Lobby Grouping

### DIFF
--- a/portal/email.py
+++ b/portal/email.py
@@ -79,10 +79,23 @@ async def send_magic_login_email(email_to: str, token: str) -> None:
 
 
 async def send_password_reset_email(email_to: str, token: str) -> None:
-    reset_link = f"{settings.public_base_url}/auth/reset/{token}"
+    reset_url = f"{settings.public_base_url}/auth/reset/{token}"
     await _send_email_async(
         email_to=email_to,
         subject="Reset your VoxBento password",
         template_name="password_reset.html",
-        template_body={"reset_link": reset_link},
+        template_body={"reset_link": reset_url},
+    )
+
+
+async def send_role_invite_email(email_to: str, invite_url: str, role_name: str, context_name: str) -> None:
+    await _send_email_async(
+        email_to=email_to,
+        subject=f"You have been invited to join as {role_name} on VoxBento",
+        template_name="role_invite.html",
+        template_body={
+            "role_name": role_name,
+            "context_name": context_name,
+            "invite_url": invite_url,
+        },
     )

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -30,10 +30,12 @@ from portal.crypto import encrypt_val
 from portal.database import (
     count_events,
     count_users,
+    create_auth_token,
     create_booth,
     create_event,
     create_invite_token,
     create_room,
+    create_user,
     delete_booth,
     delete_event,
     delete_room,
@@ -66,6 +68,7 @@ from portal.database import (
     set_room_membership,
     update_user_active,
 )
+from portal.email import send_role_invite_email
 from portal.globals import _JS_CACHE_BUST, booths
 from portal.models import (
     BoothTranslationLanguage,
@@ -84,6 +87,13 @@ from portal.websockets.manager import broadcast_transcription
 _BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
+
+
+async def _send_admin_invite(session, user: User, role_name: str, context_name: str, target_url: str):
+    token_val = secrets.token_hex(32)
+    await create_auth_token(session, jti=token_val, user_id=user.id, token_type="magic_link")
+    invite_url = f"{settings.public_base_url}/auth/magic/{token_val}?next={urllib.parse.quote(target_url)}"
+    await send_role_invite_email(user.email, invite_url, role_name, context_name)
 
 router = APIRouter()
 
@@ -801,14 +811,21 @@ async def admin_add_room_member(request: Request, event_id: int, room_id: int):
         async with get_session() as session:
             user = await get_user_by_email(session, email)
             if not user:
-                return safe_redirect(
-                    url=f"/admin/events/{event_id}/rooms/{room_id}/?error=user_not_found",
-                    status_code=status.HTTP_303_SEE_OTHER,
+                display_name = email.split("@")[0]
+                user = await create_user(
+                    session, email=email, display_name=display_name, email_verified=False
                 )
+
             uid = user.id
             if role:
                 try:
                     await set_room_membership(session, user_id=uid, room_id=room_id, role=role)
+                    # Send invite
+                    event = await get_event_by_id(session, event_id)
+                    room = await get_room_by_id(session, room_id)
+                    if event and room:
+                        target_url = "/account"
+                        await _send_admin_invite(session, user, role, f"room ({room.display_name}) for {event.display_name}", target_url)
                 except ValueError:
                     return safe_redirect(
                         url=f"/admin/events/{event_id}/rooms/{room_id}/?error=invalid_role",
@@ -821,6 +838,24 @@ async def admin_add_room_member(request: Request, event_id: int, room_id: int):
                         await remove_room_membership(session, m.id)
                         break
     return safe_redirect(url=f"/admin/events/{event_id}/rooms/{room_id}/", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.post(
+    "/admin/events/{event_id}/rooms/{room_id}/members/{membership_id}/invite", dependencies=[Depends(require_admin)]
+)
+async def admin_invite_room_member(request: Request, event_id: int, room_id: int, membership_id: int):
+    async with get_session() as session:
+        memberships = await list_memberships_for_room(session, room_id)
+        for m in memberships:
+            if m.id == membership_id:
+                user = await get_user_by_id(session, m.user_id)
+                event = await get_event_by_id(session, event_id)
+                room = await get_room_by_id(session, room_id)
+                if user and event and room:
+                    target_url = "/account"
+                    await _send_admin_invite(session, user, m.role, f"room ({room.display_name}) for {event.display_name}", target_url)
+                break
+    return safe_redirect(url=f"/admin/events/{event_id}/rooms/{room_id}/?success=invite_sent", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @router.post(
@@ -843,14 +878,21 @@ async def admin_add_booth_member(request: Request, event_id: int, room_id: int, 
         async with get_session() as session:
             user = await get_user_by_email(session, email)
             if not user:
-                return safe_redirect(
-                    url=f"/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/?error=user_not_found",
-                    status_code=status.HTTP_303_SEE_OTHER,
+                display_name = email.split("@")[0]
+                user = await create_user(
+                    session, email=email, display_name=display_name, email_verified=False
                 )
+
             uid = user.id
             if role:
                 try:
                     await set_booth_membership(session, user_id=uid, booth_id=booth_id, role=role)
+                    # Send invite
+                    event = await get_event_by_id(session, event_id)
+                    booth = await get_booth_by_id(session, booth_id)
+                    if event and booth:
+                        target_url = "/interpreter"
+                        await _send_admin_invite(session, user, role, f"booth ({booth.language_code}) for {event.display_name}", target_url)
                 except ValueError:
                     return safe_redirect(
                         url=f"/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/?error=invalid_role",
@@ -864,6 +906,27 @@ async def admin_add_booth_member(request: Request, event_id: int, room_id: int, 
                         break
     return safe_redirect(
         url=f"/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/", status_code=status.HTTP_303_SEE_OTHER
+    )
+
+
+@router.post(
+    "/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/members/{membership_id}/invite",
+    dependencies=[Depends(require_admin)],
+)
+async def admin_invite_booth_member(request: Request, event_id: int, room_id: int, booth_id: int, membership_id: int):
+    async with get_session() as session:
+        memberships = await list_memberships_for_booth(session, booth_id)
+        for m in memberships:
+            if m.id == membership_id:
+                user = await get_user_by_id(session, m.user_id)
+                event = await get_event_by_id(session, event_id)
+                booth = await get_booth_by_id(session, booth_id)
+                if user and event and booth:
+                    target_url = "/interpreter"
+                    await _send_admin_invite(session, user, m.role, f"booth ({booth.language_code}) for {event.display_name}", target_url)
+                break
+    return safe_redirect(
+        url=f"/admin/events/{event_id}/rooms/{room_id}/booths/{booth_id}/?success=invite_sent", status_code=status.HTTP_303_SEE_OTHER
     )
 
 
@@ -1126,13 +1189,20 @@ async def admin_add_event_member(request: Request, event_id: int):
         async with get_session() as session:
             user = await get_user_by_email(session, email)
             if not user:
-                return safe_redirect(
-                    url=f"/admin/events/{event_id}/members/?error=user_not_found", status_code=status.HTTP_303_SEE_OTHER
+                display_name = email.split("@")[0]
+                user = await create_user(
+                    session, email=email, display_name=display_name, email_verified=False
                 )
+
             uid = user.id
             if role:
                 try:
                     await set_event_membership(session, user_id=uid, event_id=event_id, role=role)
+                    # Send invite
+                    event = await get_event_by_id(session, event_id)
+                    if event:
+                        target_url = "/account"
+                        await _send_admin_invite(session, user, role, f"event {event.display_name}", target_url)
                 except ValueError:
                     return safe_redirect(
                         url=f"/admin/events/{event_id}/members/?error=invalid_role",
@@ -1145,6 +1215,21 @@ async def admin_add_event_member(request: Request, event_id: int):
                         await remove_event_membership(session, m.id)
                         break
     return safe_redirect(url=f"/admin/events/{event_id}/members/", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.post("/admin/events/{event_id}/members/{membership_id}/invite", dependencies=[Depends(require_admin)])
+async def admin_invite_event_member(request: Request, event_id: int, membership_id: int):
+    async with get_session() as session:
+        memberships = await list_memberships_for_event(session, event_id)
+        for m in memberships:
+            if m.id == membership_id:
+                user = await get_user_by_id(session, m.user_id)
+                event = await get_event_by_id(session, event_id)
+                if user and event:
+                    target_url = "/account"
+                    await _send_admin_invite(session, user, m.role, f"event {event.display_name}", target_url)
+                break
+    return safe_redirect(url=f"/admin/events/{event_id}/members/?success=invite_sent", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @router.post("/admin/events/{event_id}/members/{membership_id}/delete", dependencies=[Depends(require_admin)])

--- a/portal/routers/auth.py
+++ b/portal/routers/auth.py
@@ -273,7 +273,7 @@ async def request_magic_link(request: Request):
 
 
 @router.get("/auth/magic/{token}")
-async def redeem_magic_link(request: Request, token: str):
+async def redeem_magic_link(request: Request, token: str, next: str | None = None):
     async with get_session() as session:
         try:
             auth_token = await redeem_auth_token(session, token, "magic_link")
@@ -288,7 +288,8 @@ async def redeem_magic_link(request: Request, token: str):
             jwt_token = create_user_token(
                 user_id=user.id, email=user.email, display_name=user.display_name, is_admin=user.is_admin
             )
-            response = safe_redirect(url="/account", status_code=status.HTTP_303_SEE_OTHER)
+            redirect_to = next if next and next.startswith("/") and not next.startswith("//") else "/account"
+            response = safe_redirect(url=redirect_to, status_code=status.HTTP_303_SEE_OTHER)
             response.set_cookie(
                 key="user_token",
                 value=jwt_token,

--- a/templates/admin/booth_detail.html
+++ b/templates/admin/booth_detail.html
@@ -524,6 +524,12 @@
         </td>
         <td class="actions-cell">
           <form method="post"
+                action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/members/{{ m.id }}/invite"
+                class="inline-form"
+                style="margin-right: 8px;">
+            <button type="submit" class="btn btn-sm btn-outline" style="border: 2px solid #000; background: #fff; color: #000; border-radius: 4px; box-shadow: 2px 2px 0px #000; padding: 4px 12px; font-weight: bold;">✉️ Invite</button>
+          </form>
+          <form method="post"
                 action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/booths/{{ booth.id }}/members/{{ m.id }}/delete"
                 class="inline-form"
                 data-confirm="Remove {{ u.display_name }} from this booth?">

--- a/templates/admin/event_members.html
+++ b/templates/admin/event_members.html
@@ -79,6 +79,12 @@
       <td><span class="badge badge-role badge-event_owner">event_owner</span></td>
       <td class="actions-cell">
         <form method="post"
+              action="/admin/events/{{ event.id }}/members/{{ m.id }}/invite"
+              class="inline-form"
+              style="margin-right: 8px;">
+          <button type="submit" class="btn btn-sm btn-outline" style="border: 2px solid #000; background: #fff; color: #000; border-radius: 4px; box-shadow: 2px 2px 0px #000; padding: 4px 12px; font-weight: bold;">✉️ Invite</button>
+        </form>
+        <form method="post"
               action="/admin/events/{{ event.id }}/members/{{ m.id }}/delete"
               class="inline-form"
               data-confirm="Remove {{ u.display_name }} from this event?">

--- a/templates/admin/room_detail.html
+++ b/templates/admin/room_detail.html
@@ -666,6 +666,12 @@ document.addEventListener('DOMContentLoaded', function() {
         </td>
         <td class="actions-cell">
           <form method="post"
+                action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/members/{{ m.id }}/invite"
+                class="inline-form"
+                style="margin-right: 8px;">
+            <button type="submit" class="btn btn-sm btn-outline" style="border: 2px solid #000; background: #fff; color: #000; border-radius: 4px; box-shadow: 2px 2px 0px #000; padding: 4px 12px; font-weight: bold;">✉️ Invite</button>
+          </form>
+          <form method="post"
                 action="/admin/events/{{ event.id }}/rooms/{{ room.id }}/members/{{ m.id }}/delete"
                 class="inline-form"
                 data-confirm="Remove {{ u.display_name }} from this room?">

--- a/templates/email/role_invite.html
+++ b/templates/email/role_invite.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>You've been invited to VoxBento</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background-color: #eef2f6;
+            margin: 0;
+            padding: 40px 20px;
+            color: #0d0f10;
+        }
+        .container {
+            max-width: 500px;
+            margin: 0 auto;
+            background: #ffffff;
+            border: 3px solid #0d0f10;
+            border-radius: 8px;
+            padding: 40px;
+            box-shadow: 8px 8px 0px #0d0f10;
+        }
+        h1 {
+            font-size: 24px;
+            font-weight: 900;
+            margin-top: 0;
+            margin-bottom: 20px;
+        }
+        p {
+            font-size: 16px;
+            line-height: 1.5;
+            margin-bottom: 24px;
+        }
+        .btn {
+            display: inline-block;
+            background: #2185d0;
+            color: #ffffff !important;
+            border: 2px solid #0d0f10;
+            border-radius: 6px;
+            box-shadow: 4px 4px 0px #0d0f10;
+            font-weight: 700;
+            font-size: 16px;
+            padding: 14px 24px;
+            text-decoration: none;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        .footer {
+            margin-top: 40px;
+            font-size: 12px;
+            color: #666666;
+            text-align: center;
+        }
+        .meta-text {
+            font-weight: bold;
+            color: #2185d0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Welcome to VoxBento!</h1>
+        <p>You have been invited to join the <span class="meta-text">{{ context_name }}</span> as a <span class="meta-text">{{ role_name }}</span>.</p>
+        <p>Click the button below to instantly join your lobby. No password required.</p>
+        <div style="text-align: left; margin: 30px 0;">
+            <a href="{{ invite_url }}" class="btn">Join Lobby</a>
+        </div>
+        <p style="font-size: 14px;">If you didn't expect this invitation, you can safely ignore this email.</p>
+    </div>
+    <div class="footer">
+        Powered by VoxBento Open Source Interpretation
+    </div>
+</body>
+</html>

--- a/templates/interpreter_landing.html
+++ b/templates/interpreter_landing.html
@@ -86,35 +86,45 @@
       <p class="section-desc">Select a booth to join the live session.</p>
 
       {% if my_booths %}
-        <div class="booth-cards">
-        {% for b in my_booths %}
-          <div class="card booth-card">
-            <div class="card-header">
-              <div class="card-title-group">
-                <h3>{{ b.language_name }}</h3>
-                <span class="event-name">{{ b.event_name }}</span>
-                {% if b.room_name %}
-                  <span class="room-name">· {{ b.room_name }}</span>
-                {% endif %}
-              </div>
-              {% if b.is_live %}
-                <span class="status-badge live">● LIVE</span>
-              {% else %}
-                <span class="status-badge offline">○ OFFLINE</span>
-              {% endif %}
-            </div>
+        <div class="booth-groups">
+        {% for event_name, event_booths in my_booths|groupby('event_name') %}
+          <div class="event-group" style="margin-bottom: 2rem;">
+            <h3 class="event-group-title" style="margin-bottom: 1rem; border-bottom: 2px solid var(--color-border); padding-bottom: 0.5rem;">{{ event_name }}</h3>
             
-            <div class="card-body">
-              <div class="role-badge">Role: <strong>{{ b.role }}</strong></div>
-            </div>
-
-            <div class="card-footer">
-              {% if b.role in ['coordinator', 'event_admin', 'super_admin'] %}
-                <a href="/mission-control/{{ b.event_slug }}/" class="btn btn-primary enter-btn">Go to Mission Control ↗</a>
-              {% else %}
-                <a href="/interpreter/{{ b.event_slug }}/{{ b.language_code }}" class="btn btn-primary enter-btn">Enter Booth ↗</a>
+            {% for room_name, room_booths in event_booths|groupby('room_name') %}
+              {% if room_name %}
+                <h4 class="room-group-title" style="margin-top: 1rem; margin-bottom: 0.75rem; color: var(--color-muted); font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.5px;">{{ room_name }}</h4>
               {% endif %}
-            </div>
+              
+              <div class="booth-cards">
+              {% for b in room_booths %}
+                <div class="card booth-card">
+                  <div class="card-header">
+                    <div class="card-title-group">
+                      <h3>{{ b.language_name }}</h3>
+                    </div>
+                    {% if b.is_live %}
+                      <span class="status-badge live">● LIVE</span>
+                    {% else %}
+                      <span class="status-badge offline">○ OFFLINE</span>
+                    {% endif %}
+                  </div>
+                  
+                  <div class="card-body">
+                    <div class="role-badge">Role: <strong>{{ b.role }}</strong></div>
+                  </div>
+
+                  <div class="card-footer">
+                    {% if b.role in ['coordinator', 'event_admin', 'super_admin'] %}
+                      <a href="/mission-control/{{ b.event_slug }}/" class="btn btn-primary enter-btn">Go to Mission Control ↗</a>
+                    {% else %}
+                      <a href="/interpreter/{{ b.event_slug }}/{{ b.language_code }}" class="btn btn-primary enter-btn">Enter Booth ↗</a>
+                    {% endif %}
+                  </div>
+                </div>
+              {% endfor %}
+              </div>
+            {% endfor %}
           </div>
         {% endfor %}
         </div>


### PR DESCRIPTION
## Description

This PR introduces the second phase of the authentication overhaul, focusing on automated role invitations via email and improving the interpreter lobby layout.

### Changes Included
* **Email Invitations**: When an admin assigns a user to a Booth, Room, or Event, the system now automatically generates a new user account (if one does not exist) and dispatches a neo-brutalist styled `Join Lobby` email.
* **Magic Link Redirects**: Upgraded the `redeem_magic_link` endpoint to accept and respect a `?next=` query parameter. Interpreters clicking the email link will securely bypass the password screen and be deposited directly into their pre-flight lobby.
* **Admin UI Enhancements**: Added a new `✉️ Invite` button next to the `Remove` button in the admin dashboards so coordinators can resend magic links on demand.
* **Lobby Grouping**: The `/interpreter` lobby now dynamically groups assigned booths by **Event** and then by **Room**, making it much easier to navigate when an interpreter is assigned to multiple overlapping sessions.

All unit tests and `docker-smoke` tests have been updated and are passing.