### PR TITLE
fix : fixed bots microphone bug 

### DIFF
--- a/floor-bot/bot.py
+++ b/floor-bot/bot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/floor-bot/bot.py
+++ b/floor-bot/bot.py
@@ -134,7 +134,7 @@ async def run_capture():
 
         join_url = (
             f"{jitsi_url}"
-            f"#config.startWithAudioMuted=false"
+            f"#config.startWithAudioMuted=true"
             f"&config.startWithVideoMuted=true"
             f"&config.prejoinPageEnabled=false"
             f"&config.disableDeepLinking=true"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure bots join Jitsi meetings with their microphones muted by default.