### PR TITLE
fix mission control language persistence

### DIFF
--- a/portal/database.py
+++ b/portal/database.py
@@ -864,3 +864,28 @@ async def log_usage_metric(session: AsyncSession, event_id: int, metric_name: st
     metric = UsageMetric(event_id=event_id, metric_name=metric_name, value=value)
     session.add(metric)
     await session.flush()
+
+
+async def get_booth_language_name(booth_id: str) -> str:
+    """Resolve the real language name for a booth_id from the database.
+    
+    Returns 'English' as a fallback if the booth is not found or parsing fails.
+    """
+    from sqlalchemy import select
+    from portal.models import DBBooth, Event
+    from portal.booth_identity import parse_booth_id
+
+    try:
+        event_slug, room_id, language_code = parse_booth_id(booth_id)
+        async with get_session() as db_session:
+            stmt = select(DBBooth.language_name).join(Event).where(
+                Event.slug == event_slug,
+                DBBooth.room_id == room_id,
+                DBBooth.language_code == language_code
+            )
+            res = await db_session.scalar(stmt)
+            if res:
+                return res
+    except Exception:
+        pass
+    return "English"

--- a/portal/websockets/handlers.py
+++ b/portal/websockets/handlers.py
@@ -42,10 +42,14 @@ async def ws_booth(websocket: WebSocket, booth_id: str) -> None:
 
     ws_granted_role = await resolve_booth_role(payload, booth_id)
     await websocket.accept()
+    
+    from portal.database import get_booth_language_name
+    language_name = await get_booth_language_name(booth_id)
+    
     session = Session(
         booth_id=booth_id,
         participant_id=None,
-        language="English",
+        language=language_name,
         channel_id=f"{booth_id}-audio",
         granted_role=ws_granted_role,
     )

--- a/portal/websockets/manager.py
+++ b/portal/websockets/manager.py
@@ -135,7 +135,7 @@ async def broadcast_transcription(booth_id: str, payload: str | dict):
 async def _handle_join(ws: WebSocket, session: Session, data: dict) -> None:
     display_name = data.get("display_name", "Interpreter")
     role = data.get("role", "interpreter")
-    language = data.get("language", "English")
+    language = data.get("language", session.language)
     channel_id = data.get("channel_id", f"{session.booth_id}-audio")
     participant_id = data.get("participant_id")
     if session.granted_role is None:


### PR DESCRIPTION
- **fix: include room_id in booth state fetch and join**
- **fix: resolve correct booth language from DB for WebSocket connections**

## Summary by Sourcery

Persist and resolve the correct booth language for WebSocket booth sessions based on database data instead of defaulting to English.

Bug Fixes:
- Use the booth session language as the default for join events instead of always falling back to English.
- Resolve booth language name from the database using parsed booth_id and use it when creating WebSocket booth sessions, with English as a safe fallback.