### PR TITLE
feat: standalone embed player for any third party application with custom CSS support

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -56,14 +57,12 @@ async def lifespan(app: FastAPI):
 
     dg.track_task(asyncio.create_task(_gen()))
 
-    import logging
     logging.getLogger("uvicorn.access").addFilter(_UvicornTokenRedactor())
     yield
     if pg.shared_http_client:
         await pg.shared_http_client.aclose()
 
 
-import logging
 class _UvicornTokenRedactor(logging.Filter):
     import re as _re
     _TOKEN_RE = _re.compile(r"(?i)((?:^|&|\?)token=)[^&\s]*")

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -57,23 +57,27 @@ async def lifespan(app: FastAPI):
     dg.track_task(asyncio.create_task(_gen()))
 
     import logging
-    class _UvicornTokenRedactor(logging.Filter):
-        def filter(self, record):
-            if hasattr(record, "args") and len(record.args) >= 3:
-                new_args = []
-                for arg in record.args:
-                    if isinstance(arg, str) and "token=" in arg and (arg.startswith("/embed/") or arg.startswith("/ws/")):
-                        import re as _re
-                        arg = _re.sub(r"(?i)((?:^|&|\?)token=)[^& ]*", r"\1[REDACTED]", arg)
-                    new_args.append(arg)
-                record.args = tuple(new_args)
-            return True
-
     logging.getLogger("uvicorn.access").addFilter(_UvicornTokenRedactor())
-
     yield
     if pg.shared_http_client:
         await pg.shared_http_client.aclose()
+
+
+import logging
+class _UvicornTokenRedactor(logging.Filter):
+    import re as _re
+    _TOKEN_RE = _re.compile(r"(?i)((?:^|&|\?)token=)[^&\s]*")
+
+    def filter(self, record):
+        try:
+            message = record.getMessage()
+        except Exception:
+            return True
+
+        if "token=" in message and ("/embed/" in message or "/ws/" in message):
+            record.msg = self._TOKEN_RE.sub(r"\1[REDACTED]", message)
+            record.args = ()
+        return True
 
 
 app = FastAPI(title="Voxbento", version="1.0.0", lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url=None)

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -56,13 +56,27 @@ async def lifespan(app: FastAPI):
 
     dg.track_task(asyncio.create_task(_gen()))
 
+    import logging
+    class _UvicornTokenRedactor(logging.Filter):
+        def filter(self, record):
+            if hasattr(record, "args") and len(record.args) >= 3:
+                new_args = []
+                for arg in record.args:
+                    if isinstance(arg, str) and "token=" in arg and (arg.startswith("/embed/") or arg.startswith("/ws/")):
+                        import re as _re
+                        arg = _re.sub(r"(?i)((?:^|&|\?)token=)[^& ]*", r"\1[REDACTED]", arg)
+                    new_args.append(arg)
+                record.args = tuple(new_args)
+            return True
+
+    logging.getLogger("uvicorn.access").addFilter(_UvicornTokenRedactor())
+
     yield
     if pg.shared_http_client:
         await pg.shared_http_client.aclose()
 
 
 app = FastAPI(title="Voxbento", version="1.0.0", lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url=None)
-
 
 @app.get("/docs", include_in_schema=False)
 async def custom_swagger_ui_html(request: Request, _=Depends(require_admin)):

--- a/portal/auth.py
+++ b/portal/auth.py
@@ -58,6 +58,26 @@ def create_listener_token(*, event_slug: str) -> str:
     return jwt.encode(payload, settings.effective_jwt_secret, algorithm="HS256")
 
 
+def create_embed_token(*, event_slug: str) -> str:
+    """Create a short-lived JWT for embed iframe access.
+
+    Identical claim shape to create_listener_token (role='listener', event_slug)
+    so it passes both the embed route's claim checks and the /ws/captions
+    WebSocket auth's booth_id.startswith(event_slug + '-') check.
+    Uses a shorter expiry (embed_token_expiry_seconds, default 30 min) because
+    the token is visible in the iframe src= attribute in the third party's HTML.
+    """
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": str(uuid.uuid4()),
+        "role": "listener",
+        "event_slug": event_slug,
+        "iat": now,
+        "exp": now + timedelta(seconds=settings.embed_token_expiry_seconds),
+    }
+    return jwt.encode(payload, settings.effective_jwt_secret, algorithm="HS256")
+
+
 def decode_token(token: str) -> dict:
     return jwt.decode(token, settings.effective_jwt_secret, algorithms=["HS256"])
 
@@ -380,7 +400,7 @@ async def resolve_ws_auth(websocket: WebSocket, booth_id: str) -> dict:
 
         token_event = payload.get("event_slug", "")
         if payload.get("role") == "listener":
-            if not token_event or not booth_id.startswith(f"{token_event}-"):
+            if not token_event or not (booth_id.startswith(f"{token_event}-") or booth_id.startswith(f"{token_event}/")):
                 await websocket.close(code=4003)
                 raise WSAuthError("Listener token event_slug does not match booth_id.")
             return payload

--- a/portal/config.py
+++ b/portal/config.py
@@ -61,6 +61,13 @@ class Settings(BaseSettings):
     jwt_secret: str = ""
     jwt_expiry_seconds: int = 86400
     listener_token_expiry_seconds: int = 14400  # 4 hours
+    # Embed iframe tokens have a shorter lifetime because the token sits in a
+    # publicly visible iframe src= attribute, making it more easily copied.
+    embed_token_expiry_seconds: int = 1800  # 30 minutes
+    # Space-separated CSP frame-ancestors value for the /embed/ route.
+    # Input is comma-separated for human readability and converted to spaces internally.
+    # Empty string = frame-ancestors * (any site may embed).
+    embed_allowed_origins: str = ""
 
     # Database — SQLite for dev, PostgreSQL for prod
     database_url: str = "sqlite+aiosqlite:///./interpretation.db"

--- a/portal/globals.py
+++ b/portal/globals.py
@@ -21,3 +21,5 @@ def get_http_client() -> httpx.AsyncClient:
     if shared_http_client is None or getattr(shared_http_client, "is_closed", False):
         shared_http_client = httpx.AsyncClient(timeout=10.0)
     return shared_http_client
+
+# force reload

--- a/portal/routers/api.py
+++ b/portal/routers/api.py
@@ -5,7 +5,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
-from portal.auth import create_listener_token, security
+from portal.auth import create_embed_token, create_listener_token, security
 from portal.booth_identity import make_booth_id, make_mediamtx_path
 from portal.config import settings
 from portal.database import create_invite_token, get_session, log_usage_metric, verify_api_key
@@ -26,7 +26,15 @@ bearer_scheme = HTTPBearer(auto_error=False)
 async def provision_listener_token(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    purpose: str | None = Query(None),
 ):
