### PR TITLE
feat: Implement transcript hallucination filter

### DIFF
--- a/portal/transcript_processing.py
+++ b/portal/transcript_processing.py
@@ -23,30 +23,30 @@ def is_valid_transcript(text: str) -> bool:
     """
     if not text:
         return False
-        
+
     text_stripped = text.strip()
     if not text_stripped:
         return False
-        
+
     # Reject if entirely non-printable/no letters/numbers
     # A valid transcript should have at least one alphanumeric character
     has_alnum = any(c.isalnum() for c in text_stripped)
     if not has_alnum:
         return False
-        
+
     # Reject known hallucination phrases (exact match, case insensitive, stripped of punctuation)
     clean_lower = text_stripped.lower().strip(string.punctuation)
     if clean_lower in KNOWN_HALLUCINATIONS:
         return False
-        
+
     # Check for repeating garbage words like "click click click"
     words = clean_lower.split()
     if len(words) > 0 and len(set(words)) == 1 and words[0] in {"click", "cough"}:
         return False
-        
+
     # Reject if any single word is > 40 chars
     for word in text_stripped.split():
         if len(word) > 40:
             return False
-            
+
     return True

--- a/portal/transcript_processing.py
+++ b/portal/transcript_processing.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import string
 
-KNOWN_HALLUCINATIONS = {
+_punct_translator = str.maketrans(string.punctuation, ' ' * len(string.punctuation))
+
+RAW_HALLUCINATIONS = [
     "click",
     "click click",
     "cough",
@@ -14,6 +16,10 @@ KNOWN_HALLUCINATIONS = {
     "amara.org",
     "subtitle",
     "subtitles",
+]
+
+KNOWN_HALLUCINATIONS = {
+    " ".join(h.lower().translate(_punct_translator).split()) for h in RAW_HALLUCINATIONS
 }
 
 def is_valid_transcript(text: str) -> bool:
@@ -34,13 +40,15 @@ def is_valid_transcript(text: str) -> bool:
     if not has_alnum:
         return False
 
-    # Reject known hallucination phrases (exact match, case insensitive, stripped of punctuation)
-    clean_lower = text_stripped.lower().strip(string.punctuation)
-    if clean_lower in KNOWN_HALLUCINATIONS:
+    # Normalize by replacing all punctuation with spaces and collapsing whitespace
+    normalized = " ".join(text_stripped.lower().translate(_punct_translator).split())
+    
+    # Reject known hallucination phrases (exact match, case insensitive, punctuation stripped)
+    if normalized in KNOWN_HALLUCINATIONS:
         return False
 
     # Check for repeating garbage words like "click click click"
-    words = clean_lower.split()
+    words = normalized.split()
     if len(words) > 0 and len(set(words)) == 1 and words[0] in {"click", "cough"}:
         return False
 

--- a/portal/transcript_processing.py
+++ b/portal/transcript_processing.py
@@ -42,7 +42,7 @@ def is_valid_transcript(text: str) -> bool:
 
     # Normalize by replacing all punctuation with spaces and collapsing whitespace
     normalized = " ".join(text_stripped.lower().translate(_punct_translator).split())
-    
+
     # Reject known hallucination phrases (exact match, case insensitive, punctuation stripped)
     if normalized in KNOWN_HALLUCINATIONS:
         return False

--- a/portal/transcript_processing.py
+++ b/portal/transcript_processing.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import string
+
+KNOWN_HALLUCINATIONS = {
+    "click",
+    "click click",
+    "cough",
+    "cough cough",
+    "thank you",
+    "thanks for watching",
+    "please subscribe",
+    "subscribe",
+    "amara.org",
+    "subtitle",
+    "subtitles",
+}
+
+def is_valid_transcript(text: str) -> bool:
+    """
+    Validates a transcript chunk to filter out common Whisper hallucinations and garbage.
+    Returns True if valid, False if it should be rejected.
+    """
+    if not text:
+        return False
+        
+    text_stripped = text.strip()
+    if not text_stripped:
+        return False
+        
+    # Reject if entirely non-printable/no letters/numbers
+    # A valid transcript should have at least one alphanumeric character
+    has_alnum = any(c.isalnum() for c in text_stripped)
+    if not has_alnum:
+        return False
+        
+    # Reject known hallucination phrases (exact match, case insensitive, stripped of punctuation)
+    clean_lower = text_stripped.lower().strip(string.punctuation)
+    if clean_lower in KNOWN_HALLUCINATIONS:
+        return False
+        
+    # Check for repeating garbage words like "click click click"
+    words = clean_lower.split()
+    if len(words) > 0 and len(set(words)) == 1 and words[0] in {"click", "cough"}:
+        return False
+        
+    # Reject if any single word is > 40 chars
+    for word in text_stripped.split():
+        if len(word) > 40:
+            return False
+            
+    return True

--- a/portal/transcription/providers/base.py
+++ b/portal/transcription/providers/base.py
@@ -6,6 +6,7 @@ import wave
 from dataclasses import dataclass
 
 from portal.models import Event
+from portal.transcript_processing import is_valid_transcript
 from portal.transcription.constants import ProviderEnum
 
 logger = logging.getLogger(__name__)
@@ -145,8 +146,12 @@ class TranscriptionProvider:
                     booth_state.consecutive_drops = 0
 
                     if text:
-                        logger.debug(f"[{booth_id}] Transcribed: {text}")
-                        await aggregator.handle_chunk(booth_id, text)
+                        if is_valid_transcript(text):
+                            logger.debug(f"[{booth_id}] Transcribed: {text}")
+                            await aggregator.handle_chunk(booth_id, text)
+                        else:
+                            logger.debug(f"[{booth_id}] Rejected hallucination: {text}")
+                            await aggregator.handle_clear(booth_id)
                     else:
                         await aggregator.handle_clear(booth_id)
                 except Exception as e:

--- a/tests/test_transcript_processing.py
+++ b/tests/test_transcript_processing.py
@@ -28,10 +28,13 @@ def test_known_hallucinations():
     assert not is_valid_transcript("Thank you!")
     assert not is_valid_transcript("  Thanks for watching...  ")
     assert not is_valid_transcript("subscribe")
+    assert not is_valid_transcript("amara.org")
 
 def test_repeating_hallucinations():
     assert not is_valid_transcript("click click click")
     assert not is_valid_transcript("cough cough cough cough")
+    assert not is_valid_transcript("Click. Click.")
+    assert not is_valid_transcript("click, click, click")
 
 def test_long_words():
     # 41 characters word

--- a/tests/test_transcript_processing.py
+++ b/tests/test_transcript_processing.py
@@ -4,6 +4,7 @@ import pytest
 
 from portal.transcript_processing import is_valid_transcript
 
+
 def test_valid_transcripts():
     assert is_valid_transcript("Hello world.")
     assert is_valid_transcript("This is a normal sentence with 123 numbers.")

--- a/tests/test_transcript_processing.py
+++ b/tests/test_transcript_processing.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from portal.transcript_processing import is_valid_transcript
+
+def test_valid_transcripts():
+    assert is_valid_transcript("Hello world.")
+    assert is_valid_transcript("This is a normal sentence with 123 numbers.")
+    assert is_valid_transcript("¡Hola! ¿Cómo estás?")
+    assert is_valid_transcript("A")
+
+def test_empty_or_whitespace():
+    assert not is_valid_transcript("")
+    assert not is_valid_transcript("   ")
+    assert not is_valid_transcript("\n\t")
+
+def test_non_printable_or_no_alnum():
+    assert not is_valid_transcript("...")
+    assert not is_valid_transcript("!@#$%")
+    assert not is_valid_transcript("    -   ")
+    assert not is_valid_transcript("🤔")
+
+def test_known_hallucinations():
+    assert not is_valid_transcript("Click click")
+    assert not is_valid_transcript("Cough cough.")
+    assert not is_valid_transcript("Thank you!")
+    assert not is_valid_transcript("  Thanks for watching...  ")
+    assert not is_valid_transcript("subscribe")
+
+def test_repeating_hallucinations():
+    assert not is_valid_transcript("click click click")
+    assert not is_valid_transcript("cough cough cough cough")
+
+def test_long_words():
+    # 41 characters word
+    long_word = "a" * 41
+    assert not is_valid_transcript(f"This has a {long_word} word")
+    assert is_valid_transcript(f"This has a {'a'*40} word")


### PR DESCRIPTION
Fixes #315 

Created portal/transcript_processing.py which contains is_valid_transcript(). It checks for empty strings, completely non-alphanumeric strings, single words longer than 40 characters, and matches against a set of known Whisper hallucination phrases like "click click".

Updated portal/transcription/providers/base.py to route transcripts through the new filter. If it fails validation, it drops the chunk and sends a clear signal instead.

Created tests/test_transcript_processing.py containing comprehensive unit tests covering all the edge cases identified in the issue.

## Summary by Sourcery

Filter transcription output through a new transcript validation module to prevent known hallucinations and invalid text from reaching downstream consumers.

New Features:
- Introduce transcript validity filtering to drop hallucinated or garbage transcription chunks before aggregation.

Enhancements:
- Centralize transcript validation logic in a new module to encapsulate hallucination and garbage-text detection rules.

Tests:
- Add unit test coverage for transcript validation across empty input, non-alphanumeric strings, known hallucinations, repeated hallucination patterns, and overly long words.