### PR TITLE
Potential fix for code scanning alert no. 1365: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_transcription_providers.py
+++ b/tests/test_transcription_providers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from urllib.parse import urlparse
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -54,7 +55,8 @@ class TestTranscriptionProviders:
 
             mock_client.post.assert_called_once()
             call_args = mock_client.post.call_args
-            assert "api.openai.com" in call_args[0][0]
+            parsed_url = urlparse(call_args[0][0])
+            assert parsed_url.hostname == "api.openai.com"
         finally:
             pg.shared_http_client = None
 


### PR DESCRIPTION
Potential fix for [https://github.com/fossasia/voxbento/security/code-scanning/1365](https://github.com/fossasia/voxbento/security/code-scanning/1365)

Use `urllib.parse.urlparse` to parse the called URL, then assert on the parsed hostname (and optionally scheme) instead of substring containment.

Best single fix in this snippet:
- In `tests/test_transcription_providers.py`, import `urlparse` from `urllib.parse`.
- Replace line 57 assertion with:
  - parse the first positional argument as URL,
  - assert `parsed.hostname == "api.openai.com"` (exact host check).

This keeps functionality unchanged (still verifies call targets OpenAI) but removes incomplete substring sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Tests:
- Update the transcription provider test to parse the requested URL and assert the hostname equals api.openai.com instead of relying on substring containment.