### PR TITLE
test: add listener route tests

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -25,7 +25,7 @@ conditions, run every verification command, and update your row when done.
 | [011](011-tts-pipeline-cleanup.md) | Stop leaking `_RoomTTSPipeline` consumer tasks | P2 | M | — | DONE |
 | [012](012-demo-generation-race.md) | Serialize demo regen + track background tasks | P3 | S | — | DONE |
 | [013](013-dedupe-translation-key.md) | De-duplicate translation API-key + LLM call helpers | P2 | S | — | DONE |
-| [014](014-route-tests.md) | Add route tests for `demo.py` and `listener.py` | P2 | M | 012 | TODO |
+| [014](014-route-tests.md) | Add route tests for `demo.py` and `listener.py` | P2 | M | 012 | DONE |
 | [015](015-debug-default-false.md) | Default `debug` False; gate SQL echo in prod | P2 | S | 005 | DONE |
 | [016](016-listener-rate-limit.md) | Rate-limit listener join-code validation | P3 | M | — | DONE |
 

--- a/tests/test_listener_routes.py
+++ b/tests/test_listener_routes.py
@@ -1,0 +1,149 @@
+"""
+Tests for listener routes.
+
+Covers:
+- Missing event
+- Join page rendering
+- Join code validation
+- Cookie creation
+- Audio delay endpoint authorization
+- Missing room
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ["BOOTH_ACCESS_TOKEN"] = ""
+os.environ["ADMIN_PASSWORD"] = "test-admin-pass"
+
+import pytest
+
+from portal.config import settings
+
+settings.admin_password = "test-admin-pass"
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    """Set up an in-memory database for the FastAPI app."""
+    from portal.database import configure, dispose, init_db
+
+    configure("sqlite+aiosqlite://")
+    await init_db()
+    yield
+    await dispose()
+
+@pytest.fixture
+async def seed_event():
+    """Seed an event, room, and booth."""
+    from portal.database import create_booth, create_event, create_room, get_session
+
+    async with get_session() as s:
+        event = await create_event(s, slug="testcon", display_name="TestCon 2026")
+        room = await create_room(s, event_id=event.id, display_name="Main Hall")
+        booth = await create_booth(
+            s,
+            event_id=event.id,
+            room_id=room.id,
+            language_code="en",
+            language_name="English",
+        )
+    return event, room, booth
+
+
+def _client():
+    from httpx import ASGITransport, AsyncClient
+
+    from fastapi_app import app
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+
+class TestListenerRoutes:
+
+    @pytest.mark.anyio
+    async def test_missing_event_returns_404(self):
+        async with _client() as c:
+            resp = await c.get("/listener/does-not-exist")
+
+        assert resp.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_listener_without_code_renders_join_form(self, seed_event):
+        event, _, _ = seed_event
+
+        async with _client() as c:
+            resp = await c.get(f"/listener/{event.slug}")
+
+        assert resp.status_code == 200
+        assert b"Join Event" in resp.content
+        assert b"Enter the join code" in resp.content
+
+
+    @pytest.mark.anyio
+    async def test_invalid_join_code_shows_error(self, seed_event):
+        event, _, _ = seed_event
+
+        from portal.database import get_session
+
+        async with get_session() as s:
+            db_event = await s.get(type(event), event.id)
+            db_event.listener_join_code = "ROOM42"
+
+        async with _client() as c:
+            resp = await c.get(f"/listener/{event.slug}?code=WRONG")
+
+        assert resp.status_code == 200
+        assert b"Invalid join code." in resp.content
+
+
+    @pytest.mark.anyio
+    async def test_valid_join_code_sets_cookie(self, seed_event):
+        event, _, _ = seed_event
+
+        from portal.database import get_session
+
+        async with get_session() as s:
+            db_event = await s.get(type(event), event.id)
+            db_event.listener_join_code = "ROOM42"
+
+        async with _client() as c:
+            resp = await c.get(f"/listener/{event.slug}?code=ROOM42")
+
+        assert resp.status_code == 200
+        assert "listener_code_testcon" in resp.headers["set-cookie"]
+
+    
+    @pytest.mark.anyio
+    async def test_audio_delay_requires_listener_access(self, seed_event):
+        event, room, _ = seed_event
+
+        async with _client() as c:
+            resp = await c.get(
+                f"/listener/{event.slug}/rooms/{room.id}/audio-delay"
+            )
+
+        assert resp.status_code == 403
+
+
+    @pytest.mark.anyio
+    async def test_audio_delay_unknown_room_returns_404(self, seed_event):
+        event, _, _ = seed_event
+
+        from portal.database import get_session
+
+        async with get_session() as s:
+            db_event = await s.get(type(event), event.id)
+            db_event.listener_join_code = "ROOM42"
+
+        async with _client() as c:
+            resp = await c.get(
+                f"/listener/{event.slug}/rooms/9999/audio-delay?code=ROOM42"
+            )
+
+        assert resp.status_code == 404
+
+
+    

--- a/tests/test_listener_routes.py
+++ b/tests/test_listener_routes.py
@@ -115,7 +115,7 @@ class TestListenerRoutes:
         assert resp.status_code == 200
         assert "listener_code_testcon" in resp.headers["set-cookie"]
 
-    
+
     @pytest.mark.anyio
     async def test_audio_delay_requires_listener_access(self, seed_event):
         event, room, _ = seed_event
@@ -146,4 +146,3 @@ class TestListenerRoutes:
         assert resp.status_code == 404
 
 
-    


### PR DESCRIPTION
## Description

This PR adds dedicated route tests for the listener endpoints to improve coverage of listener access flows. It verifies route behavior for missing events, join code validation, cookie creation, and audio delay endpoint authorization while complementing the existing demo and listener rate-limit tests.

## Related Issue

Closes #216 

## Changes Made

- Added tests/test_listener_routes.py with dedicated route tests for listener.py
- Added coverage for listener join page rendering, join code validation, cookie creation, and audio delay endpoint behavior
- Updated plans/README.md to mark Plan 014 as DONE

## Testing

The following commands were run successfully:

```bash
uv run pytest tests/test_listener_routes.py -q

API_KEY_ENCRYPTION_KEY="ci-test-encryption-key-must-be-32-chars-long" uv run pytest tests/ -q
```

Describe how you tested these changes.

- [x] Tested locally
- [x] Existing tests pass
- [x] Added/updated tests (if applicable)

## Screenshots (if applicable)

N/A (test-only changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] My changes do not introduce new warnings or errors

## Additional Notes

This PR focuses on the missing listener route coverage. The repository already contains tests/test_demo_routes.py, so the work here complements the existing demo and listener rate-limit tests rather than duplicating them.
