### PR TITLE
fix: listener audio not starting due to missing room_id in state check

### DIFF
--- a/static/js/listener-event.js
+++ b/static/js/listener-event.js
@@ -843,7 +843,7 @@ languageSelect.addEventListener("change", function () {
         startWhepAndCaptions(whepUrl, null, selectedAudioDelayMs);
       } else {
         // Check booth live status before starting WHEP to avoid phantom timer.
-        fetch("/api/events/" + eventSlug + "/booths/" + languageCode + "/state")
+        fetch("/api/events/" + eventSlug + "/booths/" + languageCode + "/state?room_id=" + roomId)
           .then(function (r) {
             return r.ok ? r.json() : null;
           })


### PR DESCRIPTION
Fixes an issue where the listener page fails to start the WebRTC audio stream for an already-live booth because the initial API check for booth state was missing the `room_id` query parameter, resulting in a 400 Bad Request error when the event has multiple rooms.

## Summary by Sourcery

Bug Fixes:
- Include the room_id query parameter in the listener booth state API call so WebRTC audio can start correctly for events with multiple rooms.