### PR TITLE
feat: add dark mode via CSS custom property overrides

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -3,6 +3,8 @@
 :root {
   --color-bg: #f5f6fa;
   --color-surface: #ffffff;
+  --color-surface-muted: #fafbfc;
+  --color-code-bg: #f0f1f3;
   --color-border: #e1e4e8;
   --color-text: #24292e;
   --color-text-secondary: #586069;
@@ -14,12 +16,42 @@
   --color-warning: #f59e0b;
   --color-live: #16a34a;
   --color-offline: #9ca3af;
+  --color-success-soft: #f0fdf4;
+  --color-danger-soft: #fef2f2;
+  --color-danger-border: #fecaca;
   --radius: 8px;
   --radius-sm: 4px;
   --shadow-sm: 0 1px 3px rgba(0,0,0,0.08);
   --shadow-md: 0 4px 12px rgba(0,0,0,0.1);
   --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-mono: 'SF Mono', 'Fira Code', monospace;
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #12141a;
+    --color-surface: #1a1d26;
+    --color-surface-muted: #222632;
+    --color-code-bg: #242833;
+    --color-border: #2e3440;
+    --color-text: #e8eaed;
+    --color-text-secondary: #9aa0a6;
+    --color-primary: #5b8cff;
+    --color-primary-hover: #7aa3ff;
+    --color-danger: #f87171;
+    --color-danger-hover: #fca5a5;
+    --color-success: #22c55e;
+    --color-warning: #fbbf24;
+    --color-live: #22c55e;
+    --color-offline: #6b7280;
+    --color-success-soft: rgb(34 197 94 / 15%);
+    --color-danger-soft: rgb(248 113 113 / 15%);
+    --color-danger-border: rgb(248 113 113 / 35%);
+    --shadow-sm: 0 1px 3px rgba(0,0,0,0.4);
+    --shadow-md: 0 4px 12px rgba(0,0,0,0.45);
+    color-scheme: dark;
+  }
 }
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -36,7 +68,7 @@ body {
 
 a { color: var(--color-primary); text-decoration: none; }
 a:hover { text-decoration: underline; }
-code { font-family: var(--font-mono); font-size: 0.875em; background: #f0f1f3; padding: 2px 6px; border-radius: var(--radius-sm); }
+code { font-family: var(--font-mono); font-size: 0.875em; background: var(--color-code-bg); padding: 2px 6px; border-radius: var(--radius-sm); }
 
 /* ── Header ──────────────────────────────────────────────────────────────── */
 
@@ -132,15 +164,15 @@ code { font-family: var(--font-mono); font-size: 0.875em; background: #f0f1f3; p
 .card-title { font-size: 1.125rem; font-weight: 600; color: var(--color-text); text-decoration: none; }
 .card-title:hover { color: var(--color-primary); }
 .card-body { padding: 8px 20px 16px; }
-.card-actions { padding: 12px 20px; border-top: 1px solid var(--color-border); background: #fafbfc; margin-top: auto; }
+.card-actions { padding: 12px 20px; border-top: 1px solid var(--color-border); background: var(--color-surface-muted); margin-top: auto; }
 
 .stat-row { display: flex; justify-content: space-between; padding: 4px 0; font-size: 0.875rem; }
 .stat-label { color: var(--color-text-secondary); }
 .stat-value { font-weight: 600; }
 
 .booth-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
-.chip { font-size: 0.75rem; padding: 3px 10px; border-radius: 12px; border: 1px solid var(--color-border); background: #fafbfc; }
-.chip-live { border-color: var(--color-live); color: var(--color-live); background: #f0fdf4; }
+.chip { font-size: 0.75rem; padding: 3px 10px; border-radius: 12px; border: 1px solid var(--color-border); background: var(--color-surface-muted); }
+.chip-live { border-color: var(--color-live); color: var(--color-live); background: var(--color-success-soft); }
 .chip-offline { color: var(--color-text-secondary); }
 
 /* ── Section Cards ───────────────────────────────────────────────────────── */
@@ -186,12 +218,12 @@ code { font-family: var(--font-mono); font-size: 0.875em; background: #f0f1f3; p
 .data-table th, .data-table td { padding: 10px 12px; border-bottom: 1px solid var(--color-border); vertical-align: middle; text-align: left; }
 .data-table thead th { border-bottom: 2px solid var(--color-border); font-weight: 600; color: var(--color-text-secondary); font-size: 0.8125rem; text-transform: uppercase; letter-spacing: 0.04em; }
 .data-table tbody th { font-weight: 600; color: var(--color-text-secondary); font-size: 0.8125rem; text-transform: uppercase; letter-spacing: 0.04em; }
-.data-table tbody tr:hover { background: #f8f9fa; }
+.data-table tbody tr:hover { background: var(--color-surface-muted); }
 .data-table.compact th, .data-table.compact td { padding: 8px 10px; }
 
-.schedule-table .row-live { background: #f0fdf4; }
+.schedule-table .row-live { background: var(--color-success-soft); }
 .row-used { opacity: 0.6; }
-.row-expired { opacity: 0.5; background: #fef2f2; }
+.row-expired { opacity: 0.5; background: var(--color-danger-soft); }
 
 .token-preview { font-size: 0.75rem; color: var(--color-text-secondary); }
 
@@ -203,17 +235,17 @@ code { font-family: var(--font-mono); font-size: 0.875em; background: #f0f1f3; p
 /* ── Badges ──────────────────────────────────────────────────────────────── */
 
 .badge { display: inline-block; font-size: 0.75rem; font-weight: 600; padding: 2px 8px; border-radius: 12px; }
-.badge-slug { background: #e8edf3; color: var(--color-text-secondary); }
+.badge-slug { background: var(--color-surface-muted); color: var(--color-text-secondary); }
 .badge-active { background: var(--color-live); color: #fff; }
 .badge-role { text-transform: capitalize; }
 .badge-interpreter { background: #dbeafe; color: #1e40af; }
 .badge-coordinator { background: #fef3c7; color: #92400e; }
 .badge-listener { background: #e0e7ff; color: #4338ca; }
 .badge-event_admin { background: #fce7f3; color: #9d174d; }
-.badge-super_admin { background: #fecaca; color: #991b1b; }
-.badge-valid { background: #d1fae5; color: #065f46; }
-.badge-used { background: #e5e7eb; color: #6b7280; }
-.badge-expired { background: #fecaca; color: #991b1b; }
+.badge-super_admin { background: var(--color-danger-soft); color: var(--color-danger); }
+.badge-valid { background: var(--color-success-soft); color: var(--color-success); }
+.badge-used { background: var(--color-surface-muted); color: var(--color-text-secondary); }
+.badge-expired { background: var(--color-danger-soft); color: var(--color-danger); }
 
 /* ── Buttons ─────────────────────────────────────────────────────────────── */
 
@@ -235,7 +267,7 @@ code { font-family: var(--font-mono); font-size: 0.875em; background: #f0f1f3; p
   box-sizing: border-box;
   line-height: 1;
 }
-.btn:hover, .btn-sm:hover { background: #f0f1f3; text-decoration: none; }
+.btn:hover, .btn-sm:hover { background: var(--color-code-bg); text-decoration: none; }
 .btn-primary { background: var(--color-primary); color: #fff; border-color: var(--color-primary); }
 .btn-primary:hover { background: var(--color-primary-hover); }
 .btn-danger { background: var(--color-danger); color: #fff; border-color: var(--color-danger); }
@@ -264,9 +296,9 @@ code { font-family: var(--font-mono); font-size: 0.875em; background: #f0f1f3; p
 .danger-zone {
   margin-top: 32px;
   padding: 20px;
-  border: 1px solid #fecaca;
+  border: 1px solid var(--color-danger-border);
   border-radius: var(--radius);
-  background: #fef2f2;
+  background: var(--color-danger-soft);
 }
 .danger-zone h3 { font-size: 0.9375rem; font-weight: 600; color: var(--color-danger); margin-bottom: 12px; }
 .danger-text { font-size: 0.8125rem; color: var(--color-text-secondary); margin-left: 12px; }
@@ -311,7 +343,7 @@ code { font-family: var(--font-mono); font-size: 0.875em; background: #f0f1f3; p
 .login-form input { padding: 10px 14px; font-size: 1rem; border: 1px solid var(--color-border); border-radius: var(--radius-sm); }
 .login-form input:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 2px rgba(37,99,235,0.15); }
 .login-footer { text-align: center; margin-top: 20px; font-size: 0.8125rem; }
-.alert-error { background: #fef2f2; color: var(--color-danger); border: 1px solid #fecaca; padding: 10px 14px; border-radius: var(--radius-sm); font-size: 0.875rem; margin-bottom: 8px; }
+.alert-error { background: var(--color-danger-soft); color: var(--color-danger); border: 1px solid var(--color-danger-border); padding: 10px 14px; border-radius: var(--radius-sm); font-size: 0.875rem; margin-bottom: 8px; }
 
 /* ── Home Page ───────────────────────────────────────────────────────────── */
 

--- a/static/css/auth.css
+++ b/static/css/auth.css
@@ -19,6 +19,20 @@
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
+@media (prefers-color-scheme: dark) {
+  .login-page,
+  .account-card,
+  .portal-home-header {
+    --color-primary-hover: #7aa3ff;
+    --color-danger-hover: #fca5a5;
+    --color-surface: #1a1d26;
+    --color-live: #22c55e;
+    --color-offline: #6b7280;
+    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45);
+  }
+}
+
 /* ── Header (used on account.html) ──────────────────────────────────────── */
 
 .portal-home-header {
@@ -98,7 +112,7 @@
 .badge-coordinator { background: #fef3c7; color: #92400e; }
 .badge-listener { background: #e0e7ff; color: #4338ca; }
 .badge-event_admin { background: #fce7f3; color: #9d174d; }
-.badge-super_admin { background: #fecaca; color: #991b1b; }
+.badge-super_admin { background: var(--color-danger-soft, #fecaca); color: var(--color-danger, #991b1b); }
 
 .muted { color: var(--color-text-secondary); font-size: 0.875rem; }
 
@@ -109,22 +123,22 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #eef2f6; /* soft gray-blue */
+  background-color: var(--color-bg, #eef2f6);
   padding: 20px;
 }
 .login-card {
   width: 100%;
   max-width: 420px;
   background: var(--color-surface);
-  border: 3px solid #0d0f10;
+  border: 3px solid var(--color-text);
   border-radius: 8px;
   padding: 40px 32px;
-  box-shadow: 8px 8px 0px #0d0f10;
+  box-shadow: 8px 8px 0px var(--color-text);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 .login-card:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 10px 10px 0px #0d0f10;
+  box-shadow: 10px 10px 0px var(--color-text);
 }
 .login-brand { text-align: center; margin-bottom: 28px; }
 .login-subtitle { font-size: 0.875rem; color: var(--color-text-secondary); display: block; margin-top: 4px; }
@@ -133,11 +147,11 @@
 .login-form input { 
   padding: 12px 14px; 
   font-size: 1rem; 
-  border: 2px solid #0d0f10; 
+  border: 2px solid var(--color-text); 
   border-radius: 6px; 
-  background-color: #ffffff;
-  color: #0d0f10;
-  box-shadow: 4px 4px 0px #0d0f10;
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: 4px 4px 0px var(--color-text);
   transition: all 0.2s ease;
   font-family: inherit;
 }
@@ -150,9 +164,9 @@
 
 /* Brutalist Button Styles for Login/Register */
 .login-card .btn {
-  border: 2px solid #0d0f10;
+  border: 2px solid var(--color-text);
   border-radius: 6px;
-  box-shadow: 4px 4px 0px #0d0f10;
+  box-shadow: 4px 4px 0px var(--color-text);
   font-weight: 700;
   font-size: 1rem;
   padding: 12px 20px;
@@ -163,28 +177,28 @@
   margin-top: 10px;
 }
 .login-card .btn:active {
-  box-shadow: 0px 0px 0px #0d0f10;
+  box-shadow: 0px 0px 0px var(--color-text);
   transform: translate(4px, 4px);
 }
 .login-card .btn-primary {
   background: var(--color-primary);
   color: #ffffff;
-  border-color: #0d0f10;
+  border-color: var(--color-text);
 }
 .login-card .btn-primary:hover {
-  background: #1a69a4;
-  border-color: #0d0f10;
+  background: var(--color-primary-hover, #1a69a4);
+  border-color: var(--color-text);
   color: #ffffff;
 }
 .login-card .btn-outline {
-  background: #ffffff;
-  color: #0d0f10;
-  border-color: #0d0f10;
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-color: var(--color-text);
 }
 .login-card .btn-outline:hover {
-  background: #f8f9fa;
-  color: #0d0f10;
-  border-color: #0d0f10;
+  background: var(--color-surface-muted, #f8f9fa);
+  color: var(--color-text);
+  border-color: var(--color-text);
 }
 .login-footer {
   display: flex;
@@ -196,7 +210,7 @@
   color: var(--color-text-secondary);
 }
 .login-footer a { color: var(--color-primary); }
-.alert-error { background: #fef2f2; color: var(--color-danger); border: 1px solid #fecaca; padding: 10px 14px; border-radius: var(--radius-sm); font-size: 0.875rem; margin-bottom: 8px; }
+.alert-error { background: var(--color-danger-soft, #fef2f2); color: var(--color-danger); border: 1px solid var(--color-danger-border, #fecaca); padding: 10px 14px; border-radius: var(--radius-sm); font-size: 0.875rem; margin-bottom: 8px; }
 .error-list { margin: 0; padding-left: 18px; text-align: left; }
 
 @media (max-width: 768px) {

--- a/static/css/error.css
+++ b/static/css/error.css
@@ -1,7 +1,6 @@
 /* ── Unified Error Pages (403 / 404 / 429 / 500) ───────────────
-   Light theme built on the design tokens defined in interpreter.css
-   (loaded globally by base.html). Colors use the --color-* tokens where
-   possible; the card drop shadow is a literal value. */
+   Built on design tokens from interpreter.css (loaded by base.html).
+   Dark mode is handled via prefers-color-scheme token overrides. */
 
 .error-container {
   display: flex;
@@ -23,10 +22,10 @@
   width: 100%;
   max-width: 500px;
   padding: 3rem;
-  background: var(--color-bg);
+  background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  box-shadow: 0 1px 3px rgb(0 0 0 / 0.08);
+  box-shadow: var(--shadow-lightest);
 }
 
 .error-code {

--- a/static/css/home.css
+++ b/static/css/home.css
@@ -10,22 +10,22 @@
 
 /* Brutalist aesthetics inherited from auth.css for landing page */
 .brutal-card {
-  background: #ffffff;
-  border: 3px solid #0d0f10;
+  background: var(--color-surface, #ffffff);
+  border: 3px solid var(--color-text, #0d0f10);
   border-radius: 8px;
-  box-shadow: 8px 8px 0px #0d0f10;
+  box-shadow: 8px 8px 0px var(--color-text, #0d0f10);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .brutal-card:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 10px 10px 0px #0d0f10;
+  box-shadow: 10px 10px 0px var(--color-text, #0d0f10);
 }
 
 .brutal-btn {
-  border: 2px solid #0d0f10;
+  border: 2px solid var(--color-text, #0d0f10);
   border-radius: 6px;
-  box-shadow: 4px 4px 0px #0d0f10;
+  box-shadow: 4px 4px 0px var(--color-text, #0d0f10);
   font-weight: 800;
   padding: 12px 24px;
   transition: all 0.1s ease;
@@ -38,35 +38,35 @@
 }
 
 .brutal-btn:active {
-  box-shadow: 0px 0px 0px #0d0f10 !important;
+  box-shadow: 0px 0px 0px var(--color-text, #0d0f10) !important;
   transform: translate(4px, 4px) !important;
 }
 
 .brutal-btn-primary {
-  background: #2563eb;
+  background: var(--color-primary, #2563eb);
   color: #ffffff;
 }
 
 .brutal-btn-primary:hover {
-  background: #1d4ed8;
+  background: var(--color-primary-hover, #1d4ed8);
   color: #ffffff;
 }
 
 .brutal-btn-outline {
-  background: #ffffff;
-  color: #0d0f10;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-text, #0d0f10);
 }
 
 .brutal-btn-outline:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-muted, #f8f9fa);
 }
 
 .brutal-border {
-  border: 3px solid #0d0f10;
+  border: 3px solid var(--color-text, #0d0f10);
 }
 
 .brutal-shadow {
-  box-shadow: 8px 8px 0px #0d0f10;
+  box-shadow: 8px 8px 0px var(--color-text, #0d0f10);
 }
 /* Animated Flip Card (Uiverse style adapted for Brutalism) */
 .solution-card {

--- a/static/css/interpreter.css
+++ b/static/css/interpreter.css
@@ -13,6 +13,8 @@
   --color-primary: #2185d0;
   --color-primary-text: #1a69a4;
   --color-bg: #ffffff;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f5f5f5;
   --color-text: #0d0f10;
   --color-muted: #6c757d;
   --color-border: #ced4da;
@@ -21,8 +23,12 @@
   --color-success: #2a8f4c;
   --color-danger: #b23e65;
   --color-warning: #d18538;
+  --color-success-soft: rgb(42 143 76 / 10%);
+  --color-danger-soft: #fef2f2;
+  --color-danger-border: #fecaca;
   --radius: 0.25rem;
   --shadow-lightest: 0 1px 2px rgb(0 0 0 / 0.24);
+  color-scheme: light;
 
   /* Booth redesign tokens */
   --bx-bg: #eef1f6;
@@ -42,6 +48,46 @@
   --bx-radius-sm: 10px;
   --bx-shadow: 0 1px 2px rgb(16 24 40 / 0.04), 0 8px 24px rgb(16 24 40 / 0.06);
   --bx-shadow-sm: 0 1px 2px rgb(16 24 40 / 0.05);
+}
+
+/* Dark mode: override shared tokens for system preference (issue #249). */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-primary: #4da3e8;
+    --color-primary-text: #7ec0f5;
+    --color-bg: #12141a;
+    --color-surface: #1a1d26;
+    --color-surface-muted: #242833;
+    --color-text: #e8eaed;
+    --color-muted: #9aa0a6;
+    --color-border: #3a3f4b;
+    --color-panel-header: rgb(255 255 255 / 0.04);
+    --color-panel-border: rgb(255 255 255 / 0.12);
+    --color-success: #3cb371;
+    --color-danger: #e5738a;
+    --color-warning: #e0a35a;
+    --color-success-soft: rgb(60 179 113 / 15%);
+    --color-danger-soft: rgb(229 115 138 / 15%);
+    --color-danger-border: rgb(229 115 138 / 35%);
+    --shadow-lightest: 0 1px 2px rgb(0 0 0 / 0.5);
+    color-scheme: dark;
+
+    --bx-bg: #0f1117;
+    --bx-surface: #1a1d26;
+    --bx-surface-2: #222632;
+    --bx-border: #2e3440;
+    --bx-border-strong: #3a4150;
+    --bx-text: #e8eaed;
+    --bx-muted: #9aa0a6;
+    --bx-accent: #5b8cff;
+    --bx-accent-ink: #8aadff;
+    --bx-live: #22c55e;
+    --bx-live-ink: #4ade80;
+    --bx-danger: #fb7185;
+    --bx-warn: #fbbf24;
+    --bx-shadow: 0 1px 2px rgb(0 0 0 / 0.4), 0 8px 24px rgb(0 0 0 / 0.35);
+    --bx-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.35);
+  }
 }
 
 /* ── 2. Base + shared components ────────────────────────────────────────── */
@@ -101,7 +147,7 @@ label {
   border-radius: var(--radius);
   padding: 0.45rem 0.6rem;
   color: var(--color-text);
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .input:focus {
@@ -124,7 +170,7 @@ label {
 
 .btn {
   border: 1px solid var(--color-border);
-  background: #fff;
+  background: var(--color-surface);
   color: var(--color-text);
   border-radius: var(--radius);
   padding: 0.45rem 0.75rem;
@@ -224,7 +270,7 @@ label {
   width: 100%;
   height: 10px;
   border-radius: 5px;
-  background: #e9ecef;
+  background: var(--color-surface-muted);
   border: 1px solid var(--color-border);
 }
 
@@ -442,9 +488,9 @@ label {
 }
 
 .live-badge.off {
-  color: #64748b;
-  background: #f1f3f7;
-  border-color: #e2e6ee;
+  color: var(--bx-muted);
+  background: var(--bx-surface-2);
+  border-color: var(--bx-border);
 }
 
 .live-badge.on {
@@ -460,8 +506,8 @@ label {
 
 .live-badge.standby {
   color: var(--bx-warn);
-  background: #fef3e2;
-  border-color: #f6d9ad;
+  background: color-mix(in srgb, var(--bx-warn) 16%, var(--bx-surface));
+  border-color: color-mix(in srgb, var(--bx-warn) 35%, var(--bx-border));
 }
 
 .live-badge.standby .live-dot {
@@ -522,13 +568,13 @@ label {
 
 /* Mic button — colour reflects current state (red = muted, green = on air) */
 .header-btn--mic.muted {
-  background: #fff1f4;
+  background: color-mix(in srgb, var(--bx-danger) 12%, var(--bx-surface));
   color: var(--bx-danger);
-  border-color: #f7c6d3;
+  border-color: color-mix(in srgb, var(--bx-danger) 35%, var(--bx-border));
 }
 
 .header-btn--mic.muted:hover:not(:disabled) {
-  background: #ffe4ea;
+  background: color-mix(in srgb, var(--bx-danger) 18%, var(--bx-surface));
   border-color: var(--bx-danger);
   color: var(--bx-danger);
   box-shadow: 0 2px 10px rgb(225 29 72 / 0.18);
@@ -549,7 +595,7 @@ label {
 
 /* Handover button state machine (grey / green / flashing yellow) */
 .header-btn--handover.state-grey {
-  background: #fff;
+  background: var(--bx-surface);
   color: var(--bx-text);
   border-color: var(--bx-border-strong);
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{% block title %}Voxbento Interpreter Booth{% endblock %}</title>
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='img/favicon.ico') }}" />
-    <link rel="stylesheet" href="{{ url_for('static', path='css/interpreter.css') }}?v=5" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/interpreter.css') }}?v=6" />
     {% block head %}{% endblock %}
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Add `@media (prefers-color-scheme: dark)` overrides for shared CSS custom properties in `interpreter.css` and `admin.css`
- Route admin/auth/error UI through surface/soft tokens so hardcoded light colors no longer break dark mode
- Extend token usage to booth controls, login/register cards, and error pages; bump `interpreter.css` cache to `v=6`

Fixes #249

## Test plan
- [ ] With OS/browser set to **light** mode, login, admin, and a 404/error page look unchanged and readable
- [ ] With OS/browser set to **dark** mode (`prefers-color-scheme: dark`), backgrounds/text/borders switch via tokens
- [ ] Login/register card, primary/secondary buttons, and inputs remain readable in dark mode
- [ ] Error page card uses surface tokens and stays readable in dark mode
- [ ] Admin chips, danger zone, and table hover/row states use soft tokens (no harsh white blocks)
- [ ] Interpreter booth live/standby badges and mic/handover controls follow `--bx-*` dark tokens

## Screenshots / Recordings
<img width="1797" height="947" alt="image" src="https://github.com/user-attachments/assets/b31f9b4f-e501-4f1b-b8e7-8fb42f517703" />
<img width="1741" height="892" alt="image" src="https://github.com/user-attachments/assets/23f43fe6-6de6-4ac0-8fac-dee7444143b6" />

## Summary by Sourcery

Introduce token-driven dark mode support across interpreter, admin, auth, home, and error UIs.

New Features:
- Add prefers-color-scheme-based dark theme overrides for shared color tokens in interpreter and admin styles.
- Enable dark-aware styling for login/register cards, landing page brutalist components, and unified error pages via existing design tokens.

Bug Fixes:
- Prevent hardcoded light backgrounds and borders from breaking readability in dark mode across admin, auth, and error interfaces.

Enhancements:
- Refine booth badges, mic/handover controls, chips, tables, badges, danger zones, and alerts to use surface/soft token variants instead of hardcoded light colors.
- Standardize token usage for backgrounds, borders, and shadows to improve visual consistency between light and dark modes.
- Update interpreter stylesheet cache version to ensure clients receive the new token and dark mode changes.