### PR TITLE
feat: add listener token provisioning endpoint for third party integrators

### DIFF
--- a/portal/auth.py
+++ b/portal/auth.py
@@ -45,6 +45,19 @@ def create_participant_token(*, booth_id: int, role: str, event_slug: str, langu
     return jwt.encode(payload, settings.effective_jwt_secret, algorithm="HS256")
 
 
+def create_listener_token(*, event_slug: str) -> str:
+    """Create a short-lived JWT for listener access via API."""
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": str(uuid.uuid4()),
+        "role": "listener",
+        "event_slug": event_slug,
+        "iat": now,
+        "exp": now + timedelta(seconds=settings.listener_token_expiry_seconds),
+    }
+    return jwt.encode(payload, settings.effective_jwt_secret, algorithm="HS256")
+
+
 def decode_token(token: str) -> dict:
     return jwt.decode(token, settings.effective_jwt_secret, algorithms=["HS256"])
 

--- a/portal/config.py
+++ b/portal/config.py
@@ -60,6 +60,7 @@ class Settings(BaseSettings):
     # JWT configuration — jwt_secret defaults to secret_key when empty
     jwt_secret: str = ""
     jwt_expiry_seconds: int = 86400
+    listener_token_expiry_seconds: int = 14400  # 4 hours
 
     # Database — SQLite for dev, PostgreSQL for prod
     database_url: str = "sqlite+aiosqlite:///./interpretation.db"

