### PR TITLE
Fix booth going live on join; drive broadcast from Mission Control

### DIFF
--- a/docs/interpreter/going-live.mdx
+++ b/docs/interpreter/going-live.mdx
@@ -29,6 +29,12 @@ Before you attempt to go live, make sure the following are in place:
     Your session token or account assignment grants you the `interpreter` or `room_coordinator` role. Listeners cannot go live.
   
 
+:::info Broadcast is enabled from Mission Control
+Whether a booth is broadcasting is controlled by a coordinator or admin from **Mission Control** (the **Go Live / Stop** toggle). When broadcast is turned **On**, the active interpreter's audio starts publishing automatically. When it is turned **Off**, publishing stops for the whole booth immediately.
+
+Opening or **reloading** the booth page never puts you on air by itself — you land in `OFF LIVE` / `STANDBY`. A coordinator must have broadcast enabled (or re-enable it) from Mission Control for your audio to reach listeners.
+:::
+
 ## Preflight Check
 
 When you first open the booth, Voxbento automatically runs a preflight check before you can go live.

--- a/docs/interpreter/going-live.mdx
+++ b/docs/interpreter/going-live.mdx
@@ -29,10 +29,10 @@ Before you attempt to go live, make sure the following are in place:
     Your session token or account assignment grants you the `interpreter` or `room_coordinator` role. Listeners cannot go live.
   
 
-:::info Broadcast is enabled from Mission Control
-Whether a booth is broadcasting is controlled by a coordinator or admin from **Mission Control** (the **Go Live / Stop** toggle). When broadcast is turned **On**, the active interpreter's audio starts publishing automatically. When it is turned **Off**, publishing stops for the whole booth immediately.
+:::info Broadcast is controlled from Mission Control
+Whether a booth is broadcasting is controlled by a coordinator or admin from **Mission Control** (the **Go Live / Stop** toggle). When broadcast is turned **On**, the active interpreter's audio starts publishing automatically and immediately — no page reload required. When it is turned **Off**, publishing stops for the whole booth immediately.
 
-Opening or **reloading** the booth page never puts you on air by itself — you land in `OFF LIVE` / `STANDBY`. A coordinator must have broadcast enabled (or re-enable it) from Mission Control for your audio to reach listeners.
+The booth page stays in lock-step with this toggle. A booth defaults to **Off** (`OFF LIVE`) until a coordinator turns it on, so simply opening the page never puts you on air on its own. If you reload while broadcast is already **On**, the active interpreter resumes publishing automatically.
 :::
 
 ## Preflight Check

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -260,6 +260,17 @@ class BoothRegistry:
         async with self._lock:
             booth = self._get_or_create_booth(booth_id, language, channel_id)
             booth.broadcast_unlocked = unlocked
