### PR TITLE
Add stacked captions mode to listener page

### DIFF
--- a/templates/listener-event.html
+++ b/templates/listener-event.html
@@ -108,6 +108,7 @@
               <option value="original">Original</option>
               <option value="translated">Translated</option>
               <option value="side-by-side">Side-by-Side</option>
+              <option value="stacked">Stacked</option>
             </select>
           </div>
           <div class="flex flex-col gap-1 listener-hidden" id="translation-lang-group" style="display:none;">
@@ -436,25 +437,42 @@
 
   function updateCaptionLayout() {
     var mode = captionModeSelect.value;
+    var contentArea = document.getElementById('captions-content-area');
     var colOrig = document.getElementById('captions-col-original');
     var colTrans = document.getElementById('captions-col-translated');
     var transGroup = document.getElementById('translation-lang-group');
     
     if (mode === 'original') {
+      contentArea.style.flexDirection = 'row';
       colOrig.style.display = 'flex';
       colTrans.style.display = 'none';
       transGroup.style.display = 'none';
     } else if (mode === 'translated') {
+      contentArea.style.flexDirection = 'row';
       colOrig.style.display = 'none';
       colTrans.style.display = 'flex';
       colTrans.style.borderLeft = 'none';
+      colTrans.style.borderTop = 'none';
       colTrans.style.paddingLeft = '0';
+      colTrans.style.paddingTop = '0';
       transGroup.style.display = 'flex';
     } else if (mode === 'side-by-side') {
+      contentArea.style.flexDirection = 'row';
       colOrig.style.display = 'flex';
       colTrans.style.display = 'flex';
       colTrans.style.borderLeft = '1px solid #444';
+      colTrans.style.borderTop = 'none';
       colTrans.style.paddingLeft = '20px';
+      colTrans.style.paddingTop = '0';
+      transGroup.style.display = 'flex';
+    } else if (mode === 'stacked') {
+      contentArea.style.flexDirection = 'column';
+      colOrig.style.display = 'flex';
+      colTrans.style.display = 'flex';
+      colTrans.style.borderLeft = 'none';
+      colTrans.style.borderTop = '1px solid #444';
+      colTrans.style.paddingLeft = '0';
+      colTrans.style.paddingTop = '20px';
       transGroup.style.display = 'flex';
     }
   }


### PR DESCRIPTION
Added a 'Stacked' option to the listener captions mode selector that shows the original transcript on top and the translated transcript below, using a vertical flex layout with a top divider.

<img width="3648" height="4224" alt="2026-07-28_23-25-23" src="https://github.com/user-attachments/assets/4ae301f6-016f-43d3-b1df-149cc1e3ce5c" />

## Summary by Sourcery

New Features:
- Introduce a 'Stacked' captions mode that displays original and translated transcripts vertically with a divider.