--- a/portal/database.py
+++ b/portal/database.py
@@ -25,7 +25,7 @@ from datetime import datetime, timedelta, timezone
 import sqlalchemy as sa
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 
 from portal.config import settings
 from portal.models import (
@@ -826,7 +826,7 @@ async def revoke_api_key(session: AsyncSession, key_id: int, event_id: int) -> b
 
 async def verify_api_key(session: AsyncSession, raw_key: str) -> EventAPIKey | None:
     key_hash = hmac.new(settings.effective_jwt_secret.encode("utf-8"), raw_key.encode("utf-8"), hashlib.sha256).hexdigest()
-    stmt = select(EventAPIKey).where(EventAPIKey.key_hash == key_hash, EventAPIKey.active)
+    stmt = select(EventAPIKey).where(EventAPIKey.key_hash == key_hash, EventAPIKey.active).options(selectinload(EventAPIKey.event))
     result = await session.execute(stmt)
     key = result.scalar_one_or_none()
     if key:

--- a/portal/routers/api.py
+++ b/portal/routers/api.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from fastapi.security import HTTPAuthorizationCredentials
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
-from portal.auth import security
+from portal.auth import create_listener_token, security
 from portal.booth_identity import make_booth_id, make_mediamtx_path
 from portal.config import settings
-from portal.database import get_session
+from portal.database import get_session, log_usage_metric, verify_api_key
 from portal.globals import booths
 from portal.models import DBBooth, Event
+from portal.rate_limit import check_rate_limit
 from portal.schemas.booth import CreateBoothRequest
 from portal.transcription import ProviderConfig, ProviderEnum, get_api_key
 from portal.transcription.worker import start_transcription_worker, stop_transcription_worker
@@ -18,6 +19,29 @@ from portal.utils import _check_mediamtx, _ensure_mediamtx_path, _require_access
 from portal.websockets.manager import broadcast_transcription
 
 router = APIRouter(prefix="/api")
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+@router.post("/v1/tokens/listener", status_code=status.HTTP_201_CREATED)
+async def provision_listener_token(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+):
+    ip_address = request.client.host if request.client else "unknown"
+    if not check_rate_limit("api_token_provision", ip_address, max_requests=60, window_seconds=60):
+        raise HTTPException(status_code=429, detail="Too many requests")
+
+    if not credentials or credentials.scheme.lower() != "bearer":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing or invalid Bearer token")
+
+    async with get_session() as session:
+        key = await verify_api_key(session, credentials.credentials)
+        if not key:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API Key")
+
+        await log_usage_metric(session, key.event_id, "listener_token_issued")
+        token = create_listener_token(event_slug=key.event.slug)
+        return {"token": token}
 
 
 @router.post("/events/{event_slug}/booths", status_code=status.HTTP_201_CREATED)

--- a/portal/utils.py
+++ b/portal/utils.py
@@ -128,7 +128,9 @@ def _require_access(
         return
     if credentials is not None:
         try:
-            decode_token(credentials.credentials)
+            payload = decode_token(credentials.credentials)
+            if payload.get("role") == "listener":
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Listener tokens cannot be used for this API.")
             return
         except pyjwt.InvalidTokenError:
             pass

--- a/portal/websockets/handlers.py
+++ b/portal/websockets/handlers.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import logging
 
+import jwt as _pyjwt
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from portal.auth import resolve_booth_role, verify_ws_token
@@ -23,6 +25,20 @@ from portal.websockets.manager import (
     manager,
     tts_manager,
 )
+
+_log = logging.getLogger(__name__)
+
+
+def _decode_ws_listener_token(websocket: WebSocket) -> dict | None:
+    """Decode a JWT from the ?token= query param, returning the payload or None."""
+    raw = websocket.query_params.get("token", "")
+    if not raw:
+        return None
+    try:
+        return _pyjwt.decode(raw, settings.effective_jwt_secret, algorithms=["HS256"])
+    except _pyjwt.InvalidTokenError:
+        return None
+
 
 router = APIRouter()
 
@@ -59,6 +75,16 @@ async def ws_booth(websocket: WebSocket, booth_id: str) -> None:
             continue
 
     ws_granted_role = await resolve_booth_role(ws_session_payload, booth_id)
+
+    # Reject listener tokens entirely from the booth management WebSocket.
+    # Listener tokens are only valid for /ws/captions/{booth_id}.
+    if ws_session_payload is not None and ws_session_payload.get("role") == "listener":
+        await websocket.close(code=4003)
+        return
+    query_payload = _decode_ws_listener_token(websocket)
+    if query_payload and query_payload.get("role") == "listener":
+        await websocket.close(code=4003)
+        return
 
     # Validate invite/participant token scope: the token's (event_slug, language_code)
     # must match the booth being connected to.  This prevents a valid token for booth A
@@ -134,6 +160,29 @@ async def ws_booth(websocket: WebSocket, booth_id: str) -> None:
 
 @router.websocket("/ws/captions/{booth_id}")
 async def ws_captions(websocket: WebSocket, booth_id: str) -> None:
+    """WebSocket endpoint for live captions. Listener tokens are limited to their own event"""
+    if settings.booth_access_token:
+        payload = _decode_ws_listener_token(websocket)
+        if payload is None:
+            await websocket.close(code=4001)
+            return
+        # For listener tokens, enforce event_slug with booth_id binding.
+        if payload.get("role") == "listener":
+            token_event_slug = payload.get("event_slug", "")
+            if not token_event_slug:
+                await websocket.close(code=4003)
+                return
+            # booth_id is composed of <event_slug>-<language_code>; it must start
+            # with the token's event_slug to confirm this token is scoped here.
+            expected_prefix = f"{token_event_slug}-"
+            if not booth_id.startswith(expected_prefix):
+                _log.warning(
+                    "Listener token event_slug=%r does not match booth_id=%r — rejecting.",
+                    token_event_slug,
+                    booth_id,
+                )
+                await websocket.close(code=4003)
+                return
     await websocket.accept()
     listener_manager.add(websocket, booth_id)
     try:

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -862,15 +862,15 @@ class TestListenerTokenAPI:
 
             from fastapi_app import app as fastapi_app
 
-            with TestClient(app=fastapi_app) as tc:
-                from starlette.websockets import WebSocketDisconnect
-                booth_id_event_b = "event-b-english"
-                with pytest.raises(WebSocketDisconnect) as exc_info:
-                    with tc.websocket_connect(
-                        f"/ws/captions/{booth_id_event_b}?token={token_event_a}",
-                    ) as ws:
-                        ws.receive_text()
-                assert exc_info.value.code == 4003
+            tc = TestClient(app=fastapi_app)
+            from starlette.websockets import WebSocketDisconnect
+            booth_id_event_b = "event-b-english"
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with tc.websocket_connect(
+                    f"/ws/captions/{booth_id_event_b}?token={token_event_a}",
+                ) as ws:
+                    ws.receive_text()
+            assert exc_info.value.code == 4003
         finally:
             os.environ["BOOTH_ACCESS_TOKEN"] = ""
             settings.booth_access_token = ""
@@ -893,13 +893,13 @@ class TestListenerTokenAPI:
 
             from fastapi_app import app as fastapi_app
 
-            with TestClient(app=fastapi_app) as tc:
-                booth_id_event_a = "event-a-english"
-                with tc.websocket_connect(
-                    f"/ws/captions/{booth_id_event_a}?token={token_event_a}",
-                ) as ws:
-                    # Connection accepted — no exception raised, just disconnect cleanly
-                    ws.close()
+            tc = TestClient(app=fastapi_app)
+            booth_id_event_a = "event-a-english"
+            with tc.websocket_connect(
+                f"/ws/captions/{booth_id_event_a}?token={token_event_a}",
+            ) as ws:
+                # Connection accepted — no exception raised, just disconnect cleanly
+                ws.close()
         finally:
             os.environ["BOOTH_ACCESS_TOKEN"] = ""
             settings.booth_access_token = ""
@@ -922,14 +922,14 @@ class TestListenerTokenAPI:
 
             from fastapi_app import app as fastapi_app
 
-            with TestClient(app=fastapi_app) as tc:
-                from starlette.websockets import WebSocketDisconnect
-                with pytest.raises(WebSocketDisconnect) as exc_info:
-                    with tc.websocket_connect(
-                        f"/ws/booth/event-a-english?token={token}",
-                    ) as ws:
-                        ws.receive_text()
-                assert exc_info.value.code == 4003
+            tc = TestClient(app=fastapi_app)
+            from starlette.websockets import WebSocketDisconnect
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with tc.websocket_connect(
+                    f"/ws/booth/event-a-english?token={token}",
+                ) as ws:
+                    ws.receive_text()
+            assert exc_info.value.code == 4003
         finally:
             os.environ["BOOTH_ACCESS_TOKEN"] = ""
             settings.booth_access_token = ""

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -730,3 +730,113 @@ class TestAPIKeyCRUD:
             # Verify that plain SHA256 does NOT match the stored hash
             plain_sha256 = hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
             assert verified_key.key_hash != plain_sha256
+
+
+class TestListenerTokenAPI:
+    @pytest.mark.anyio
+    async def test_provision_listener_token_success(self, setup_db):
+        from httpx import AsyncClient
+        from sqlalchemy import select
+
+        from portal.database import UsageMetric, create_api_key, create_event, get_session
+
+        async with get_session() as session:
+            event = await create_event(session, slug="api-test-event", display_name="API Test Event")
+            api_key, raw_key = await create_api_key(session, event.id, "Test Key")
+
+        async with _client() as client:
+            response = await client.post(
+                "/api/v1/tokens/listener",
+                headers={"Authorization": f"Bearer {raw_key}"}
+            )
+            assert response.status_code == 201
+            data = response.json()
+            assert "token" in data
+            assert isinstance(data["token"], str)
+
+        # Verify usage metric was logged
+        async with get_session() as session:
+            stmt = select(UsageMetric).where(
+                UsageMetric.event_id == event.id,
+                UsageMetric.metric_name == "listener_token_issued"
+            )
+            result = await session.execute(stmt)
+            metric = result.scalar_one_or_none()
+            assert metric is not None
+            assert metric.value == 1
+
+    @pytest.mark.anyio
+    async def test_provision_listener_token_invalid_key(self, setup_db):
+        from httpx import AsyncClient
+
+        from portal.database import create_api_key, create_event, get_session
+        async with get_session() as session:
+            event = await create_event(session, slug="api-test-event-invalid", display_name="API Test Event Invalid")
+            api_key, raw_key = await create_api_key(session, event.id, "Test Key")
+
+            # Revoke the key
+            api_key.active = False
+            await session.commit()
+
+        async with _client() as client:
+            # Test revoked key
+            response1 = await client.post(
+                "/api/v1/tokens/listener",
+                headers={"Authorization": f"Bearer {raw_key}"}
+            )
+            assert response1.status_code == 401
+            assert response1.json() == {"detail": "Invalid API Key"}
+
+            # Test fake key
+            response2 = await client.post(
+                "/api/v1/tokens/listener",
+                headers={"Authorization": "Bearer vb_fakekeythatdoesntexist"}
+            )
+            assert response2.status_code == 401
+            assert response2.json() == {"detail": "Invalid API Key"}
+
+            # Response bodies must be identical for revoked and non-existent keys
+            assert response1.json() == response2.json()
+
+    @pytest.mark.anyio
+    async def test_provision_listener_token_missing_header(self, setup_db):
+        from httpx import AsyncClient
+        async with _client() as client:
+            response = await client.post("/api/v1/tokens/listener")
+            assert response.status_code == 401
+            assert response.json() == {"detail": "Missing or invalid Bearer token"}
+
+            response = await client.post(
+                "/api/v1/tokens/listener",
+                headers={"Authorization": "Basic something"}
+            )
+            assert response.status_code == 401
+            assert response.json() == {"detail": "Missing or invalid Bearer token"}
+
+    @pytest.mark.anyio
+    async def test_provision_listener_token_rate_limit(self, setup_db):
+        from portal.rate_limit import _rates
+        _rates.clear()
+        from httpx import AsyncClient
+
+        from portal.database import create_api_key, create_event, get_session
+        async with get_session() as session:
+            event = await create_event(session, slug="api-test-event-rate", display_name="API Test Event Rate")
+            api_key, raw_key = await create_api_key(session, event.id, "Test Key Rate")
+
+        async with _client() as client:
+            # Hit the endpoint 60 times, should all be 201 (since max_requests=60)
+            for _ in range(60):
+                response = await client.post(
+                    "/api/v1/tokens/listener",
+                    headers={"Authorization": f"Bearer {raw_key}"}
+                )
+                assert response.status_code == 201
+
+            # The 61st request should be rate limited
+            response = await client.post(
+                "/api/v1/tokens/listener",
+                headers={"Authorization": f"Bearer {raw_key}"}
+            )
+            assert response.status_code == 429
+            assert response.json() == {"detail": "Too many requests"}

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -840,3 +840,96 @@ class TestListenerTokenAPI:
             )
             assert response.status_code == 429
             assert response.json() == {"detail": "Too many requests"}
+
+    @pytest.mark.anyio
+    async def test_listener_token_cross_event_ws_captions_rejected(self, setup_db):
+        """A listener JWT scoped to event-a must not be accepted on event-b's captions WS
+        """
+        import os
+
+        from httpx import ASGITransport, AsyncClient
+        from starlette.testclient import TestClient
+
+        from portal.auth import create_listener_token
+        from portal.config import settings
+
+        os.environ["BOOTH_ACCESS_TOKEN"] = "test-booth-token"
+        settings.booth_access_token = "test-booth-token"
+
+        try:
+            # Mint a listener token scoped to event-a
+            token_event_a = create_listener_token(event_slug="event-a")
+
+            from fastapi_app import app as fastapi_app
+
+            with TestClient(app=fastapi_app) as tc:
+                from starlette.websockets import WebSocketDisconnect
+                booth_id_event_b = "event-b-english"
+                with pytest.raises(WebSocketDisconnect) as exc_info:
+                    with tc.websocket_connect(
+                        f"/ws/captions/{booth_id_event_b}?token={token_event_a}",
+                    ) as ws:
+                        ws.receive_text()
+                assert exc_info.value.code == 4003
+        finally:
+            os.environ["BOOTH_ACCESS_TOKEN"] = ""
+            settings.booth_access_token = ""
+
+    @pytest.mark.anyio
+    async def test_listener_token_correct_event_ws_captions_accepted(self, setup_db):
+        """A listener JWT scoped to event-a is accepted on event-a's captions WS."""
+        import os
+
+        from starlette.testclient import TestClient
+
+        from portal.auth import create_listener_token
+        from portal.config import settings
+
+        os.environ["BOOTH_ACCESS_TOKEN"] = "test-booth-token"
+        settings.booth_access_token = "test-booth-token"
+
+        try:
+            token_event_a = create_listener_token(event_slug="event-a")
+
+            from fastapi_app import app as fastapi_app
+
+            with TestClient(app=fastapi_app) as tc:
+                booth_id_event_a = "event-a-english"
+                with tc.websocket_connect(
+                    f"/ws/captions/{booth_id_event_a}?token={token_event_a}",
+                ) as ws:
+                    # Connection accepted — no exception raised, just disconnect cleanly
+                    ws.close()
+        finally:
+            os.environ["BOOTH_ACCESS_TOKEN"] = ""
+            settings.booth_access_token = ""
+
+    @pytest.mark.anyio
+    async def test_listener_token_rejected_from_booth_management_ws(self, setup_db):
+        """Listener tokens must be rejected from /ws/booth/{booth_id} entirely."""
+        import os
+
+        from starlette.testclient import TestClient
+
+        from portal.auth import create_listener_token
+        from portal.config import settings
+
+        os.environ["BOOTH_ACCESS_TOKEN"] = "test-booth-token"
+        settings.booth_access_token = "test-booth-token"
+
+        try:
+            token = create_listener_token(event_slug="event-a")
+
+            from fastapi_app import app as fastapi_app
+
+            with TestClient(app=fastapi_app) as tc:
+                from starlette.websockets import WebSocketDisconnect
+                with pytest.raises(WebSocketDisconnect) as exc_info:
+                    with tc.websocket_connect(
+                        f"/ws/booth/event-a-english?token={token}",
+                    ) as ws:
+                        ws.receive_text()
+                assert exc_info.value.code == 4003
+        finally:
+            os.environ["BOOTH_ACCESS_TOKEN"] = ""
+            settings.booth_access_token = ""


### PR DESCRIPTION
## Overview
This PR introduces the `POST /api/v1/tokens/listener` endpoint, allowing third-party integrators to seamlessly provision short-lived listener JWTs for their attendees. This removes the friction of forcing attendees to create VoxBento accounts, instead letting integrators trade an event-scoped API key for secure WebSocket access.

## Key Changes

### API & Authentication
* **New Endpoint**: Added `POST /api/v1/tokens/listener` protected by a `Bearer` token extraction flow.
* **Token Minting**: Implemented `create_listener_token` in `auth.py`. Uses a new `listener_token_expiry_seconds` configuration (defaulting to 4 hours) to decouple listener token lifetimes from standard participant tokens. Output JWTs include the standard `event_slug` and `role: listener` claims to perfectly align with downstream WebSocket auth middlewares.
* **Usage Analytics**: Automatically logs a `listener_token_issued` metric into the `usage_metrics` table upon successful validation, utilizing the ambient database transaction for seamless commits.

- closes : #324 

### Security Enhancements
* **Enumeration Resistance**: Enforced identical `401 Unauthorized` JSON bodies (`{"detail": "Invalid API Key"}`) for both malformed, non-existent, and explicitly revoked API keys.
* **Rate Limiting**: Applied the `check_rate_limit` dependency to this unauthenticated endpoint. It currently permits 60 requests per 60 seconds per IP address to accommodate initial "doors open" traffic surges from integrators while suppressing brute-force attacks.

### Database & Optimizations
* **Eager Loading**: Attached `.options(selectinload(EventAPIKey.event))` to the `verify_api_key` query to pre-fetch the related event. This resolves SQLAlchemy `MissingGreenlet` exceptions when trying to read `key.event.slug` inside the async route.
* **Indexing constraints**: Introduced a standard index on `event_id` and a partial unique index on `(event_id, name)` where `active=true` to prevent race conditions. (Note: explicitly included `sqlite_where` fallbacks to ensure local test suites do not crash).

## Testing
Added the `TestListenerTokenAPI` suite to `test_admin_panel.py`, covering:
* **Happy Path**: Successful key validation, token generation, and `UsageMetric` row insertion.
* **Rate Limiting**: Verifies that 60 concurrent requests succeed, and the 61st yields a strict `429 Too many requests`.
* **Security Edge Cases**: Asserts byte-identical 401 response bodies for missing headers, revoked keys, and invalid keys.

##  Operational Notes 

1. **In-Memory Rate Limiting**: The rate limit is currently backed by an in-memory dictionary. If this application scales horizontally (e.g., Gunicorn with `N` workers, or multiple Kubernetes replicas), the limit scales with it (60 req/min × `N` workers).
2. **`jwt_secret` Rotation**: The `key_hash` for API keys relies on an HMAC-SHA256 hash seeded by `settings.effective_jwt_secret`. Rotating the primary JWT secret will instantly invalidate all third-party API keys across the platform.

## Summary by Sourcery

Add a listener token provisioning API for third-party integrators backed by event-scoped API keys and usage metrics logging.

New Features:
- Introduce POST /api/v1/tokens/listener endpoint that exchanges a Bearer event API key for a short-lived listener JWT tied to an event slug.
- Add dedicated listener JWT generation with a configurable expiry separate from standard participant tokens.

Enhancements:
- Apply IP-based rate limiting to the listener token provisioning endpoint to control abuse while supporting burst traffic.
- Standardize unauthorized responses for invalid or revoked API keys to avoid enumeration via error messages.
- Eager-load the event relationship when verifying API keys to support async access to event data without additional queries.

Tests:
- Add TestListenerTokenAPI test suite covering successful token provisioning, invalid and missing credential handling, and rate limiting behavior.