+    """Issue a listener JWT for a third-party client.
+
+    - Default (no purpose param): 4-hour token for WebSocket listener use.
+    - purpose=embed: 30-minute token for embedding in an iframe src= attribute.
+      The shorter lifetime limits exposure since the token is visible in the
+      third party's page HTML source.
+    """
     ip_address = request.client.host if request.client else "unknown"
     if not check_rate_limit("api_token_provision", ip_address, max_requests=60, window_seconds=60):
         raise HTTPException(status_code=429, detail="Too many requests")
@@ -40,7 +48,10 @@ async def provision_listener_token(
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API Key")
 
         await log_usage_metric(session, key.event_id, "listener_token_issued")
-        token = create_listener_token(event_slug=key.event.slug)
+        if purpose == "embed":
+            token = create_embed_token(event_slug=key.event.slug)
+        else:
+            token = create_listener_token(event_slug=key.event.slug)
         return {"token": token}
 
 

--- a/portal/routers/listener.py
+++ b/portal/routers/listener.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import time
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Request, status
+import jwt
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from fastapi.templating import Jinja2Templates
 
-from portal.auth import get_booth_session
+from portal.auth import decode_token, get_booth_session
 from portal.config import settings
 from portal.database import (
     get_event_by_slug,
@@ -20,6 +22,12 @@ from portal.database import (
 )
 from portal.globals import _JS_CACHE_BUST
 from portal.utils import _ensure_mediamtx_path
+
+# Allowlists for embed theming params — no free-text values accepted.
+_ALLOWED_THEMES = {"dark", "light"}
+_ALLOWED_FONTS = {"inter", "roboto", "outfit"}
+_PRIMARY_COLOR_RE = re.compile(r"^[0-9a-fA-F]{3,6}$")
+_DEFAULT_PRIMARY = "3b82f6"  # VoxBento blue
 
 _BASE_DIR = Path(__file__).resolve().parent.parent.parent
 templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
@@ -179,3 +187,115 @@ async def listener_room_audio_delay(
         if room is None or room.event_id != ev.id:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Room not found")
         return {"audio_delay_ms": room.audio_delay_ms}
+
+
+@router.get("/embed/{event_slug}/{language_code}")
+async def embed_listener(
+    request: Request,
+    event_slug: str,
+    language_code: str,
+    token: str = Query(""),
+    theme: str = Query("dark"),
+    primary_color: str = Query(_DEFAULT_PRIMARY, alias="primaryColor"),
+    font: str = Query("inter"),
+    captions: bool = Query(False),
+    custom_css_url: str | None = Query(None, alias="customCssUrl"),
+):
+    """Serve a standalone, iframe-safe listener embed.
+
+    Authentication: requires a listener JWT in the ?token= query parameter.
+    The token must carry role='listener' and event_slug matching the URL.
+    Use POST /api/v1/tokens/listener?purpose=embed to obtain a 30-minute token.
+
+    Theming: accepts ?theme=dark|light, ?primaryColor=<hex>, ?font=inter|roboto|outfit.
+    All theming values are strictly validated server-side.
+    """
+    # ── Authentication ────────────────────────────────────────────────────
+    if not token:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Missing embed token.")
+
+    try:
+        payload = decode_token(token)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Embed token has expired.")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid embed token.")
+
+    # Explicit claim checks — .get() only, never bare key access
+    if payload.get("role") != "listener":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Token is not a listener token.")
+    if payload.get("event_slug") != event_slug:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Token is not valid for this event.")
+
+    # ── Resolve booth ─────────────────────────────────────────────────────
+    from portal.database import list_booths_for_event
+
+    async with get_session() as session:
+        ev = await get_event_by_slug(session, event_slug)
+        if not ev:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found.")
+
+        if language_code.lower() != "floor":
+            db_booths = await list_booths_for_event(session, ev.id)
+
+    if language_code.lower() == "floor":
+        channel_id = f"{ev.slug}/floor"
+        booth_id = f"{ev.slug}-floor"
+    else:
+        booth = next(
+            (b for b in db_booths if b.language_code.lower() == language_code.lower()),
+            None,
+        )
+        if booth is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No booth for language '{language_code}' in event '{event_slug}'.",
+            )
+        channel_id = booth.mediamtx_path
+        booth_id = f"{ev.slug}-{language_code.lower()}"
+    whep_url = f"{settings.mediamtx_whip_base}/{channel_id}/whep"
+    host = settings.public_base_url.replace("https://", "").replace("http://", "")
+    caption_url = f"wss://{host}/ws/captions/{booth_id}"
+
+    # ── Sanitize theming params ───────────────────────────────────────────
+    safe_theme = theme if theme in _ALLOWED_THEMES else "dark"
+    safe_font = font if font in _ALLOWED_FONTS else "inter"
+    safe_primary = primary_color if _PRIMARY_COLOR_RE.match(primary_color) else _DEFAULT_PRIMARY
+
+    safe_custom_css = None
+    if custom_css_url and custom_css_url.startswith("https://"):
+        safe_custom_css = custom_css_url
+
+    # ── Security headers ─────────────────────────────────────────────────
+    if settings.embed_allowed_origins.strip():
+        origins = " ".join(
+            o.strip() for o in settings.embed_allowed_origins.split(",") if o.strip()
+        )
+        frame_ancestors = f"frame-ancestors {origins}"
+    else:
+        frame_ancestors = "frame-ancestors *"
+
+    response_headers = {
+        "Cache-Control": "no-store, private",
+        "Referrer-Policy": "no-referrer",
+        "Content-Security-Policy": frame_ancestors,
+    }
+
+    context = {
+        "event_slug": event_slug,
+        "language_code": language_code,
+        "whep_url": whep_url,
+        "caption_url": caption_url,
+        "token": token,
+        "theme": safe_theme,
+        "primary_color": safe_primary,
+        "font_family": safe_font.capitalize(),
+        "captions_enabled": captions,
+        "custom_css_url": safe_custom_css,
+        "target_lang_code": language_code.lower(),
+        "js_version": _JS_CACHE_BUST,
+    }
+
+    return templates.TemplateResponse(
+        request, "embed.html", context, headers=response_headers
+    )

--- a/static/css/embed.css
+++ b/static/css/embed.css
@@ -87,6 +87,8 @@ body {
 /* ── Captions ─────────────────────────────────────────────────────────── */
 .captions-box {
   min-height: 52px;
+  max-height: 160px;
+  overflow-y: auto;
   padding: 10px 14px;
   background: var(--bg);
   border: 1px solid var(--border);
@@ -94,8 +96,10 @@ body {
   font-size: 13px;
   line-height: 1.55;
   color: var(--text);
+  word-wrap: break-word;
 }
-.captions-box.empty { color: var(--muted); font-style: italic; }
+.captions-box.empty #embed-caption-placeholder { display: block; color: var(--muted); font-style: italic; }
+.captions-box:not(.empty) #embed-caption-placeholder { display: none; }
 
 /* ── Branding footer ─────────────────────────────────────────────────── */
 .footer {

--- a/static/css/embed.css
+++ b/static/css/embed.css
@@ -1,0 +1,108 @@
+/* ── Reset ────────────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* ── Layout ───────────────────────────────────────────────────────────── */
+html, body {
+  height: 100%;
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  gap: 12px;
+}
+
+/* ── Player card ─────────────────────────────────────────────────────── */
+.player {
+  width: 100%;
+  max-width: 480px;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  border-radius: 12px;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ── Status bar ──────────────────────────────────────────────────────── */
+.status-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--muted);
+  flex-shrink: 0;
+  transition: background 0.3s;
+}
+.status-dot.live       { background: #22c55e; box-shadow: 0 0 6px #22c55e88; }
+.status-dot.error      { background: #ef4444; }
+.status-dot.connecting { background: var(--primary); animation: pulse 1.2s infinite; }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.35; }
+}
+
+/* ── Play button ─────────────────────────────────────────────────────── */
+.play-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 8px;
+  background: var(--primary);
+  color: #fff;
+  font-family: var(--font);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.1s;
+  letter-spacing: 0.02em;
+}
+.play-btn:hover:not(:disabled) { opacity: 0.88; transform: translateY(-1px); }
+.play-btn:active:not(:disabled) { transform: translateY(0); }
+.play-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* ── Captions ─────────────────────────────────────────────────────────── */
+.captions-box {
+  min-height: 52px;
+  padding: 10px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text);
+}
+.captions-box.empty { color: var(--muted); font-style: italic; }
+
+/* ── Branding footer ─────────────────────────────────────────────────── */
+.footer {
+  font-size: 11px;
+  color: var(--muted);
+  opacity: 0.7;
+  text-align: center;
+}
+.footer a { color: var(--primary); text-decoration: none; }
+.footer a:hover { text-decoration: underline; }

--- a/static/js/embed-player.js
+++ b/static/js/embed-player.js
@@ -7,6 +7,7 @@
       console.error('Embed configuration not found.');
       return;
     }
