### PR TITLE
fix: handle existing booths in eventyay integration

### DIFF
--- a/portal/routers/api.py
+++ b/portal/routers/api.py
@@ -128,7 +128,7 @@ async def create_event_booth(
         )
         await session.commit()
 
-        state["interpreter_invite_url"] = f"{settings.public_base_url}/auth/magic/{invite.token}"
+        state["interpreter_invite_url"] = f"{settings.public_base_url}/join/{invite.token}"
 
     state["caption_url"] = f"wss://{settings.public_base_url.replace('https://', '').replace('http://', '')}/ws/captions/{state['booth_id']}"
     return state

--- a/portal/routers/api.py
+++ b/portal/routers/api.py
@@ -66,7 +66,17 @@ async def create_event_booth(
             room_id=body.room_id,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+        if "already exists" in str(exc):
+            booth_id = make_booth_id(event_slug, body.language_code)
+            mtx_path = make_mediamtx_path(event_slug, body.language_code)
+            state = await booths.snapshot(
+                booth_id=booth_id,
+                language=body.language or body.language_code.upper(),
+                channel_id=mtx_path,
+                room_id=body.room_id,
+            )
+        else:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     mediamtx_path = state["mediamtx_path"]
     await _ensure_mediamtx_path(mediamtx_path)
     state["whip_url"] = f"{settings.mediamtx_whip_base}/{mediamtx_path}/whip"

--- a/portal/routers/api.py
+++ b/portal/routers/api.py
@@ -98,10 +98,17 @@ async def create_event_booth(
                 select(Room).where(Room.event_id == event.id, Room.eventyay_room_id == str(body.room_id))
             )
             room = room_query.scalar_one_or_none()
+            display_name = body.room_name or f"Room {body.room_id}"
             if not room:
-                room = Room(event_id=event.id, display_name=f"Room {body.room_id}", eventyay_room_id=str(body.room_id))
+                room = Room(
+                    event_id=event.id,
+                    display_name=display_name,
+                    eventyay_room_id=str(body.room_id),
+                )
                 session.add(room)
-                await session.flush()
+            elif room.display_name != display_name:
+                room.display_name = display_name
+            await session.flush()
             db_room_id = room.id
 
         # 3. Get or Create DBBooth

--- a/portal/schemas/booth.py
+++ b/portal/schemas/booth.py
@@ -5,4 +5,5 @@ class CreateBoothRequest(BaseModel):
     language_code: str
     language: str = ""
     room_id: int | None = None
+    room_name: str | None = None
     instance: str = "primary"

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -1023,12 +1023,12 @@ def test_create_event_booth():
     assert body["whep_url"].endswith("/pycon2026/en/whep")
 
 
-def test_create_event_booth_duplicate_returns_400():
-    """Creating the same booth twice returns 400."""
+def test_create_event_booth_duplicate_returns_existing():
+    """Creating the same booth twice returns the existing booth data."""
     client.post("/api/events/duptest/booths", json={"language_code": "fr", "language": "French"})
     res = client.post("/api/events/duptest/booths", json={"language_code": "fr", "language": "French"})
-    assert res.status_code == 400
-    assert "already exists" in res.json()["detail"]
+    assert res.status_code == 201
+    assert res.json()["booth_id"] == "duptest-fr"
 
 
 def test_create_event_booth_invalid_language_code():


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Allow event booth creation to succeed by reusing the existing booth state when the underlying integration reports that the booth already exists.