### PR TITLE
fix: fixing the event loop freezing

### DIFF
--- a/portal/transcription/providers/local.py
+++ b/portal/transcription/providers/local.py
@@ -27,6 +27,7 @@ class ModelEntry:
 _loaded_models = {}
 _active_booths_per_model = {}
 _model_lock = threading.Lock()
+_load_lock = threading.Lock()
 
 
 def increment_model_ref(model_size: str):
@@ -42,15 +43,24 @@ def decrement_model_ref(model_size: str):
 
 def get_model(model_size: str):
     with _model_lock:
-        if model_size not in _loaded_models:
-            logger.info(f"Loading faster-whisper model: {model_size}")
-            from faster_whisper import WhisperModel
-
-            model = WhisperModel(model_size, device="cpu", compute_type="int8")
-            _loaded_models[model_size] = ModelEntry(model=model, last_used=time.time())
-        else:
+        if model_size in _loaded_models:
             _loaded_models[model_size].last_used = time.time()
-        return _loaded_models[model_size].model
+            return _loaded_models[model_size].model
+
+    with _load_lock:
+        # Double-check inside the load lock
+        with _model_lock:
+            if model_size in _loaded_models:
+                _loaded_models[model_size].last_used = time.time()
+                return _loaded_models[model_size].model
+
+        logger.info(f"Loading faster-whisper model: {model_size}")
+        from faster_whisper import WhisperModel
+
+        model = WhisperModel(model_size, device="cpu", compute_type="int8")
+        with _model_lock:
+            _loaded_models[model_size] = ModelEntry(model=model, last_used=time.time())
+            return _loaded_models[model_size].model
 
 
 async def eviction_loop():

--- a/portal/translations/providers/local.py
+++ b/portal/translations/providers/local.py
@@ -101,6 +101,7 @@ class ModelEntry:
 _loaded_models = {}
 _active_translations_per_model = {}
 _model_lock = threading.Lock()
+_load_lock = threading.Lock()
 
 
 def increment_model_ref(model_size: str):
@@ -117,53 +118,60 @@ def decrement_model_ref(model_size: str):
             _active_translations_per_model[model_size] -= 1
 
 
-
 def get_model_and_tokenizer(model_size: str):
     with _model_lock:
-        if model_size not in _loaded_models:
-            logger.info(f"Loading NLLB model: {model_size}")
-            import ctranslate2
-            import transformers
-            from huggingface_hub import snapshot_download
-
-            if not os.path.exists(model_size):
-                try:
-                    logger.info(f"Starting download of {model_size} from HuggingFace. This may take a few minutes...")
-
-                    class ScopedTqdm(ModelDownloadTqdm):
-                        def __init__(self, *args, **kwargs):
-                            super().__init__(*args, **kwargs)
-                            self._custom_model_id = model_size
-
-                    with _progress_lock:
-                        _download_progress[model_size] = {"n": 0, "total": 100, "rate": 0, "status": "downloading"}
-                    hf_repo_id = model_size
-                    rev = "main"
-                    if model_size == "nllb-200-distilled-600M":
-                        hf_repo_id = "JustFrederik/nllb-200-distilled-600M-ct2-int8"
-                        rev = "302d78f00e6fdb50a1064059df7c392b735e9d05"
-                    local_model_path = snapshot_download(repo_id=hf_repo_id, revision=rev, tqdm_class=ScopedTqdm)
-                    with _progress_lock:
-                        _download_progress[model_size]["status"] = "completed"
-                    logger.info(f"Successfully downloaded {model_size} to {local_model_path}")
-                except Exception as e:
-                    logger.error(f"Failed to download {model_size} from HuggingFace: {e}")
-                    with _progress_lock:
-                        _download_progress[model_size] = {"status": "error"}
-                    local_model_path = model_size
-            else:
-                local_model_path = model_size
-                with _progress_lock:
-                    _download_progress[model_size] = {"status": "completed"}
-
-            tokenizer = transformers.AutoTokenizer.from_pretrained(local_model_path, src_lang="eng_Latn", revision="main")  # nosec
-            model = ctranslate2.Translator(local_model_path, device="cpu", compute_type="int8")
-
-            _loaded_models[model_size] = ModelEntry(model=model, tokenizer=tokenizer, last_used=time.time())
-        else:
+        if model_size in _loaded_models:
             _loaded_models[model_size].last_used = time.time()
+            return _loaded_models[model_size].model, _loaded_models[model_size].tokenizer
 