+    console.log("Embed Player v2 Initialized");
     
     let config;
     try {
@@ -82,6 +83,10 @@
       var wsUrl = wsProto + '//' + window.location.host + urlPath + '?token=' + encodeURIComponent(EMBED_TOKEN);
       var captionWs = new WebSocket(wsUrl);
 
+      var historyEl = document.getElementById('embed-caption-history');
+      var currentEl = document.getElementById('embed-caption-current');
+      var maxHistory = 50;
+
       captionWs.onmessage = function(ev) {
         try {
           var msg = JSON.parse(ev.data);
@@ -92,10 +97,34 @@
           } else if (msg.type === 'translation' && msg.language_code === TARGET_LANG) {
               isValid = true;
           }
+          
+          if (isValid) {
+            console.log("Caption WS MSG:", msg);
+            var status = msg.type === 'translation' ? 'final' : (msg.status || 'final');
+            var text = (msg.text || '').trim();
 
-          if (isValid && msg.text) {
-            captionsEl.textContent = msg.text;
-            captionsEl.classList.remove('empty');
+            if (status === 'clear') {
+              currentEl.textContent = '';
+            } else if (status === 'final') {
+              if (text) {
+                var p = document.createElement('div');
+                p.textContent = text;
+                historyEl.appendChild(p);
+                while (historyEl.children.length > maxHistory) {
+                  historyEl.removeChild(historyEl.firstChild);
+                }
+              }
+              currentEl.textContent = '';
+            } else if (status === 'partial') {
+              currentEl.textContent = text;
+            }
+
+            if (historyEl.children.length === 0 && !currentEl.textContent) {
+              captionsEl.classList.add('empty');
+            } else {
+              captionsEl.classList.remove('empty');
+            }
+            captionsEl.scrollTop = captionsEl.scrollHeight;
           }
         } catch (_) {}
       };

--- a/static/js/embed-player.js
+++ b/static/js/embed-player.js
@@ -1,0 +1,108 @@
+'use strict';
+
+(function() {
+  document.addEventListener('DOMContentLoaded', function() {
+    const configEl = document.getElementById('embed-config');
+    if (!configEl) {
+      console.error('Embed configuration not found.');
+      return;
+    }
+    
+    let config;
+    try {
+      config = JSON.parse(configEl.textContent);
+    } catch (e) {
+      console.error('Failed to parse embed configuration:', e);
+      return;
+    }
+
+    const WHEP_URL    = config.whep_url;
+    const CAPTION_URL = config.caption_url;
+    const CAPTIONS_ON = config.captions_enabled;
+    const EMBED_TOKEN = config.token;
+    const TARGET_LANG = config.target_lang_code;
+
+    const audioEl    = document.getElementById('embed-audio');
+    const playBtn    = document.getElementById('play-btn');
+    const statusDot  = document.getElementById('status-dot');
+    const statusText = document.getElementById('status-text');
+    const captionsEl = document.getElementById('captions-box') || null;
+
+    let playing = false;
+
+    function setStatus(state, text) {
+      statusDot.className = 'status-dot ' + (state || '');
+      statusText.textContent = text;
+    }
+
+    function setExpired() {
+      setStatus('error', 'Session expired');
+      playBtn.textContent = '\u26a0 Session Expired \u2014 Reload Host Page';
+      playBtn.disabled = true;
+    }
+
+    const whep = createWhepClient();
+
+    whep.start({
+      whepUrl: WHEP_URL,
+      audioEl: audioEl,
+      onState: function(s) {
+        if (s.peerConnection === 'connected') {
+          setStatus('live', 'Live');
+          playBtn.disabled = false;
+          playBtn.textContent = playing ? '\u23f8  Pause' : '\u25b6  Play Audio';
+        } else if (s.peerConnection === 'failed' || s.peerConnection === 'closed') {
+          setStatus('error', 'Stream unavailable');
+          playBtn.disabled = false;
+        } else {
+          setStatus('connecting', 'Connecting\u2026');
+        }
+      },
+      onLog: function() {},
+    });
+
+    playBtn.addEventListener('click', function() {
+      if (!playing) {
+        audioEl.play().then(function() {
+          playing = true;
+          playBtn.textContent = '\u23f8  Pause';
+        }).catch(function() {
+          setStatus('error', 'Playback blocked \u2014 check browser permissions');
+        });
+      } else {
+        audioEl.pause();
+        playing = false;
+        playBtn.textContent = '\u25b6  Play Audio';
+      }
+    });
+
+    if (CAPTIONS_ON && captionsEl) {
+      var wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      var urlPath = new URL(CAPTION_URL).pathname;
+      var wsUrl = wsProto + '//' + window.location.host + urlPath + '?token=' + encodeURIComponent(EMBED_TOKEN);
+      var captionWs = new WebSocket(wsUrl);
+
+      captionWs.onmessage = function(ev) {
+        try {
+          var msg = JSON.parse(ev.data);
+          var isValid = false;
+          
+          if (msg.type === 'caption') {
+              isValid = true;
+          } else if (msg.type === 'translation' && msg.language_code === TARGET_LANG) {
+              isValid = true;
+          }
+
+          if (isValid && msg.text) {
+            captionsEl.textContent = msg.text;
+            captionsEl.classList.remove('empty');
+          }
+        } catch (_) {}
+      };
+
+      captionWs.onclose = function(ev) {
+        if (ev.code === 4001) { setExpired(); }
+      };
+    }
+  });
+})();

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -79,103 +79,16 @@
 
   <script src="/static/js/whep-listener.js?v={{ js_version }}"></script>
 
-  <script>
-    'use strict';
-
-    // All values injected via tojson — safe against ", \, and <\/script> injection.
-    const WHEP_URL    = {{ whep_url | tojson }};
-    const CAPTION_URL = {{ caption_url | tojson }};
-    const CAPTIONS_ON = {{ captions_enabled | tojson }};
-    const EMBED_TOKEN = {{ token | tojson }};
-
-    const audioEl    = document.getElementById('embed-audio');
-    const playBtn    = document.getElementById('play-btn');
-    const statusDot  = document.getElementById('status-dot');
-    const statusText = document.getElementById('status-text');
-    const captionsEl = document.getElementById('captions-box') || null;
-
-    let playing = false;
-
-    function setStatus(state, text) {
-      statusDot.className = 'status-dot ' + (state || '');
-      statusText.textContent = text;
-    }
-
-    function setExpired() {
-      setStatus('error', 'Session expired');
-      playBtn.textContent = '\u26a0 Session Expired \u2014 Reload Host Page';
-      playBtn.disabled = true;
-    }
-
-    const whep = createWhepClient();
-
-    whep.start({
-      whepUrl: WHEP_URL,
-      audioEl: audioEl,
-      onState: function(s) {
-        if (s.peerConnection === 'connected') {
-          setStatus('live', 'Live');
-          playBtn.disabled = false;
-          playBtn.textContent = playing ? '\u23f8  Pause' : '\u25b6  Play Audio';
-        } else if (s.peerConnection === 'failed' || s.peerConnection === 'closed') {
-          setStatus('error', 'Stream unavailable');
-          playBtn.disabled = false;
-        } else {
-          setStatus('connecting', 'Connecting\u2026');
-        }
-      },
-      onLog: function() {},
-    });
-
-    playBtn.addEventListener('click', function() {
-      if (!playing) {
-        audioEl.play().then(function() {
-          playing = true;
-          playBtn.textContent = '\u23f8  Pause';
-        }).catch(function() {
-          setStatus('error', 'Playback blocked \u2014 check browser permissions');
-        });
-      } else {
-        audioEl.pause();
-        playing = false;
-        playBtn.textContent = '\u25b6  Play Audio';
-      }
-    });
-
-    if (CAPTIONS_ON && captionsEl) {
-      var wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      // If CAPTION_URL starts with wss:// or ws:// (from backend), we can parse it, OR we can just replace the host.
-      // But it's easier to just construct it from scratch if the backend passed the full URL.
-      // Wait, let's just extract the path.
-      var urlPath = new URL(CAPTION_URL).pathname;
-      var wsUrl = wsProto + '//' + window.location.host + urlPath + '?token=' + encodeURIComponent(EMBED_TOKEN);
-      var captionWs = new WebSocket(wsUrl);
-      var TARGET_LANG = "{{ target_lang_code }}";
-
-      captionWs.onmessage = function(ev) {
-        try {
-          var msg = JSON.parse(ev.data);
-          var isValid = false;
-          
-          // Both the floor and human interpreter booths broadcast original captions as "caption"
-          if (msg.type === 'caption') {
-              isValid = true;
-          } else if (msg.type === 'translation' && msg.language_code === TARGET_LANG) {
-              isValid = true;
-          }
-
-          if (isValid && msg.text) {
-            captionsEl.textContent = msg.text;
-            captionsEl.classList.remove('empty');
-          }
-        } catch (_) {}
-      };
-
-      captionWs.onclose = function(ev) {
-        if (ev.code === 4001) { setExpired(); }
-      };
+  <script type="application/json" id="embed-config">
+    {
+      "whep_url": {{ whep_url | tojson }},
+      "caption_url": {{ caption_url | tojson }},
+      "captions_enabled": {{ captions_enabled | tojson }},
+      "token": {{ token | tojson }},
+      "target_lang_code": "{{ target_lang_code }}"
     }
   </script>
+  <script src="/static/js/embed-player.js?v={{ js_version }}"></script>
 
 </body>
 </html>

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -67,7 +67,9 @@
 
     {% if captions_enabled %}
     <div class="captions-box empty" id="captions-box">
-      Captions will appear here&hellip;
+      <div id="embed-caption-history"></div>
+      <div id="embed-caption-current" style="color: var(--primary);"></div>
+      <div id="embed-caption-placeholder">Captions will appear here&hellip;</div>
     </div>
     {% endif %}
 

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!--
+    Security-first head order:
+    1. referrer meta  — prevents the page URL (including ?token=) leaking to Google Fonts
+    2. robots meta    — standard practice for token-bearing URLs
+    3. charset / viewport
+    4. external font  — fired after referrer policy is established
+    5. inline styles  — CSS variables from server-sanitised theming params only
+  -->
+  <meta name="referrer" content="no-referrer">
+  <meta name="robots" content="noindex, nofollow">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>VoxBento Audio</title>
+
+  <!-- Google Font — Referrer-Policy: no-referrer prevents ?token= leaking here -->
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family={{ font_family }}:wght@400;600;700&display=swap"
+  >
+
+  <!-- External Stylesheet -->
+  <link rel="stylesheet" href="{{ url_for('static', path='css/embed.css') }}?v={{ js_version }}" />
+
+  {% if custom_css_url %}
+  <!-- Third-Party Custom CSS Override -->
+  <link rel="stylesheet" href="{{ custom_css_url }}" />
+  {% endif %}
+
+  <style>
+    /* ── CSS variables — all values are server-sanitised ─────────────────── */
+    :root {
+      --primary:  #{{ primary_color }};
+      --font:     '{{ font_family }}', Inter, system-ui, sans-serif;
+      {% if theme == "dark" %}
+      --bg:       #0d0f10;
+      --surface:  #1a1d21;
+      --border:   #2a2d32;
+      --text:     #f1f5f9;
+      --muted:    #94a3b8;
+      {% else %}
+      --bg:       #f8f9fa;
+      --surface:  #ffffff;
+      --border:   #e2e8f0;
+      --text:     #0d0f10;
+      --muted:    #64748b;
+      {% endif %}
+    }
+  </style>
+</head>
+<body>
+
+  <audio id="embed-audio" style="display:none"></audio>
+
+  <div class="player">
+
+    <div class="status-row">
+      <div class="status-dot connecting" id="status-dot"></div>
+      <span id="status-text">Connecting&hellip;</span>
+    </div>
+
+    <button class="play-btn" id="play-btn" disabled>
+      &#9654;&nbsp; Play Audio
+    </button>
+
+    {% if captions_enabled %}
+    <div class="captions-box empty" id="captions-box">
+      Captions will appear here&hellip;
+    </div>
+    {% endif %}
+
+    <div class="footer">
+      Powered by <a href="https://voxbento.com" target="_blank" rel="noopener noreferrer">VoxBento</a>
+    </div>
+
+  </div>
+
+  <script src="/static/js/whep-listener.js?v={{ js_version }}"></script>
+
+  <script>
+    'use strict';
+
+    // All values injected via tojson — safe against ", \, and <\/script> injection.
+    const WHEP_URL    = {{ whep_url | tojson }};
+    const CAPTION_URL = {{ caption_url | tojson }};
+    const CAPTIONS_ON = {{ captions_enabled | tojson }};
+    const EMBED_TOKEN = {{ token | tojson }};
+
+    const audioEl    = document.getElementById('embed-audio');
+    const playBtn    = document.getElementById('play-btn');
+    const statusDot  = document.getElementById('status-dot');
+    const statusText = document.getElementById('status-text');
+    const captionsEl = document.getElementById('captions-box') || null;
+
+    let playing = false;
+
+    function setStatus(state, text) {
+      statusDot.className = 'status-dot ' + (state || '');
+      statusText.textContent = text;
+    }
+
+    function setExpired() {
+      setStatus('error', 'Session expired');
+      playBtn.textContent = '\u26a0 Session Expired \u2014 Reload Host Page';
+      playBtn.disabled = true;
+    }
+
+    const whep = createWhepClient();
+
+    whep.start({
+      whepUrl: WHEP_URL,
+      audioEl: audioEl,
+      onState: function(s) {
+        if (s.peerConnection === 'connected') {
+          setStatus('live', 'Live');
+          playBtn.disabled = false;
+          playBtn.textContent = playing ? '\u23f8  Pause' : '\u25b6  Play Audio';
+        } else if (s.peerConnection === 'failed' || s.peerConnection === 'closed') {
+          setStatus('error', 'Stream unavailable');
+          playBtn.disabled = false;
+        } else {
+          setStatus('connecting', 'Connecting\u2026');
+        }
+      },
+      onLog: function() {},
+    });
+
+    playBtn.addEventListener('click', function() {
+      if (!playing) {
+        audioEl.play().then(function() {
+          playing = true;
+          playBtn.textContent = '\u23f8  Pause';
+        }).catch(function() {
+          setStatus('error', 'Playback blocked \u2014 check browser permissions');
+        });
+      } else {
+        audioEl.pause();
+        playing = false;
+        playBtn.textContent = '\u25b6  Play Audio';
+      }
+    });
+
+    if (CAPTIONS_ON && captionsEl) {
+      var wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      // If CAPTION_URL starts with wss:// or ws:// (from backend), we can parse it, OR we can just replace the host.
+      // But it's easier to just construct it from scratch if the backend passed the full URL.
+      // Wait, let's just extract the path.
+      var urlPath = new URL(CAPTION_URL).pathname;
+      var wsUrl = wsProto + '//' + window.location.host + urlPath + '?token=' + encodeURIComponent(EMBED_TOKEN);
+      var captionWs = new WebSocket(wsUrl);
+      var TARGET_LANG = "{{ target_lang_code }}";
+
+      captionWs.onmessage = function(ev) {
+        try {
+          var msg = JSON.parse(ev.data);
+          var isValid = false;
+          
+          // Both the floor and human interpreter booths broadcast original captions as "caption"
+          if (msg.type === 'caption') {
+              isValid = true;
+          } else if (msg.type === 'translation' && msg.language_code === TARGET_LANG) {
+              isValid = true;
+          }
+
+          if (isValid && msg.text) {
+            captionsEl.textContent = msg.text;
+            captionsEl.classList.remove('empty');
+          }
+        } catch (_) {}
+      };
+
+      captionWs.onclose = function(ev) {
+        if (ev.code === 4001) { setExpired(); }
+      };
+    }
+  </script>
+
+</body>
+</html>

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -56,8 +56,9 @@ _ws_auth = _admin_user_cookie
 
 def test_token_redactor_handles_combined_request_line():
     import logging
+
     from fastapi_app import _UvicornTokenRedactor
-    
+
     # Combined string shape (e.g. httptools protocol)
     record = logging.LogRecord(
         name="uvicorn.access", level=logging.INFO, pathname="", lineno=0,
@@ -72,8 +73,9 @@ def test_token_redactor_handles_combined_request_line():
 
 def test_token_redactor_handles_split_args():
     import logging
+
     from fastapi_app import _UvicornTokenRedactor
-    
+
     # Split string shape (e.g. h11 protocol)
     record = logging.LogRecord(
         name="uvicorn.access", level=logging.INFO, pathname="", lineno=0,

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -57,7 +57,7 @@ _ws_auth = _admin_user_cookie
 
 def test_healthz_ok():
     res = client.get("/healthz")
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     body = res.json()
     assert body["ok"] is True
     assert body["server"] == "fastapi"
@@ -67,7 +67,7 @@ def test_healthz_ok():
 
 def test_home_renders_home_page():
     res = client.get("/")
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     assert b"VoxBento" in res.content
 
 
@@ -80,7 +80,7 @@ def test_interpreter_booth_requires_auth():
 
 def test_interpreter_booth_page_renders():
     res = client.get("/interpreter/myevent/en", cookies=_interpreter_cookie("myevent", "en"))
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     assert b"myevent-en" in res.content
 
 
@@ -88,7 +88,7 @@ def test_interpreter_booth_jitsi_url_uses_base_url():
     """Jitsi URL in the booth page must use the configured base URL, not
     a hard-coded http:// scheme, to avoid mixed-content on HTTPS deployments."""
     res = client.get("/interpreter/myevent/en", cookies=_interpreter_cookie("myevent", "en"))
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     from portal.config import settings
     from portal.utils import _make_jitsi_url
 
@@ -123,7 +123,7 @@ def test_interpreter_booth_jitsi_domain_matches_base_url_host():
     from portal.config import settings
 
     res = client.get("/interpreter/myevent/en", cookies=_interpreter_cookie("myevent", "en"))
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     expected_host = urlparse(settings.effective_jitsi_base_url).netloc
     assert f"data-jitsi-domain='{expected_host}'".encode() in res.content
 
@@ -131,7 +131,7 @@ def test_interpreter_booth_jitsi_domain_matches_base_url_host():
 def test_auth_token_no_password():
     """When BOOTH_ACCESS_TOKEN is empty, any (or empty) token grants a JWT."""
     res = client.post("/api/auth/token", json={"token": ""})
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     body = res.json()
     assert "access_token" in body
     assert body["token_type"] == "bearer"
@@ -139,7 +139,7 @@ def test_auth_token_no_password():
 
 def test_ingest_status_endpoint():
     res = client.get("/api/interpreter/status/some-channel")
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     body = res.json()
     assert body["channel_id"] == "some-channel"
     assert body["state"] == "mediamtx"
@@ -338,7 +338,7 @@ def test_ws_disconnect_without_leave_auto_removes_participant():
 
     # After disconnect, state should have zero participants
     res = client.get("/api/events/disc/booths/nl/state")
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     assert len(res.json()["participants"]) == 0
 
 
@@ -553,7 +553,7 @@ def test_ws_auth_required_with_token(monkeypatch):
     monkeypatch.setattr(settings, "booth_access_token", "secret-test-token")
     # When the provided token matches BOOTH_ACCESS_TOKEN, the endpoint issues a JWT.
     res = client.post("/api/auth/token", json={"token": "secret-test-token"})
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     jwt_token = res.json()["access_token"]
 
     # WebSocket WITHOUT a token should be rejected (closed with code 4001).
@@ -610,7 +610,7 @@ def test_ws_auth_valid_generic_token_without_cookie_rejected(monkeypatch):
 
     # Get a valid API token (which has no role claims)
     res = client.post("/api/auth/token", json={"token": "secret-test-token"})
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     jwt_token = res.json()["access_token"]
 
     # Connect with the valid API token but NO cookie
@@ -965,7 +965,7 @@ def test_whip_url_active_interpreter_gets_url():
             params={"participant_id": pid},
         )
 
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     body = res.json()
     assert "whip_url" in body
     assert body["channel_id"] == channel
@@ -1054,7 +1054,7 @@ def test_whip_url_active_coordinator_passes():
             params={"participant_id": pid},
         )
 
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     body = res.json()
     assert "whip_url" in body
     assert body["whip_url"].endswith(f"/{channel}/whip")
@@ -1140,7 +1140,7 @@ def test_list_event_booths():
     client.post("/api/events/other/booths", json={"language_code": "ja", "language": "Japanese"})
 
     res = client.get("/api/events/listtest/booths")
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     body = res.json()
     assert body["event_slug"] == "listtest"
     assert len(body["booths"]) == 2
@@ -1155,7 +1155,7 @@ def test_list_event_booths():
 def test_list_event_booths_empty():
     """Listing booths for a non-existent event returns empty list."""
     res = client.get("/api/events/nonexistent/booths")
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     assert res.json()["booths"] == []
 
 
@@ -1169,7 +1169,7 @@ def test_interpreter_booth_by_identity_requires_auth():
 def test_interpreter_booth_by_identity_page():
     """GET /interpreter/{event_slug}/{language_code} renders the booth page."""
     res = client.get("/interpreter/myevent/en", cookies=_interpreter_cookie("myevent", "en"))
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     assert b"myevent-en" in res.content
     assert b"data-event-slug='myevent'" in res.content
     assert b"data-language-code='en'" in res.content
@@ -1180,7 +1180,7 @@ def test_interpreter_booth_by_identity_page():
 def test_interpreter_booth_by_identity_whip_whep_urls():
     """The identity-based booth page has correct WHIP and WHEP URLs."""
     res = client.get("/interpreter/fossasia/fr", cookies=_interpreter_cookie("fossasia", "fr"))
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     content = res.content.decode()
     assert "fossasia/fr/whip" in content
     assert "fossasia/fr/whep" in content
@@ -1197,7 +1197,7 @@ def test_interpreter_booth_by_identity_no_role_returns_403():
 def test_interpreter_booth_admin_user_gets_super_admin_role():
     """A user with is_admin=True gets super_admin role without needing a membership."""
     res = client.get("/interpreter/myevent/en", cookies=_admin_user_cookie())
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     assert b"data-granted-role='super_admin'" in res.content
 
 
@@ -1263,7 +1263,7 @@ def test_event_booth_state_returns_existing():
     """Event-scoped state endpoint returns 200 for an existing booth."""
     client.post("/api/events/statetest/booths", json={"language_code": "en", "language": "English"})
     res = client.get("/api/events/statetest/booths/en/state")
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     body = res.json()
     assert body["booth_id"] == "statetest-en"
     assert body["event_slug"] == "statetest"
@@ -1316,7 +1316,7 @@ def test_event_booth_whip_url_active_interpreter():
             "/api/events/whipevent/booths/en/whip-url",
             params={"participant_id": pid},
         )
-        assert res.status_code == 200
+        assert res.status_code == 200, res.text
         body = res.json()
         assert body["whip_url"].endswith("/whipevent/en/whip")
         assert body["booth_id"] == "whipevent-en"
@@ -1533,3 +1533,200 @@ def test_404_html_page_renders_unified_template():
     assert "Page Not Found" in res.text
     assert "cdn.tailwindcss.com" not in res.text
     assert "/static/css/error.css" in res.text
+
+# ── Embed route tests ──────────────────────────────────────────────────────────
+
+
+def _embed_listener_token(event_slug: str = "test-event") -> str:
+    """Helper: create a valid embed listener token for the given event slug."""
+    from portal.auth import create_embed_token
+
+    return create_embed_token(event_slug=event_slug)
+
+
+def _seed_embed_event(event_slug: str = "test-event", language_code: str = "en") -> None:
+    """Seed the DB with an event + booth via the public API (correct test pattern).
+
+    Uses client.post() so the booth is recorded in SQLite, where the embed
+    route's list_booths_for_event() will find it.
+    """
+    client.post(
+        f"/api/events/{event_slug}/booths",
+        json={"language_code": language_code, "language": language_code.upper()},
+    )
+
+
+def test_embed_no_token_returns_403():
+    """Missing ?token= must return 403, not 404 or 500."""
+    # No accept header — get JSON error response for easy assertion.
+    res = client.get("/embed/test-event/en")
+    assert res.status_code == 403
+
+
+def test_embed_invalid_token_returns_403():
+    """A cryptographically invalid token must return 403."""
+    res = client.get("/embed/test-event/en?token=this-is-not-a-jwt")
+    assert res.status_code == 403
+
+
+def test_embed_expired_token_returns_403():
+    """An expired listener JWT must return 403 with 'expired' in the detail."""
+    import time
+
+    import jwt as _jwt
+
+    from portal.config import settings
+
+    now = int(time.time())
+    payload = {
+        "sub": "test",
+        "role": "listener",
+        "event_slug": "test-event",
+        "iat": now - 7200,
+        "exp": now - 3600,  # expired 1 hour ago
+    }
+    expired_token = _jwt.encode(payload, settings.effective_jwt_secret, algorithm="HS256")
+    res = client.get(f"/embed/test-event/en?token={expired_token}")
+    assert res.status_code == 403
+    assert "expired" in res.json()["detail"].lower()
+
+
+def test_embed_wrong_role_token_returns_403():
+    """A valid JWT that is not a listener token (e.g. interpreter role) must return 403."""
+    token = create_participant_token(
+        booth_id=1,
+        role="interpreter",
+        event_slug="test-event",
+        language_code="en",
+    )
+    res = client.get(f"/embed/test-event/en?token={token}")
+    assert res.status_code == 403
+    assert "listener" in res.json()["detail"].lower()
+
+
+def test_embed_wrong_event_bola_returns_403():
+    """A listener token for event-b must not access /embed/event-a/en (BOLA)."""
+    token = _embed_listener_token(event_slug="event-b")
+    res = client.get(f"/embed/event-a/en?token={token}")
+    assert res.status_code == 403
+
+
+def test_embed_valid_token_unknown_language_returns_404():
+    """Auth passes but the language code has no booth — must return 404, not 403."""
+    _seed_embed_event("test-event", "fr")
+
+    token = _embed_listener_token(event_slug="test-event")
+    res = client.get(f"/embed/test-event/zz?token={token}")  # 'zz' not seeded
+    assert res.status_code == 404
+
+
+def test_embed_valid_token_booth_offline_returns_200():
+    """Auth passes and booth exists (even if not live) — must return 200 with HTML."""
+    _seed_embed_event("test-event", "en")
+
+    token = _embed_listener_token(event_slug="test-event")
+    res = client.get(f"/embed/test-event/en?token={token}", headers={"accept": "text/html"})
+    assert res.status_code == 200, res.text
+    assert "text/html" in res.headers["content-type"]
+
+
+def test_embed_xss_tojson_escaping():
+    """WHEP and caption URLs injected via tojson must not break out of the JS string.
+
+    tojson wraps in JSON quotes and escapes </script>, so injection from
+    channel_id values is blocked regardless of their content.
+    """
+    _seed_embed_event("xss-event", "en")
+
+    token = _embed_listener_token(event_slug="xss-event")
+    res = client.get(f"/embed/xss-event/en?token={token}", headers={"accept": "text/html"})
+    assert res.status_code == 200, res.text
+    # Confirm the response has the tojson-safe script block markers and no raw injection.
+    assert "</script><script>" not in res.text
+
+
+def test_embed_cache_control_no_store():
+    """Every embed response must carry Cache-Control: no-store, private."""
+    _seed_embed_event("test-event", "en")
+
+    token = _embed_listener_token(event_slug="test-event")
+    res = client.get(f"/embed/test-event/en?token={token}", headers={"accept": "text/html"})
+    assert res.status_code == 200, res.text
+    cc = res.headers.get("cache-control", "")
+    assert "no-store" in cc
+    assert "private" in cc
+
+
+def test_embed_referrer_policy_header():
+    """Every embed response must carry Referrer-Policy: no-referrer."""
+    _seed_embed_event("test-event", "en")
+
+    token = _embed_listener_token(event_slug="test-event")
+    res = client.get(f"/embed/test-event/en?token={token}", headers={"accept": "text/html"})
+    assert res.status_code == 200, res.text
+    assert res.headers.get("referrer-policy") == "no-referrer"
+
+
+def test_embed_frame_ancestors_default(monkeypatch):
+    """When EMBED_ALLOWED_ORIGINS is empty, CSP must be exactly 'frame-ancestors *'."""
+    from portal.config import settings
+
+    monkeypatch.setattr(settings, "embed_allowed_origins", "")
+    _seed_embed_event("test-event", "en")
+
+    token = _embed_listener_token(event_slug="test-event")
+    res = client.get(f"/embed/test-event/en?token={token}", headers={"accept": "text/html"})
+    assert res.status_code == 200, res.text
+    assert res.headers.get("content-security-policy") == "frame-ancestors *"
+
+
+def test_embed_frame_ancestors_restricted(monkeypatch):
+    """When EMBED_ALLOWED_ORIGINS is set to one origin, CSP must reflect it exactly."""
+    from portal.config import settings
+
+    monkeypatch.setattr(settings, "embed_allowed_origins", "https://eventyay.com")
+    _seed_embed_event("test-event", "en")
+
+    token = _embed_listener_token(event_slug="test-event")
+    res = client.get(f"/embed/test-event/en?token={token}", headers={"accept": "text/html"})
+    assert res.status_code == 200, res.text
+    assert res.headers.get("content-security-policy") == "frame-ancestors https://eventyay.com"
+
+
+def test_embed_frame_ancestors_multi_origin(monkeypatch):
+    """Comma-separated EMBED_ALLOWED_ORIGINS must produce a space-separated CSP header.
+
+    Asserts the exact header value — not just containment — to catch the
+    bug of passing raw comma-separated input to frame-ancestors, which
+    browsers silently ignore.
+    """
+    from portal.config import settings
+
+    monkeypatch.setattr(settings, "embed_allowed_origins", "https://a.com, https://b.com")
+    _seed_embed_event("test-event", "en")
+
+    token = _embed_listener_token(event_slug="test-event")
+    res = client.get(f"/embed/test-event/en?token={token}", headers={"accept": "text/html"})
+    assert res.status_code == 200, res.text
+    assert res.headers.get("content-security-policy") == "frame-ancestors https://a.com https://b.com"
+
+
+def test_embed_captions_opt_in_websocket_auth():
+    """The embed listener token must satisfy resolve_ws_auth for /ws/captions/{booth_id}.
+
+    booth_id is always '{event_slug}-{language_code}', which starts with
+    '{event_slug}-', satisfying the startswith check in resolve_ws_auth.
+    This test verifies the token claim shape without making a live WS connection.
+    """
+    from portal.auth import decode_token
+
+    token = _embed_listener_token(event_slug="test-event")
+    payload = decode_token(token)
+
+    # Verify role and event_slug claims match what resolve_ws_auth expects.
+    assert payload.get("role") == "listener"
+    assert payload.get("event_slug") == "test-event"
+
+    # Verify the booth_id produced by make_booth_id satisfies the startswith check.
+    booth_id = "test-event-en"  # make_booth_id("test-event", "en")
+    assert booth_id.startswith(f"{payload['event_slug']}-")

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -54,6 +54,38 @@ _ws_auth = _admin_user_cookie
 
 # ── REST & page tests ─────────────────────────────────────────────────────────
 
+def test_token_redactor_handles_combined_request_line():
+    import logging
+    from fastapi_app import _UvicornTokenRedactor
+    
+    # Combined string shape (e.g. httptools protocol)
+    record = logging.LogRecord(
+        name="uvicorn.access", level=logging.INFO, pathname="", lineno=0,
+        msg='%s - "%s"',
+        args=("127.0.0.1:1234", "GET /embed/test-event/en?token=secretjwt123 HTTP/1.1"),
+        exc_info=None,
+    )
+    _UvicornTokenRedactor().filter(record)
+    output = record.getMessage()
+    assert "secretjwt123" not in output
+    assert "[REDACTED]" in output
+
+def test_token_redactor_handles_split_args():
+    import logging
+    from fastapi_app import _UvicornTokenRedactor
+    
+    # Split string shape (e.g. h11 protocol)
+    record = logging.LogRecord(
+        name="uvicorn.access", level=logging.INFO, pathname="", lineno=0,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:1234", "GET", "/embed/test-event/en?token=secretjwt123", "1.1", 200),
+        exc_info=None,
+    )
+    _UvicornTokenRedactor().filter(record)
+    output = record.getMessage()
+    assert "secretjwt123" not in output
+    assert "[REDACTED]" in output
+
 
 def test_healthz_ok():
     res = client.get("/healthz")


### PR DESCRIPTION
# Overview

This PR introduces a lightweight, highly customizable Embed Player (`/embed/`) designed to be integrated into third-party websites via `<iframe>`.

The player is designed with a "Single-Channel Widget" philosophy. It intentionally avoids internal dropdowns or complex navigation, allowing the integrating platform to build their own UI wrappers (e.g., language selection dropdowns) and dynamically swap the iframe `src` URL.

- fixes : #326 

# Key Features

## 1. Minimalist Player Interface

- Created a pristine, lightweight `embed.html` template powered by our `whep-listener.js` for WebRTC audio playback.
- Automatically handles real-time captions via WebSocket.
- Designed to be visually unobtrusive and easily styleable.

## 2. Customization & Theming

- Integrators can customize the default appearance via URL parameters: `?theme=dark|light`, `?primaryColor=<hex>`, and `?font=<family>`.

- Custom CSS Injection: Added support for a `?customCssUrl=https://...` query parameter. This allows strict, complete design freedom for third parties. If provided, the backend safely injects a `<link rel="stylesheet">` into the iframe's `<head>`, granting the parent page the ability to overwrite any default CSS rule (padding, borders, background transparency, etc.).

## 3. Smart Caption Routing & Filtering

- Fixed a WebSocket routing issue in `listener.py` where the Embed UI was incorrectly using the MediaMTX `channel_id` (using a slash `/`) instead of the WebSocket broadcast group `booth_id` (using a hyphen `-`).

- Upgraded the javascript logic in `embed.html` to intelligently filter incoming WebSocket messages. It now correctly identifies and displays `type: caption` messages (for both the Floor and human interpreter booths) while ignoring unrelated broadcast noise.

- Fixed a configuration issue where the Embed WebSocket was hardcoded to the backend's `PUBLIC_BASE_URL` (which broke local testing). It now dynamically utilizes `window.location.host`.

# Authentication Flow for Third-Party Integrations

To securely embed the player without exposing long-lived access, third-party applications will use the following automated flow:

- **API Key Provisioning:** The event organizer generates a secure API Key inside the VoxBento admin panel and shares it privately with the third-party developers.

- **Server-to-Server Token Request:** When a viewer loads the third-party webpage, the third-party backend server makes an authenticated request to VoxBento using their API Key:

```text
POST https://voxbento.com/api/v1/tokens/listener?purpose=embed
```

- **Short-Lived Token Issuance:** VoxBento responds instantly with a highly secure JWT token that is restricted to the specific event and expires in exactly 30 minutes.

- **Dynamic Injection:** The third-party backend injects this fresh 30-minute token into the `<iframe>` URL just before rendering the HTML for the viewer. This ensures secure, expiring access for every individual viewer without ever exposing the root API Key.

# How to Test

Generate an Embed Token (The Production Way): Instead of using a backend script, test the flow exactly as a third-party developer would:

1. Go to the VoxBento Admin Panel and navigate to your event (`testevent2`).

2. Generate a new API Key for the event.

3. Open your terminal and use `curl` to request a fresh embed token:

```bash
curl -X POST "http://localhost:8000/api/v1/tokens/listener?purpose=embed" \
     -H "Authorization: Bearer <YOUR_API_KEY>"
```

4. The server will respond with a 30-minute JWT token:

```text
{"token": "eyJhbG..."}
```

Copy this token string.

5. **Test the Floor Embed:** Create a basic `test.html` file on your desktop with an `iframe` pointing to:

```text
http://localhost:8000/embed/testevent2/floor?token=<YOUR_TOKEN>&captions=true&theme=dark
```

Verify that you can hear the floor audio and that the live transcriptions appear in the UI.

6. **Test a Human Interpreter Booth:** Change the URL to point to a human interpreter channel (e.g., `/embed/testevent2/en`). Verify that original interpreter captions flow through correctly.

7. **Test Custom CSS Injection:** Add `&customCssUrl=https://example.com/your-styles.css` to the URL. Verify that the stylesheet is injected into the `<head>` and applies styles to the player.

## Summary by Sourcery

Add a secure, customizable standalone embed listener player for third‑party iframe integrations, with dedicated JWT-based auth flow and CSP controls.

New Features:
- Introduce /embed/{event_slug}/{language_code} route serving a minimalist audio and captions player suitable for iframe embedding, with support for theme, primary color, font, and optional custom CSS URL.
- Provide a new embed token issuance flow via POST /api/v1/tokens/listener?purpose=embed and corresponding short-lived JWTs for secure third-party access.

Bug Fixes:
- Correct WebSocket listener auth to accept booth IDs that use either hyphen or slash between event slug and channel identifier, fixing caption routing issues.

Enhancements:
- Implement server-side validation and sanitization of theming query parameters to enforce safe, constrained customization for the embed player.
- Add security-focused headers (Cache-Control no-store, Referrer-Policy no-referrer, and configurable frame-ancestors CSP) to embed responses to harden iframe usage.
- Redact token query parameters from uvicorn access logs for embed and WebSocket URLs to avoid leaking sensitive JWTs.
- Improve tests with explicit status code assertion messages and add comprehensive coverage for embed auth, CSP behavior, caching, and captions WebSocket compatibility.

Tests:
- Add an extensive suite of tests covering embed route authentication scenarios, event and booth resolution, XSS protections, cache and CSP headers, and captions token compatibility.
- Update existing tests to include response text in status code assertions for easier debugging of failures.