### PR TITLE
fix: filter /healthz from uvicorn access logs

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -58,9 +58,18 @@ async def lifespan(app: FastAPI):
     dg.track_task(asyncio.create_task(_gen()))
 
     logging.getLogger("uvicorn.access").addFilter(_UvicornTokenRedactor())
+    logging.getLogger("uvicorn.access").addFilter(_HealthCheckFilter())
     yield
     if pg.shared_http_client:
         await pg.shared_http_client.aclose()
+
+
+class _HealthCheckFilter(logging.Filter):
+    def filter(self, record):
+        try:
+            return record.getMessage().find("GET /healthz") == -1
+        except Exception:
+            return True
 
 
 class _UvicornTokenRedactor(logging.Filter):


### PR DESCRIPTION
Silences the Docker healthcheck log spam by adding a filter to Uvicorn's access logger to ignore GET /healthz requests.

## Summary by Sourcery

Bug Fixes:
- Prevent noisy Uvicorn access logs caused by repeated GET /healthz health check requests.