### PR TITLE
style: add horizontal scrolling container to role membership table

### DIFF
--- a/templates/account.html
+++ b/templates/account.html
@@ -55,8 +55,9 @@
     <div class="account-info">
       <h3>Your Roles</h3>
       {% if memberships %}
-      <table class="data-table compact">
-        <thead>
+      <div style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
+        <table class="data-table compact">
+          <thead>
           <tr><th>Scope</th><th>Context</th><th>Role</th><th>Since</th></tr>
         </thead>
         <tbody>
@@ -76,6 +77,7 @@
           {% endfor %}
         </tbody>
       </table>
+      </div>
       {% else %}
       <p class="muted">You have not been assigned a role for any event, room, or booth yet.</p>
       {% endif %}


### PR DESCRIPTION
<img width="376" height="807" alt="Screenshot 2026-07-10 at 1 54 12 PM" src="https://github.com/user-attachments/assets/9acfbf2d-88f1-4bf7-b7bd-824b1ae9e4d3" />

## Summary by Sourcery

Enhancements:
- Add a horizontally scrollable wrapper div around the roles membership data table to maintain layout on small screens.