### PR TITLE
docs: Fix broken markdown images and internal links (#36)

### DIFF
--- a/docs/admin/dashboard-guide.mdx
+++ b/docs/admin/dashboard-guide.mdx
@@ -6,8 +6,8 @@ description: "A visual map of the Voxbento Admin Panel, explaining the navigatio
 
 The Voxbento Admin Panel (often referred to as Mission Control) is the central hub for managing your interpretation infrastructure. Depending on your role (`super_admin` or `event_owner`), your view of the dashboard will be tailored to what you have permission to manage.
 
-*(Placeholder: Add your `admin_dashboard.png` screenshot here)*
-`![Mission Control Dashboard](pathname:///static/admin_dashboard.png)`
+*(TODO: Add `admin_dashboard.png` screenshot here)*
+![Mission Control Dashboard](pathname:///static/admin_dashboard.png)
 
 ## 1. Global Navigation (Sidebar)
 

--- a/docs/api/booths/events.mdx
+++ b/docs/api/booths/events.mdx
@@ -16,7 +16,7 @@ POST /api/events/{event_slug}/booths
 
 ### Authentication
 
-A Bearer token is required. See the [Authentication guide](/api/authentication) for details on obtaining a token.
+A Bearer token is required. See the [Authentication guide](../authentication.mdx) for details on obtaining a token.
 
 ### Path Parameters
 
@@ -138,7 +138,7 @@ curl https://voxbento.com/api/events/pycon2026/booths \
 
 **`event_slug`** *(string)* — The event slug echoed from the request path.
 
-**`booths`** *(array)* — An array of booth state objects. Each object has the same shape as the response from [GET booth state](/api/booths/state).
+**`booths`** *(array)* — An array of booth state objects. Each object has the same shape as the response from [GET booth state](./state.mdx).
 
   <details>
 <summary>Booth object fields</summary>

--- a/docs/api/booths/state.mdx
+++ b/docs/api/booths/state.mdx
@@ -19,7 +19,7 @@ For the legacy endpoint, construct `booth_id` as `{event_slug}-{language_code}` 
 
 ## Authentication
 
-Both endpoints require a Bearer token in the `Authorization` header. Obtain a token from `POST /api/auth/token`. See the [Authentication guide](/api/authentication) for the full token flow.
+Both endpoints require a Bearer token in the `Authorization` header. Obtain a token from `POST /api/auth/token`. See the [Authentication guide](../authentication.mdx) for the full token flow.
 
 :::warning
 Requests without a valid Bearer token receive a `403 Forbidden` response.

--- a/docs/api/booths/whip-whep.mdx
+++ b/docs/api/booths/whip-whep.mdx
@@ -19,7 +19,7 @@ The WHIP URL is the endpoint your interpreter client POSTs a WebRTC SDP offer to
 
 ### Authentication
 
-Both WHIP URL endpoints require a Bearer token. See the [Authentication guide](/api/authentication) for details on obtaining a token.
+Both WHIP URL endpoints require a Bearer token. See the [Authentication guide](../authentication.mdx) for details on obtaining a token.
 
 :::warning
 This endpoint enforces the active-interpreter rule. Only the participant currently designated as the active interpreter receives a successful response. All other callers receive `403 Forbidden`.

--- a/docs/api/overview.mdx
+++ b/docs/api/overview.mdx
@@ -22,7 +22,7 @@ All request bodies must be sent as `application/json`, and all successful respon
 
 ## Available Endpoints
 
-The tables below list every REST and WebSocket endpoint exposed by the Voxbento API. Endpoints marked **Bearer** require an `Authorization: Bearer {token}` header — see [Authentication](/api/authentication) for details.
+The tables below list every REST and WebSocket endpoint exposed by the Voxbento API. Endpoints marked **Bearer** require an `Authorization: Bearer {token}` header — see [Authentication](./authentication.mdx) for details.
 
 ### REST Endpoints
 
@@ -88,22 +88,22 @@ Use `mediamtx_ok` to determine whether the media server is reachable before star
 
 ## Explore the API
 
-### [Authentication](/api/authentication)
+### [Authentication](./authentication.mdx)
 
     Learn how to obtain a bearer JWT and include it in your API requests.
   
 
-  ### [Booth State](/api/booths/state)
+  ### [Booth State](./booths/state.mdx)
 
     Query the live state of any interpreter booth, including participant list and active interpreter.
   
 
-  ### [WHIP & WHEP URLs](/api/booths/whip-whep)
+  ### [WHIP & WHEP URLs](./booths/whip-whep.mdx)
 
     Retrieve the WHIP ingest and WHEP playback URLs for a booth's audio channel.
   
 
-  ### [Events & Booths](/api/booths/events)
+  ### [Events & Booths](./booths/events.mdx)
 
     Create and list in-memory booths scoped to a specific event slug.
   

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,22 +6,22 @@ description: "Voxbento is a browser-first simultaneous interpretation platform. 
 
 Voxbento lets you run professional simultaneous interpretation for any live event, entirely in the browser. Interpreters monitor the floor session through a built-in Jitsi console and broadcast translated audio directly to attendees via WebRTC — with sub-second latency and seamless handoff between interpreter shifts.
 
-### [Quick Start](/quickstart)
+### [Quick Start](./quickstart.mdx)
 
     Set up your first event, booth, and invite interpreters in minutes.
   
 
-  ### [How It Works](/how-it-works)
+  ### [How It Works](./how-it-works.mdx)
 
     Understand the interpretation flow from floor audio to listener playback.
   
 
-  ### [Admin Guide](/admin/events-and-rooms)
+  ### [Admin Guide](./admin/events-and-rooms.mdx)
 
     Create events, manage rooms, assign roles, and generate invite tokens.
   
 
-  ### [API Reference](/api/overview)
+  ### [API Reference](./api/overview.mdx)
 
     Integrate Voxbento into your event platform using the REST and WebSocket APIs.
   

--- a/docs/interpreter/going-live.mdx
+++ b/docs/interpreter/going-live.mdx
@@ -16,7 +16,7 @@ Before you attempt to go live, make sure the following are in place:
 
 ### Joined the Booth
 
-    You have opened the booth via an invite link or your registered account dashboard. See [Joining a Booth](/interpreter/joining-a-booth) if you haven't done this yet.
+    You have opened the booth via an invite link or your registered account dashboard. See [Joining a Booth](./joining-a-booth.mdx) if you haven't done this yet.
   
 
   ### Mic Permission Granted

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -59,22 +59,22 @@ Python is never in the audio path. MediaMTX handles all WebRTC termination and p
 
 ## Explore Voxbento
 
-### [Quickstart](/quickstart)
+### [Quickstart](./quickstart.mdx)
 
 Set up your first event and get an interpreter live in under ten minutes.
   
 
-  ### [How It Works](/how-it-works)
+  ### [How It Works](./how-it-works.mdx)
 
     Understand the full WebRTC pipeline from interpreter mic to listener playback.
   
 
-  ### [Events & Rooms](/admin/events-and-rooms)
+  ### [Events & Rooms](./admin/events-and-rooms.mdx)
 
     Learn how to create and manage events, rooms, and language booths.
   
 
-  ### [API Overview](/api/overview)
+  ### [API Overview](./api/overview.mdx)
 
     Explore the REST and WebSocket APIs that power Voxbento's coordination layer.
   

--- a/docs/listener/attending-an-event.mdx
+++ b/docs/listener/attending-an-event.mdx
@@ -14,8 +14,8 @@ Every Voxbento event has a dedicated listener page at `/listener/{event_slug}`. 
 https://voxbento.com/listener/pycon2026
 ```
 
-*(Placeholder: Add your listener selection screenshot here)*
-`![Listener Page Selection](pathname:///static/listener_selection.png)`
+*(TODO: Add listener selection screenshot here)*
+![Listener Page Selection](pathname:///static/listener_selection.png)
 
 This page lists every language booth that is active for the event. No login is required as long as you have a valid session — either from your invite link or from a publicly accessible event URL.
 
@@ -61,8 +61,8 @@ The listener page shows all available language booths for this event. Click the 
 If your browser's autoplay policy prevents audio from starting automatically, a **Play** button appears. Click it once to begin playback.
   ### Hear live interpretation
 
-*(Placeholder: Add your listener playback screenshot here)*
-`![Listener Playback](pathname:///static/listener_playback.png)`
+*(TODO: Add listener playback screenshot here)*
+![Listener Playback](pathname:///static/listener_playback.png)
 
 Audio starts within a second over WebRTC. You are now listening to live interpretation. Leave this tab open for the duration of the session.
 

--- a/docs/listener/live-captions.mdx
+++ b/docs/listener/live-captions.mdx
@@ -12,8 +12,8 @@ Voxbento can display live captions alongside the audio stream for any interpreta
 
 ## How Live Captions Are Delivered
 
-*(Placeholder: Add your listener captions screenshot here)*
-`![Live Captions Overlay](pathname:///static/listener_captions.png)`
+*(TODO: Add listener captions screenshot here)*
+![Live Captions Overlay](pathname:///static/listener_captions.png)
 
 Captions arrive through a persistent connection that the listener page opens automatically when you select a language booth. You do not need to enable, install, or configure anything. If transcription is active for a booth, captions simply appear; if it is not enabled, the caption area stays hidden.
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -10,7 +10,7 @@ This guide walks you through the complete flow of setting up a Voxbento event fr
 
 Before you begin, make sure you have:
 
-- A running Voxbento instance with MediaMTX and Jitsi available. See [Deployment](/configuration/deployment) if you need to stand one up.
+- A running Voxbento instance with MediaMTX and Jitsi available. See [Deployment](./configuration/deployment.mdx) if you need to stand one up.
 - Admin credentials (the `ADMIN_PASSWORD` you configured in your `.env` file).
 
 ### Log in to the admin panel
@@ -152,6 +152,6 @@ For devices that do not support WebRTC well, Voxbento automatically falls back t
 
 Now that your first booth is live, explore these topics to get more from Voxbento:
 
-- [**How It Works**](/how-it-works) — understand the full audio pipeline and interpreter handoff mechanism.
-- [**Events & Rooms**](/admin/events-and-rooms) — manage multiple events, rooms, and booths across your organization.
-- [**API Overview**](/api/overview) — integrate Voxbento data into your event management tooling via the REST and WebSocket APIs.
+- [**How It Works**](./how-it-works.mdx) — understand the full audio pipeline and interpreter handoff mechanism.
+- [**Events & Rooms**](./admin/events-and-rooms.mdx) — manage multiple events, rooms, and booths across your organization.
+- [**API Overview**](./api/overview.mdx) — integrate Voxbento data into your event management tooling via the REST and WebSocket APIs.


### PR DESCRIPTION
- Fixed image placeholders wrapped in backticks to use standard Markdown image tags
- Standardized placeholder text as TODO notes instead of generic placeholders
- Updated internal Docusaurus absolute links to use relative paths (e.g. `./` or `../`) and explicitly included `.mdx` file extensions to resolve 404 dead link issues when running `npx docusaurus build`.

## Summary by Sourcery

Fix broken internal documentation links and clean up placeholder screenshots in the Voxbento docs.

Documentation:
- Update internal Docusaurus links to use correct relative `.mdx` paths to prevent 404s in built docs.
- Standardize screenshot placeholders as TODO notes and convert them to valid Markdown image tags referencing static assets.