### PR TITLE
fix: Use HTTPS for internal floor bot WebRTC connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       DEFAULT_JITSI_ROOM: "${DEFAULT_JITSI_ROOM:-eventyay-stage-room}"
       JITSI_DOMAIN: "${JITSI_DOMAIN:-jitsi.voxbento.com}"
       JITSI_BASE_URL: "${JITSI_BASE_URL:-http://${JITSI_DOMAIN:-localhost:8080}}"
-      JITSI_INTERNAL_BASE: "http://jitsi-web:80"
+      JITSI_INTERNAL_BASE: "https://jitsi-web:443"
       # Browser-facing URLs — must be reachable from the user's machine
       MEDIAMTX_WHIP_BASE: "${MEDIAMTX_WHIP_BASE:-http://localhost:8889}"
       FLOOR_BOT_BASE: "http://floor-bot:8080"


### PR DESCRIPTION
Fixes the Floor Bot transcription startup failure where Chromium would reject `getUserMedia` calls with `Cannot read properties of undefined`. This was caused by the bot connecting to the internal Jitsi instance over HTTP (`http://jitsi-web:80`), which disabled secure context APIs like WebRTC. By connecting over `https://jitsi-web:443` internally (ignoring the self-signed certificate), WebRTC works normally without relying on experimental insecure origin flags.

## Summary by Sourcery

Update the internal Jitsi base URL to use HTTPS for the floor bot WebRTC connection.

Bug Fixes:
- Resolve floor bot transcription startup failures by ensuring the internal Jitsi connection uses a secure HTTPS context.

Build:
- Adjust docker-compose environment configuration to point JITSI_INTERNAL_BASE at the HTTPS internal Jitsi endpoint.