-        return _loaded_models[model_size].model, _loaded_models[model_size].tokenizer
+    with _load_lock:
+        # Double-check inside the load lock
+        with _model_lock:
+            if model_size in _loaded_models:
+                _loaded_models[model_size].last_used = time.time()
+                return _loaded_models[model_size].model, _loaded_models[model_size].tokenizer
+
+        logger.info(f"Loading NLLB model: {model_size}")
+        import ctranslate2
+        import transformers
+        from huggingface_hub import snapshot_download
+
+        if not os.path.exists(model_size):
+            try:
+                logger.info(f"Starting download of {model_size} from HuggingFace. This may take a few minutes...")
+
+                class ScopedTqdm(ModelDownloadTqdm):
+                    def __init__(self, *args, **kwargs):
+                        super().__init__(*args, **kwargs)
+                        self._custom_model_id = model_size
+
+                with _progress_lock:
+                    _download_progress[model_size] = {"n": 0, "total": 100, "rate": 0, "status": "downloading"}
+                hf_repo_id = model_size
+                rev = "main"
+                if model_size == "nllb-200-distilled-600M":
+                    hf_repo_id = "JustFrederik/nllb-200-distilled-600M-ct2-int8"
+                    rev = "302d78f00e6fdb50a1064059df7c392b735e9d05"
+                local_model_path = snapshot_download(repo_id=hf_repo_id, revision=rev, tqdm_class=ScopedTqdm)
+                with _progress_lock:
+                    _download_progress[model_size]["status"] = "completed"
+                logger.info(f"Successfully downloaded {model_size} to {local_model_path}")
+            except Exception as e:
+                logger.error(f"Failed to download {model_size} from HuggingFace: {e}")
+                with _progress_lock:
+                    _download_progress[model_size] = {"status": "error"}
+                local_model_path = model_size
+        else:
+            local_model_path = model_size
+            with _progress_lock:
+                _download_progress[model_size] = {"status": "completed"}
+
+        tokenizer = transformers.AutoTokenizer.from_pretrained(local_model_path, src_lang="eng_Latn", revision="main")  # nosec
+        model = ctranslate2.Translator(local_model_path, device="cpu", compute_type="int8")
+
+        with _model_lock:
+            _loaded_models[model_size] = ModelEntry(model=model, tokenizer=tokenizer, last_used=time.time())
+            return _loaded_models[model_size].model, _loaded_models[model_size].tokenizer
 
 
 async def eviction_loop():

--- a/tests/test_local_translation.py
+++ b/tests/test_local_translation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from unittest.mock import patch
 
@@ -88,3 +89,46 @@ async def test_local_provider_eviction_respects_ref_count():
             pass
 
     assert model_size not in _loaded_models
+
+
+
+@pytest.mark.anyio
+async def test_eviction_loop_does_not_block_on_model_load():
+    model_size = "test-model-slow-load"
+    if model_size in _loaded_models:
+        del _loaded_models[model_size]
+
+    def slow_download(*args, **kwargs):
+        time.sleep(2)
+        return model_size
+
+    def background_loader():
+        with patch("huggingface_hub.snapshot_download", side_effect=slow_download), \
+             patch("ctranslate2.Translator"), \
+             patch("transformers.AutoTokenizer.from_pretrained"):
+            from portal.translations.providers.local import get_model_and_tokenizer
+
+            get_model_and_tokenizer(model_size)
+
+    # Start the slow model load in a background thread
+    t = threading.Thread(target=background_loader)
+    t.start()
+
+    # Yield control to let the thread acquire the locks and start sleeping
+    await asyncio.sleep(0.2)
+
+    start_time = time.time()
+
+    # Run eviction loop for one pass, expecting it to NOT block on the slow download
+    with patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()]):
+        try:
+            await asyncio.wait_for(eviction_loop(), timeout=1.0)
+        except asyncio.CancelledError:
+            pass
+        except TimeoutError:
+            pytest.fail("Eviction loop timed out because it was blocked by the model loading lock!")
+
+    elapsed = time.time() - start_time
+    assert elapsed < 1.0, f"Eviction loop blocked for {elapsed} seconds, indicating lock contention!"
+
+    t.join()

--- a/tests/test_local_translation.py
+++ b/tests/test_local_translation.py
@@ -98,12 +98,18 @@ async def test_eviction_loop_does_not_block_on_model_load():
     if model_size in _loaded_models:
         del _loaded_models[model_size]
 
-    def slow_download(*args, **kwargs):
-        time.sleep(2)
+    lock_acquired_event = threading.Event()
+    release_lock_event = threading.Event()
+
+    def simulated_slow_download(*args, **kwargs):
+        # Signal that the background thread is actively holding the load lock
+        lock_acquired_event.set()
+        # Block until the main thread tells us to release
+        release_lock_event.wait(timeout=5.0)
         return model_size
 
     def background_loader():