+            # Locking the booth (Mission Control "Stop") forces every publisher
+            # offline so the room truly stops: mic + ingest flags are cleared and
+            # the aggregate ingest status returns to disconnected. This keeps the
+            # booth/Mission Control UI consistent even if a client is slow to tear
+            # down its own WHIP publish.
+            if not unlocked:
+                for participant in booth.participants.values():
+                    participant.mic_active = False
+                    participant.ingest_connected = False
+                    participant.updated_at = utc_now_iso()
+                booth.ingest_status = "disconnected"
             return booth.as_public_dict()
 
     async def set_active_interpreter(

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -164,7 +164,9 @@ async def mission_control_grid(request: Request, event_slug: str, user=Depends(r
                     "active_interpreter_id": None,
                     "handoff_state": "idle",
                     "handoff_initiator_id": None,
-                    "broadcast_unlocked": db_b.broadcast_unlocked,
+                    # Broadcast on/off is live, in-memory session state owned by
+                    # Mission Control. A booth with no active session is off.
+                    "broadcast_unlocked": False,
                     "ingest_status": "disconnected",
                     "participants": [],
                     "chat_messages": [],

--- a/portal/websockets/manager.py
+++ b/portal/websockets/manager.py
@@ -296,6 +296,18 @@ async def _handle_set_broadcast_unlocked(ws: WebSocket, session: Session, data: 
         logging.getLogger(__name__).error(f"Error persisting broadcast lock: {e}")
     try:
         state = await booths.set_broadcast_unlocked(session.booth_id, unlocked, session.language, session.channel_id)
+        # Locking the booth must immediately stop everything tied to it: the
+        # transcription worker (which pulls audio independently of any browser)
+        # is torn down here so captions stop even if the interpreter's client is
+        # unresponsive. Publisher mic/ingest state is already reset inside
+        # set_broadcast_unlocked.
+        if not unlocked:
+            try:
+                from portal.transcription.worker import stop_transcription_worker
+
+                await stop_transcription_worker(session.booth_id)
+            except Exception as e:
+                logging.getLogger(__name__).warning(f"Failed to stop transcription on lock: {e}")
         await manager.broadcast(session.booth_id, {"type": "booth:state", "state": state})
         await listener_manager.broadcast(session.booth_id, {"type": "booth:state", "state": state})
     except Exception as exc:

--- a/portal/websockets/manager.py
+++ b/portal/websockets/manager.py
@@ -5,13 +5,9 @@ import logging
 from dataclasses import dataclass
 
 from fastapi import WebSocket
-from sqlalchemy import select
 
 from portal.auth import can_perform_role
-from portal.booth_identity import parse_booth_id
-from portal.database import get_session as get_db_session
 from portal.globals import booths
-from portal.models import DBBooth, Event, Room
 
 
 @dataclass
@@ -185,19 +181,11 @@ async def _handle_join(ws: WebSocket, session: Session, data: dict) -> None:
     session.participant_id = participant.participant_id
     session.language = language
     session.channel_id = channel_id
-    if not state.get("broadcast_unlocked"):
-        try:
-            _slug, _lang = parse_booth_id(session.booth_id)
-            async with get_db_session() as _db:
-                _db_booth = await _db.scalar(
-                    select(DBBooth).join(Event).where(Event.slug == _slug, DBBooth.language_code == _lang)
-                )
-                if _db_booth and _db_booth.broadcast_unlocked:
-                    state = await booths.set_broadcast_unlocked(session.booth_id, True, language, channel_id)
-        except Exception as e:
-            import logging
-
-            logging.getLogger(__name__).warning(f"Failed to set broadcast unlocked: {e}")
+    # Broadcast on/off is a live, in-memory state owned exclusively by Mission
+    # Control (the Go Live / Stop toggle). Joining or reloading the booth must
+    # never change it, so we deliberately do NOT re-apply any persisted value
+    # here — doing so would flip an interpreter live (or Mission Control to
+    # "Stop") simply because they reconnected.
     await ws.send_text(
         json.dumps({"type": "booth:joined", "participant_id": participant.participant_id, "state": state})
     )
@@ -278,22 +266,6 @@ async def _handle_set_broadcast_unlocked(ws: WebSocket, session: Session, data: 
         )
         return
     unlocked = bool(data.get("unlocked"))
-    try:
-        event_slug, language_code = parse_booth_id(session.booth_id)
-        async with get_db_session() as db:
-            stmt = (
-                select(DBBooth)
-                .join(Room)
-                .join(Event)
-                .where(Event.slug == event_slug, DBBooth.language_code == language_code)
-            )
-            result = await db.execute(stmt)
-            db_booth = result.scalar_one_or_none()
-            if db_booth:
-                db_booth.broadcast_unlocked = unlocked
-                await db.commit()
-    except Exception as e:
-        logging.getLogger(__name__).error(f"Error persisting broadcast lock: {e}")
     try:
         state = await booths.set_broadcast_unlocked(session.booth_id, unlocked, session.language, session.channel_id)
         # Locking the booth must immediately stop everything tied to it: the

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -23,6 +23,7 @@ const state = {
   whipResourceUrl: null,
   micMuted: true,
   ingestConnected: false,
+  ingestStarting: false,
   ingestReachable: Boolean(portal.dataset.whipBase),
   defaultJitsiRoom: portal.dataset.defaultJitsi || '',
   jitsiDomain: portal.dataset.jitsiDomain || '',
@@ -196,10 +197,12 @@ function handleServerMessage(data) {
   if (type === 'booth:joined') {
     state.participantId = data.participant_id
     state.joined = true
-    // Never auto-start ingest on join/reload. Going live is driven exclusively
-    // by Mission Control toggling broadcast On (an off→on transition delivered
-    // as a subsequent booth:state message), not by simply (re)connecting.
-    applyBoothState(data.state, { skipAutoStart: true })
+    // Re-sync to Mission Control's current broadcast state. If a coordinator
+    // already has the booth live (On), the active interpreter resumes
+    // publishing; if it is Off, we stay off. Going live is driven by broadcast
+    // being unlocked from Mission Control — never by the act of joining itself,
+    // because a booth defaults to locked (Off) until a coordinator turns it on.
+    applyBoothState(data.state)
     joinMonitoringFeed()
     render()
     showError('')
@@ -461,7 +464,6 @@ async function fetchIngestReachability() {
 
 function applyBoothState(payload, { skipAutoStart = false } = {}) {
   const previousActiveInterpreterId = state.activeInterpreterId
-  const previousBroadcastUnlocked = state.broadcastUnlocked
 
   state.participants = payload.participants || []
   state.activeInterpreterId = payload.active_interpreter_id || null
@@ -498,8 +500,6 @@ function applyBoothState(payload, { skipAutoStart = false } = {}) {
     state.activeInterpreterId !== state.participantId &&
     previousActiveInterpreterId === state.participantId
 
-  const becameUnlocked = state.broadcastUnlocked && !previousBroadcastUnlocked
-
   // Level-triggered: while broadcast is locked, an active interpreter that is
   // still publishing must stop — regardless of whether we observed the exact
   // off→on transition. This makes Mission Control's "Stop" reliable even if a
@@ -524,10 +524,22 @@ function applyBoothState(payload, { skipAutoStart = false } = {}) {
     })
   }
 
-  // Auto-start ingest when becoming active or when broadcast unlocks
-  const shouldStartIngest = (becameActive || becameUnlocked) && state.activeInterpreterId === state.participantId && state.broadcastUnlocked
+  // Level-triggered: the active interpreter publishes whenever Mission Control
+  // has broadcast unlocked (On). This keeps the booth in lock-step with the
+  // Go Live / Stop toggle without a page reload, and covers every ordering —
+  // already present when unlocked, joining after unlock, or becoming active
+  // while unlocked. The ingestStarting guard prevents overlapping starts when
+  // several state messages arrive during the WHIP handshake.
+  const shouldStartIngest =
+    state.joined &&
+    state.participantId &&
+    state.activeInterpreterId === state.participantId &&
+    state.broadcastUnlocked &&
+    !state.ingestConnected &&
+    !state.ingestStarting
 
-  if (!skipAutoStart && shouldStartIngest && !state.ingestConnected && state.ingestReachable) {
+  if (!skipAutoStart && shouldStartIngest) {
+    state.ingestStarting = true
     if (state.micMuted) {
       state.micMuted = false
       if (state.micStream) {
@@ -1138,6 +1150,7 @@ async function stopLiveIngest() {
     }
   }
   state.ingestConnected = false
+  state.ingestStarting = false
   renderMicControls()
 }
 
@@ -1146,13 +1159,13 @@ const _RELAY_RETRY_INTERVAL_MS = 200
 const _RELAY_MAX_ATTEMPTS = 8
 
 function attemptRelayStart(attempt) {
-  if (attempt >= _RELAY_MAX_ATTEMPTS) return
+  if (attempt >= _RELAY_MAX_ATTEMPTS) { state.ingestStarting = false; return }
   window.setTimeout(async () => {
-    if (!state.joined || !state.participantId) return
-    if (state.activeInterpreterId !== state.participantId) return
+    if (!state.joined || !state.participantId) { state.ingestStarting = false; return }
+    if (state.activeInterpreterId !== state.participantId) { state.ingestStarting = false; return }
     // Broadcast must be unlocked by Mission Control before any ingest can start.
-    if (!state.broadcastUnlocked) return
-    if (state.ingestConnected) return
+    if (!state.broadcastUnlocked) { state.ingestStarting = false; return }
+    if (state.ingestConnected) { state.ingestStarting = false; return }
     try {
       await ensureMicStream()
       if (state.micStream) {
@@ -1179,7 +1192,7 @@ function attemptRelayStart(attempt) {
       if (!state.whipBase) throw new Error('MEDIAMTX_WHIP_BASE is not configured')
       await doWhipIngest(pc)
       state.ingestConnected = true
-
+      state.ingestStarting = false
       // Start backend transcription worker now that WHIP ingest is live
       if (portal.dataset.eventSlug && portal.dataset.languageCode) {
         try {
@@ -1208,6 +1221,7 @@ function attemptRelayStart(attempt) {
         attemptRelayStart(attempt + 1)
         return
       }
+      state.ingestStarting = false
       showError(`Could not start relay: ${error.message}`)
     }
     renderMicControls()

--- a/static/js/interpreter-booth.js
+++ b/static/js/interpreter-booth.js
@@ -196,7 +196,10 @@ function handleServerMessage(data) {
   if (type === 'booth:joined') {
     state.participantId = data.participant_id
     state.joined = true
-    applyBoothState(data.state, { skipAutoStart: false })
+    // Never auto-start ingest on join/reload. Going live is driven exclusively
+    // by Mission Control toggling broadcast On (an off→on transition delivered
+    // as a subsequent booth:state message), not by simply (re)connecting.
+    applyBoothState(data.state, { skipAutoStart: true })
     joinMonitoringFeed()
     render()
     showError('')
@@ -496,10 +499,17 @@ function applyBoothState(payload, { skipAutoStart = false } = {}) {
     previousActiveInterpreterId === state.participantId
 
   const becameUnlocked = state.broadcastUnlocked && !previousBroadcastUnlocked
-  const becameLocked = !state.broadcastUnlocked && previousBroadcastUnlocked
 
-  const lostPublishingRights = 
-    lostActivePublisher || (becameLocked && state.activeInterpreterId === state.participantId)
+  // Level-triggered: while broadcast is locked, an active interpreter that is
+  // still publishing must stop — regardless of whether we observed the exact
+  // off→on transition. This makes Mission Control's "Stop" reliable even if a
+  // lock-transition state message was missed or arrived out of order.
+  const lockedWhilePublishing =
+    !state.broadcastUnlocked &&
+    state.ingestConnected &&
+    state.activeInterpreterId === state.participantId
+
+  const lostPublishingRights = lostActivePublisher || lockedWhilePublishing
 
   if (lostPublishingRights) {
     state.relayingOut = true
@@ -1140,6 +1150,8 @@ function attemptRelayStart(attempt) {
   window.setTimeout(async () => {
     if (!state.joined || !state.participantId) return
     if (state.activeInterpreterId !== state.participantId) return
+    // Broadcast must be unlocked by Mission Control before any ingest can start.
+    if (!state.broadcastUnlocked) return
     if (state.ingestConnected) return
     try {
       await ensureMicStream()

--- a/tests/test_booth_state.py
+++ b/tests/test_booth_state.py
@@ -68,6 +68,30 @@ async def test_active_interpreter_can_pass_relay_and_old_publisher_is_cleared():
 
 
 @pytest.mark.anyio
+async def test_locking_broadcast_stops_active_publisher():
+    """Mission Control 'Stop' (lock) must force the active publisher offline."""
+    registry = BoothRegistry()
+    interpreter = await join(registry, "Interpreter A")
+    await registry.set_broadcast_unlocked("hall-a-fr", True, "French", "hall-a-fr-audio")
+    await registry.update_participant_state(
+        "hall-a-fr",
+        interpreter.participant_id,
+        "French",
+        "hall-a-fr-audio",
+        mic_active=True,
+        ingest_connected=True,
+    )
+
+    state = await registry.set_broadcast_unlocked("hall-a-fr", False, "French", "hall-a-fr-audio")
+
+    participants = {p["participant_id"]: p for p in state["participants"]}
+    assert state["broadcast_unlocked"] is False
+    assert state["ingest_status"] == "disconnected"
+    assert participants[interpreter.participant_id]["mic_active"] is False
+    assert participants[interpreter.participant_id]["ingest_connected"] is False
+
+
+@pytest.mark.anyio
 async def test_standby_interpreter_cannot_reassign_another_interpreter():
     registry = BoothRegistry()
     await join(registry, "Interpreter A")


### PR DESCRIPTION
Joining or reloading the interpreter booth no longer auto-starts WHIP ingest. Going live is now driven solely by the Mission Control Go Live / Stop toggle (broadcast unlock):

- booth:joined now applies state with skipAutoStart, so (re)connecting never puts an interpreter on air by itself.
- attemptRelayStart bails when broadcast is locked, closing a retry race that could re-establish ingest on a stopped booth.
- The lock-stop check is level-triggered, so Mission Control 'Stop' reliably tears down an active publisher even if a transition message is missed.
- Locking a booth server-side resets every participant's mic/ingest flags and stops the transcription worker, so the whole room stops immediately and the booth/Mission Control status stays consistent.

## Summary by Sourcery

Drive interpreter booth publishing strictly from Mission Control broadcast lock state so joining/reloading never auto-starts ingest and locking reliably stops all booth activity.

New Features:
- Ensure broadcast lock state prevents ingest retries from starting when the booth is locked.
- Stop the transcription worker whenever a booth is locked so captions cease along with audio publishing.

Bug Fixes:
- Prevent interpreter booth reconnects from automatically putting an interpreter on air.
- Ensure an active publisher is forced offline when broadcast is locked, even if lock transition messages are missed or delayed.
- Keep booth and Mission Control ingest status consistent by resetting participant mic and ingest flags on broadcast lock.

Enhancements:
- Clarify interpreter-facing documentation around going live, emphasizing that broadcast is controlled from Mission Control and that opening or reloading the booth never puts interpreters on air.

Tests:
- Add coverage to verify that locking broadcast stops an active publisher and clears mic/ingest state for the interpreter.