### PR TITLE
ci: sequence deploy workflow after tests and rebuild docker images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,11 @@ jobs:
             echo "--- docker compose up -d --build ---"
             docker compose up -d --build --remove-orphans
 
+            # ── Clean up dangling images ────────────────────────────────────
+            # Prevents storage from filling up with old <none> images created by --build
+            echo "--- cleaning up unused images ---"
+            docker image prune -f
+
             # ── Restart portal (loads fresh code since --reload is disabled) ────
             # Because we disabled uvicorn --reload for production performance,
             # this explicit restart is required for the FastAPI app to load new code.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,10 @@
 name: Deploy to Production
 
-# Trigger: auto-deploy whenever a commit lands on main (direct push or PR merge)
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
     branches:
       - main
 
@@ -18,6 +20,7 @@ permissions:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     name: SSH deploy → voxbento.com
     runs-on: ubuntu-latest
 
@@ -55,10 +58,10 @@ jobs:
             fi
 
             # ── Apply changes from docker-compose.yml ──────────────────────
-            # Running 'up -d' ensures new environment variables and port mappings
-            # (like the new RTSP port 8554) are actually applied.
-            echo "--- docker compose up -d ---"
-            docker compose up -d --remove-orphans
+            # Running 'up -d --build' ensures new environment variables, port mappings,
+            # and Dockerfile changes are applied to services without volume mounts.
+            echo "--- docker compose up -d --build ---"
+            docker compose up -d --build --remove-orphans
 
             # ── Restart portal (loads fresh code since --reload is disabled) ────
             # Because we disabled uvicorn --reload for production performance,


### PR DESCRIPTION
Resolves the CI race condition where broken code could be deployed before tests catch the failure by chaining `deploy.yml` to wait for `tests.yml` (CI). Also adds the `--build` flag to the production deployment script so that services without volume mounts (like `floor-bot`) correctly rebuild their Docker images when new code is pushed, fixing the issue where the floor bot would appear 'Stopped' due to running outdated code.

## Summary by Sourcery

Sequence the production deploy workflow after successful CI runs and ensure production services rebuild Docker images on deployment.

CI:
- Trigger the deploy workflow only after the CI workflow completes successfully on the main branch.

Deployment:
- Update the deploy job condition to run only on manual dispatch or successful CI workflow runs.
- Change the production docker compose deployment to use `up -d --build --remove-orphans` so images are rebuilt when deploying.