-        with patch("huggingface_hub.snapshot_download", side_effect=slow_download), \
+        with patch("huggingface_hub.snapshot_download", side_effect=simulated_slow_download), \
              patch("ctranslate2.Translator"), \
              patch("transformers.AutoTokenizer.from_pretrained"):
             from portal.translations.providers.local import get_model_and_tokenizer
@@ -114,8 +120,9 @@ async def test_eviction_loop_does_not_block_on_model_load():
     t = threading.Thread(target=background_loader)
     t.start()
 
-    # Yield control to let the thread acquire the locks and start sleeping
-    await asyncio.sleep(0.2)
+    # Yield control until the thread firmly acquires the load lock
+    while not lock_acquired_event.is_set():
+        await asyncio.sleep(0.01)
 
     start_time = time.time()
 
@@ -131,4 +138,6 @@ async def test_eviction_loop_does_not_block_on_model_load():
     elapsed = time.time() - start_time
     assert elapsed < 1.0, f"Eviction loop blocked for {elapsed} seconds, indicating lock contention!"
 
+    # Release the background thread so it can finish
+    release_lock_event.set()
     t.join()

--- a/tests/test_transcription_providers.py
+++ b/tests/test_transcription_providers.py
@@ -104,3 +104,48 @@ class TestTranscriptionProviders:
 
         decrement_model_ref("nonexistent-model")
         assert _active_booths_per_model.get("nonexistent-model", 0) == 0
+
+    async def test_transcription_eviction_loop_does_not_block_on_model_load(self):
+        import threading
+        import time
+
+        from portal.transcription.providers.local import _loaded_models, eviction_loop
+
+        model_size = "test-model-slow-load"
+        if model_size in _loaded_models:
+            del _loaded_models[model_size]
+
+        lock_acquired_event = threading.Event()
+        release_lock_event = threading.Event()
+
+        def simulated_slow_load(*args, **kwargs):
+            lock_acquired_event.set()
+            release_lock_event.wait(timeout=5.0)
+            return MagicMock()
+
+        def background_loader():
+            with patch("faster_whisper.WhisperModel", side_effect=simulated_slow_load):
+                from portal.transcription.providers.local import get_model
+                get_model(model_size)
+
+        t = threading.Thread(target=background_loader)
+        t.start()
+
+        while not lock_acquired_event.is_set():
+            await asyncio.sleep(0.01)
+
+        start_time = time.time()
+
+        with patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()]):
+            try:
+                await asyncio.wait_for(eviction_loop(), timeout=1.0)
+            except asyncio.CancelledError:
+                pass
+            except TimeoutError:
+                pytest.fail("Eviction loop timed out because it was blocked by the model loading lock!")
+
+        elapsed = time.time() - start_time
+        assert elapsed < 1.0, f"Eviction loop blocked for {elapsed} seconds, indicating lock contention!"
+
+        release_lock_event.set()
+        t.join()


### PR DESCRIPTION
## Summary

The issue stemmed from using a single lock (`_model_lock`) to protect both fast dictionary reads/writes and slow, blocking I/O (model downloading and VRAM loading). When the `eviction_loop` (running on the main asyncio thread) tried to acquire this lock while a background thread was loading a model, it would block the entire web server for minutes.

fixes #317 

## Changes Made

- **Introduced `_load_lock`**: Added a new global `_load_lock` to both `portal/transcription/providers/local.py` and `portal/translations/providers/local.py`. This lock's sole purpose is to serialize the slow process of downloading and instantiating models, preventing VRAM spikes.
- **Implemented Double-Checked Locking**: Refactored `get_model` and `get_model_and_tokenizer` to use the Double-Checked Locking pattern.
  - The ultra-fast `_model_lock` is now only held for a fraction of a millisecond to check if the model is already loaded.
  - If the model is not loaded, we release `_model_lock`, acquire the slow `_load_lock`, and do the heavy lifting, before briefly re-acquiring `_model_lock` to register the loaded model.
- **Added Concurrency Test**: Wrote a new asynchronous test `test_eviction_loop_does_not_block_on_model_load` in `tests/test_local_translation.py`. This test mocks a slow HuggingFace download (using `time.sleep`) running on a background thread, and proves that the `eviction_loop` can continue to run concurrently without blocking.

## Summary by Sourcery

Decouple fast model cache access from slow model loading to prevent event loop blocking under concurrent usage.

Bug Fixes:
- Prevent the translations and transcription eviction loops from blocking while background threads perform slow model downloads and initialization.

Tests:
- Add an asynchronous concurrency test ensuring the translation eviction loop continues running while a model is slowly loading in a background thread.