### PR TITLE
fix: remember selected room when adding booths in setup wizard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8001:8000"
+      - "8000:8000"
     environment:
       HOST: "0.0.0.0"
       PORT: "8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8001:8000"
     environment:
       HOST: "0.0.0.0"
       PORT: "8000"

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -459,11 +459,11 @@ async def admin_setup_add_booth(request: Request, event_id: int):
                 )
         except Exception as e:
             logger.warning(f"Error creating booth in setup wizard: {e}")
-            
+
     redirect_url = f"/admin/events/{event_id}/setup/booths"
     if room_id_str:
         redirect_url += f"?room_id={room_id_str}"
-        
+
     return safe_redirect(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
 
 

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -459,6 +459,7 @@ async def admin_setup_add_booth(request: Request, event_id: int):
                 )
         except Exception as e:
             logger.warning(f"Error creating booth in setup wizard: {e}")
+        return safe_redirect(url=f"/admin/events/{event_id}/setup/booths?room_id={room_id_str}", status_code=status.HTTP_303_SEE_OTHER)
     return safe_redirect(url=f"/admin/events/{event_id}/setup/booths", status_code=status.HTTP_303_SEE_OTHER)
 
 

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -459,8 +459,12 @@ async def admin_setup_add_booth(request: Request, event_id: int):
                 )
         except Exception as e:
             logger.warning(f"Error creating booth in setup wizard: {e}")
-        return safe_redirect(url=f"/admin/events/{event_id}/setup/booths?room_id={room_id_str}", status_code=status.HTTP_303_SEE_OTHER)
-    return safe_redirect(url=f"/admin/events/{event_id}/setup/booths", status_code=status.HTTP_303_SEE_OTHER)
+            
+    redirect_url = f"/admin/events/{event_id}/setup/booths"
+    if room_id_str:
+        redirect_url += f"?room_id={room_id_str}"
+        
+    return safe_redirect(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
 
 
 @router.get("/admin/events/{event_id}/setup/invite", dependencies=[Depends(require_admin)])

--- a/templates/admin/wizard_booths.html
+++ b/templates/admin/wizard_booths.html
@@ -17,7 +17,7 @@
           <label for="room_id">Room</label>
           <select id="room_id" name="room_id" required>
             {% for room in rooms %}
-            <option value="{{ room.id }}">{{ room.display_name }}</option>
+            <option value="{{ room.id }}" {% if request.query_params.get('room_id') == room.id|string %}selected{% endif %}>{{ room.display_name }}</option>
             {% endfor %}
           </select>
         </div>


### PR DESCRIPTION
## Summary by Sourcery

Preserve the selected room when adding booths in the admin setup wizard so the user’s choice is not lost after submission.

Bug Fixes:
- Retain the previously selected room in the booth setup wizard by marking the matching room option as selected based on the room_id query parameter.
- Redirect back to the booths setup page with the current room_id in the query string after attempting to add a booth.