### PR TITLE
Adjust local transcription inference parameters for better accuracy

### DIFF
--- a/portal/transcription/providers/local.py
+++ b/portal/transcription/providers/local.py
@@ -124,7 +124,15 @@ class LocalProvider(TranscriptionProvider):
     ) -> str:
         model = get_model(model_size)
         segments, _ = model.transcribe(
-            audio_data, beam_size=5, vad_filter=True, language=language_code, word_timestamps=True
+            audio_data, 
+            beam_size=5, 
+            vad_filter=True, 
+            language=language_code, 
+            word_timestamps=True,
+            compression_ratio_threshold=2.4,
+            no_speech_threshold=0.6,
+            log_prob_threshold=-1.0,
+            condition_on_previous_text=False
         )
 
         valid_words = []

--- a/portal/transcription/providers/local.py
+++ b/portal/transcription/providers/local.py
@@ -124,10 +124,10 @@ class LocalProvider(TranscriptionProvider):
     ) -> str:
         model = get_model(model_size)
         segments, _ = model.transcribe(
-            audio_data, 
-            beam_size=5, 
-            vad_filter=True, 
-            language=language_code, 
+            audio_data,
+            beam_size=5,
+            vad_filter=True,
+            language=language_code,
             word_timestamps=True,
             compression_ratio_threshold=2.4,
             no_speech_threshold=0.6,

--- a/tests/test_transcription_providers.py
+++ b/tests/test_transcription_providers.py
@@ -149,3 +149,64 @@ class TestTranscriptionProviders:
 
         release_lock_event.set()
         t.join()
+
+    async def test_local_provider_applies_hallucination_filters(self):
+        import numpy as np
+
+        from portal.transcription.providers.local import LocalProvider
+
+        provider = LocalProvider()
+
+        with patch("portal.transcription.providers.local.get_model") as mock_get_model:
+            # Create a dummy function with the expected signature so inspect.signature works
+            def dummy_transcribe(
+                audio,
+                beam_size=5,
+                vad_filter=False,
+                language=None,
+                word_timestamps=False,
+                compression_ratio_threshold=2.4,
+                no_speech_threshold=0.6,
+                log_prob_threshold=-1.0,
+                condition_on_previous_text=False,
+                **kwargs
+            ):
+                pass
+
+            mock_model = MagicMock()
+            mock_model.transcribe = MagicMock(spec=dummy_transcribe)
+            mock_get_model.return_value = mock_model
+
+            # Mock a segment with valid speech
+            mock_segment = MagicMock()
+            mock_segment.text = "Hello world"
+
+            mock_word1 = MagicMock()
+            mock_word1.word = "Hello"
+            mock_word1.end = 1.5
+
+            mock_word2 = MagicMock()
+            mock_word2.word = "world"
+            mock_word2.end = 2.0
+
+            mock_segment.words = [mock_word1, mock_word2]
+
+            # Transcribe returns an iterable of segments and info
+            mock_model.transcribe.return_value = ([mock_segment], None)
+
+            # Run inference with dummy audio
+            audio_data = np.zeros(16000, dtype=np.float32)
+            result = provider._run_inference(audio_data, "en", "tiny", None)
+
+            # Verify that valid speech passes through
+            assert result == "Hello world"
+
+            # Verify that the anti-hallucination filters are strictly applied
+            mock_model.transcribe.assert_called_once()
+            _, kwargs = mock_model.transcribe.call_args
+
+            assert kwargs.get("compression_ratio_threshold") == 2.4
+            assert kwargs.get("no_speech_threshold") == 0.6
+            assert kwargs.get("log_prob_threshold") == -1.0
+            assert kwargs.get("condition_on_previous_text") is False
+            assert kwargs.get("vad_filter") is True


### PR DESCRIPTION
## Description

This PR addresses the hallucination issues in our current transcription pipeline. When processing silent or noisy audio segments, the `faster-whisper` model was prone to hallucinating repetitive phrases (e.g., "Click click") or outputting garbage encoding. 

This PR updates the `model.transcribe()` configuration in `local.py` to include the standard recommended anti-hallucination thresholds and context-isolation attributes to ensure reliable, clean transcription outputs and prevent wasting downstream API tokens.

## Related Issue

Closes #315 

## Changes Made

- Updated the `model.transcribe()` call in `portal/transcription/providers/local.py` with specific anti-hallucination parameters.
- **Added `compression_ratio_threshold=2.4`**: Filters out repetitive text hallucinations (like repeating phrases or coughing sounds). Whisper rejects the text if the output compresses too easily, which is a strong indicator of repetition.
- **Added `no_speech_threshold=0.6`**: Improves silence and background noise detection. If the model's confidence in the `<|nospeech|>` token exceeds this value, it will safely classify the segment as silence rather than attempting to guess random words.
- **Added `log_prob_threshold=-1.0`**: Acts as a strict confidence filter. If the model starts outputting garbage text, its confidence (log probability) drops. If it drops below `-1.0`, the chunk is discarded instead of returning the garbage. 
- **Added `condition_on_previous_text=False`**: Disables providing the previous text output as context for the current chunk. This prevents a single hallucination from cascading into an infinite loop across consecutive audio chunks, which is critical for our chunked processing pipeline.

## Summary by Sourcery

Bug Fixes:
- Mitigate repetitive or low-confidence hallucinations from the local transcription model by applying stricter anti-hallucination parameters to transcribe calls.