### PR TITLE
fix: added reference count for nllb

### DIFF
--- a/portal/translations/providers/local.py
+++ b/portal/translations/providers/local.py
@@ -94,7 +94,20 @@ class ModelEntry:
 
 
 _loaded_models = {}
+_active_translations_per_model = {}
 _model_lock = threading.Lock()
+
+
+def increment_model_ref(model_size: str):
+    with _model_lock:
+        _active_translations_per_model[model_size] = _active_translations_per_model.get(model_size, 0) + 1
+
+
+def decrement_model_ref(model_size: str):
+    with _model_lock:
+        if model_size in _active_translations_per_model:
+            _active_translations_per_model[model_size] = max(0, _active_translations_per_model[model_size] - 1)
+
 
 
 def get_model_and_tokenizer(model_size: str):
@@ -152,7 +165,8 @@ async def eviction_loop():
         to_delete = []
         with _model_lock:
             for size, entry in _loaded_models.items():
-                if (now - entry.last_used) > 3600:  # 1 hour idle
+                refs = _active_translations_per_model.get(size, 0)
+                if refs == 0 and (now - entry.last_used) > 3600:  # 1 hour idle
                     to_delete.append(size)
             for size in to_delete:
                 logger.info(f"Evicting idle NLLB model: {size}")
@@ -200,7 +214,7 @@ class LocalProvider(TranslationProvider):
         return await asyncio.to_thread(self._run_inference, text, source_lang_token, target_lang_token, model)
 
     def _run_inference(self, text: str, source_lang_token: str, target_lang_token: str, model_size: str) -> str | None:
-
+        increment_model_ref(model_size)
         try:
             model, tokenizer = get_model_and_tokenizer(model_size)
             source = tokenizer.convert_ids_to_tokens(tokenizer.encode(text))
@@ -216,3 +230,5 @@ class LocalProvider(TranslationProvider):
         except Exception as e:
             logger.error(f"NLLB local translation failed: {e}")
             return None
+        finally:
+            decrement_model_ref(model_size)

--- a/portal/translations/providers/local.py
+++ b/portal/translations/providers/local.py
@@ -110,8 +110,11 @@ def increment_model_ref(model_size: str):
 
 def decrement_model_ref(model_size: str):
     with _model_lock:
-        if model_size in _active_translations_per_model:
-            _active_translations_per_model[model_size] = max(0, _active_translations_per_model[model_size] - 1)
+        if _active_translations_per_model.get(model_size, 0) <= 0:
+            logger.warning(f"Reference count underflow for {model_size}! This indicates a bug in tracking.")
+            _active_translations_per_model[model_size] = 0
+        else:
+            _active_translations_per_model[model_size] -= 1
 
 
 

--- a/tests/test_local_translation.py
+++ b/tests/test_local_translation.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import asyncio
+import time
 from unittest.mock import patch
 
 import pytest
 
-from portal.translations.providers.local import LocalProvider
+from portal.translations.providers.local import (
+    LocalProvider,
+    ModelEntry,
+    _active_translations_per_model,
+    _loaded_models,
+    eviction_loop,
+)
 
 
 @pytest.mark.anyio
@@ -37,3 +45,46 @@ async def test_local_provider_translate_invalid_language():
         api_key=None,
     )
     assert result is None
+
+
+def test_local_provider_ref_count_decrements_on_exception():
+    provider = LocalProvider()
+    model_size = "test-model-exception"
+
+    _active_translations_per_model[model_size] = 0
+
+    with patch("portal.translations.providers.local.get_model_and_tokenizer", side_effect=ValueError("Mock Error")):
+        result = provider._run_inference("Hello", "eng_Latn", "fra_Latn", model_size)
+        assert result is None
+
+    assert _active_translations_per_model.get(model_size, 0) == 0
+
+
+@pytest.mark.anyio
+async def test_local_provider_eviction_respects_ref_count():
+    model_size = "test-model-eviction"
+
+    # Populate loaded models with an idle timestamp (older than 1 hour)
+    _loaded_models[model_size] = ModelEntry(model=None, tokenizer=None, last_used=time.time() - 4000)
+
+    # Active reference prevents eviction
+    _active_translations_per_model[model_size] = 1
+
+    with patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()]):
+        try:
+            await eviction_loop()
+        except asyncio.CancelledError:
+            pass
+
+    assert model_size in _loaded_models
+
+    # Releasing the reference allows eviction
+    _active_translations_per_model[model_size] = 0
+
+    with patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()]):
+        try:
+            await eviction_loop()
+        except asyncio.CancelledError:
+            pass
+
+    assert model_size not in _loaded_models


### PR DESCRIPTION
## Description
This PR introduces reference counting to the local NLLB translation provider (`portal/translations/providers/local.py`). Previously, the background `eviction_loop` could evict an NLLB model from memory while a translation was actively in-flight, which could lead to crashes or dropped translations under load. This brings the translation provider to parity with the `faster-whisper` provider's safety mechanisms. 
## Related Issue
Closes  #308 
## Changes Made
- Ported the `increment_model_ref` and `decrement_model_ref` pattern to `portal/translations/providers/local.py` using a new `_active_translations_per_model` dictionary.
- Updated the `eviction_loop` to explicitly check that a model's reference count is exactly `0` before marking it for eviction.
- Wrapped the core execution path of `_run_inference` in a `try...finally` block to guarantee reference counts are incremented before inference and decremented upon completion.

## Summary by Sourcery

Add reference counting to the local NLLB translation provider to prevent models from being evicted while in use.

Bug Fixes:
- Prevent NLLB models from being evicted during active translations by tracking per-model reference counts in the eviction loop.

Enhancements:
- Introduce per-model active translation reference tracking and ensure counts are correctly incremented and decremented around NLLB inference execution.