### PR TITLE
ref : Transcription architecture to support continuous streaming

### DIFF
--- a/portal/transcription/providers/base.py
+++ b/portal/transcription/providers/base.py
@@ -4,6 +4,7 @@ import logging
 import time
 import wave
 from dataclasses import dataclass
+from typing import AsyncGenerator, AsyncIterator, Awaitable, Callable
 
 from portal.models import Event
 from portal.transcription.constants import ProviderEnum
@@ -174,3 +175,258 @@ class TranscriptionProvider:
 
         reader.cancel()
         inference.cancel()
+
+
+@dataclass(frozen=True)
+class AudioFrame:
+    """
+    Represents a discrete chunk of audio data.
+    `start_timestamp` is audio-relative (derived strictly from bytes read / sample rate),
+    NOT monotonic wall-clock, ensuring it strictly aligns with the audio stream's true duration.
+    """
+    data: bytes
+    start_timestamp: float
+    duration: float
+    seq: int
+
+class AudioIngester:
+    def __init__(self, process: asyncio.subprocess.Process, sample_rate: int = 16000, channels: int = 1, sample_width: int = 2):
+        self.process = process
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self.sample_width = sample_width
+        self.bytes_per_second = sample_rate * channels * sample_width
+
+    async def stream(self, chunk_size: int = 4096) -> AsyncGenerator[AudioFrame, None]:
+        seq = 0
+        total_bytes = 0
+        while self.process.returncode is None:
+            try:
+                chunk = await self.process.stdout.read(chunk_size)
+                if not chunk:
+                    break
+                duration = len(chunk) / self.bytes_per_second
+                start_timestamp = total_bytes / self.bytes_per_second
+                yield AudioFrame(
+                    data=chunk,
+                    start_timestamp=start_timestamp,
+                    duration=duration,
+                    seq=seq
+                )
+                seq += 1
+                total_bytes += len(chunk)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.error(f"AudioIngester error: {e}")
+                break
+
+class StreamingProvider:
+    async def process_stream(
+        self,
+        audio_generator: AsyncIterator[AudioFrame],
+        aggregator,
+        notify_gap: Callable[[float, float], Awaitable[None]],
+        language_code: str,
+        model_variant: str,
+        config: ProviderConfig,
+        booth_id: str,
+    ) -> None:
+        raise NotImplementedError
+
+class ContinuousProvider(StreamingProvider):
+    async def process_stream(
+        self,
+        audio_generator: AsyncIterator[AudioFrame],
+        aggregator,
+        notify_gap: Callable[[float, float], Awaitable[None]],
+        language_code: str,
+        model_variant: str,
+        config: ProviderConfig,
+        booth_id: str,
+    ) -> None:
+        self.aggregator = aggregator
+        self.notify_gap = notify_gap
+        self.language_code = language_code
+        self.model_variant = model_variant
+        self.config = config
+        self.booth_id = booth_id
+
+        self.queue = asyncio.Queue()
+        self.queue_duration = 0.0
+        self.MAX_QUEUE_DURATION = 10.0
+        self.eof_event = asyncio.Event()
+        self._dropped_start = None
+        self._dropped_end = None
+
+        self.consumer_task = asyncio.create_task(self._consume_generator(audio_generator))
+
+        try:
+            await self._run_reconnect_loop()
+        finally:
+            self.consumer_task.cancel()
+            try:
+                await self.consumer_task
+            except asyncio.CancelledError:
+                pass
+
+    async def _consume_generator(self, audio_generator: AsyncIterator[AudioFrame]):
+        try:
+            async for frame in audio_generator:
+                self.queue.put_nowait(frame)
+                self.queue_duration += frame.duration
+
+                while self.queue_duration > self.MAX_QUEUE_DURATION:
+                    try:
+                        dropped = self.queue.get_nowait()
+                        self.queue_duration -= dropped.duration
+                        if self._dropped_start is None:
+                            self._dropped_start = dropped.start_timestamp
+                        self._dropped_end = dropped.start_timestamp + dropped.duration
+                    except asyncio.QueueEmpty:
+                        break
+
+            await self.queue.put(None)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"[{self.booth_id}] Error in audio consumer: {e}")
+            await self.queue.put(None)
+        finally:
+            self.eof_event.set()
+
+    async def _run_reconnect_loop(self):
+        retries = 0
+        while retries <= 5:
+            try:
+                if self._dropped_start is not None:
+                    await self.notify_gap(self._dropped_start, self._dropped_end)
+                    self._dropped_start = None
+                    self._dropped_end = None
+
+                await self.connect_and_stream()
+                return
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                retries += 1
+                if retries > 5:
+                    logger.error(f"[{self.booth_id}] Terminal error: {e}")
+                    if hasattr(self.aggregator, "broadcast_callback"):
+                        await self.aggregator.broadcast_callback(self.booth_id, "[Server disconnected: transcription failed. Please refresh.]")
+                    return
+
+                backoff = min(10.0, 2 ** retries)
+                logger.warning(f"[{self.booth_id}] Connection failed: {e}. Reconnecting in {backoff}s...")
+
+                try:
+                    await asyncio.wait_for(self.eof_event.wait(), timeout=backoff)
+                    logger.info(f"[{self.booth_id}] EOF reached during reconnect backoff. Terminating cleanly.")
+                    return
+                except asyncio.TimeoutError:
+                    pass
+
+    async def connect_and_stream(self):
+        raise NotImplementedError
+
+class ChunkedProvider(StreamingProvider):
+    async def process_block(self, audio_bytes: bytes, start_timestamp: float, language_code: str, model_variant: str, config: ProviderConfig) -> str:
+        raise NotImplementedError
+
+    async def process_stream(
+        self,
+        audio_generator: AsyncIterator[AudioFrame],
+        aggregator,
+        notify_gap: Callable[[float, float], Awaitable[None]],
+        language_code: str,
+        model_variant: str,
+        config: ProviderConfig,
+        booth_id: str,
+    ) -> None:
+        self.aggregator = aggregator
+        self.notify_gap = notify_gap
+        self.language_code = language_code
+        self.model_variant = model_variant
+        self.config = config
+        self.booth_id = booth_id
+
+        self.MAX_PENDING_BLOCKS = 3
+        self.BLOCK_DURATION = 3.0
+
+        self.block_queue = asyncio.Queue()
+        self.consumer_task = asyncio.create_task(self._assemble_blocks(audio_generator))
+
+        consecutive_errors = 0
+        try:
+            while True:
+                block_data = await self.block_queue.get()
+                if block_data is None:
+                    break
+
+                audio_bytes, start_ts, duration, is_partial = block_data
+
+                try:
+                    text = await self.process_block(audio_bytes, start_ts, language_code, model_variant, config)
+                    consecutive_errors = 0
+                    if text:
+                        await self.aggregator.handle_chunk(self.booth_id, text)
+                    else:
+                        await self.aggregator.handle_clear(self.booth_id)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    consecutive_errors += 1
+                    logger.error(f"[{self.booth_id}] Provider error ({consecutive_errors}/3): {e}")
+                    if consecutive_errors >= 3:
+                        if hasattr(self.aggregator, "broadcast_callback"):
+                            await self.aggregator.broadcast_callback(self.booth_id, "[Transcription provider failed. Check logs.]")
+                        break
+        except asyncio.CancelledError:
+            raise
+        finally:
+            self.consumer_task.cancel()
+            try:
+                await self.consumer_task
+            except asyncio.CancelledError:
+                pass
+
+    async def _assemble_blocks(self, audio_generator: AsyncIterator[AudioFrame]):
+        current_block = bytearray()
+        current_duration = 0.0
+        start_ts = None
+
+        try:
+            async for frame in audio_generator:
+                if start_ts is None:
+                    start_ts = frame.start_timestamp
+
+                current_block.extend(frame.data)
+                current_duration += frame.duration
+
+                if current_duration >= self.BLOCK_DURATION:
+                    await self._enqueue_block(bytes(current_block), start_ts, current_duration, False)
+                    current_block = bytearray()
+                    current_duration = 0.0
+                    start_ts = None
+
+            if current_block:
+                await self._enqueue_block(bytes(current_block), start_ts, current_duration, True)
+            await self.block_queue.put(None)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"[{self.booth_id}] Error assembling blocks: {e}")
+            await self.block_queue.put(None)
+
+    async def _enqueue_block(self, audio_bytes: bytes, start_ts: float, duration: float, is_partial: bool):
+        while self.block_queue.qsize() >= self.MAX_PENDING_BLOCKS:
+            try:
+                dropped = self.block_queue.get_nowait()
+                if dropped is not None:
+                    _, drop_start, drop_duration, _ = dropped
+                    await self.notify_gap(drop_start, drop_start + drop_duration)
+            except asyncio.QueueEmpty:
+                break
+
+        self.block_queue.put_nowait((audio_bytes, start_ts, duration, is_partial))

--- a/portal/transcription/worker.py
+++ b/portal/transcription/worker.py
@@ -104,9 +104,27 @@ class TranscriptionWorkerSession:
                 async with FfmpegProcess(self.rtsp_url, self.sample_rate, self.booth_id) as process:
                     try:
                         actual_language = self.transcription_language or self.language_code
-                        await self.provider.run_stream(
-                            process, actual_language, self.model_size, self.config, self.broadcast_callback, self.booth_id, self.room_id
-                        )
+                        from portal.transcription.providers.base import AudioIngester, StreamingProvider
+                        if isinstance(self.provider, StreamingProvider):
+                            ingester = AudioIngester(process, sample_rate=self.sample_rate)
+                            from portal.transcription.aggregator import CaptionAggregator
+                            aggregator = CaptionAggregator(self.broadcast_callback, room_id=self.room_id)
+                            async def notify_gap(start: float, end: float):
+                                logger.warning(f"[{self.booth_id}] Audio gap: {start:.1f}s - {end:.1f}s")
+                                await self.broadcast_callback(self.booth_id, f"[Audio gap: {end-start:.1f}s skipped to catch up]")
+                            await self.provider.process_stream(
+                                ingester.stream(),
+                                aggregator,
+                                notify_gap,
+                                language_code=actual_language,
+                                model_variant=self.model_size,
+                                config=self.config,
+                                booth_id=self.booth_id
+                            )
+                        else:
+                            await self.provider.run_stream(
+                                process, actual_language, self.model_size, self.config, self.broadcast_callback, self.booth_id, self.room_id
+                            )
                     except asyncio.IncompleteReadError:
                         logger.error(f"[{self.booth_id}][{self.session_id}] ffmpeg stream ended abruptly. Retrying...")
                     except asyncio.CancelledError:

--- a/tests/test_transcription_providers_contract.py
+++ b/tests/test_transcription_providers_contract.py
@@ -1,0 +1,196 @@
+import asyncio
+
+import pytest
+
+from portal.transcription.providers.base import AudioFrame, ChunkedProvider, ContinuousProvider, ProviderConfig
+
+
+class MockAggregator:
+    def __init__(self):
+        self.chunks = []
+        self.clears = []
+        self.system_messages = []
+
+    async def handle_chunk(self, booth_id, text):
+        self.chunks.append(text)
+
+    async def handle_clear(self, booth_id):
+        self.clears.append(booth_id)
+
+    async def broadcast_callback(self, booth_id, msg):
+        self.system_messages.append(msg)
+
+async def mock_audio_generator(frames):
+    for f in frames:
+        yield f
+        await asyncio.sleep(0.001)
+
+class DummyContinuousProvider(ContinuousProvider):
+    def __init__(self, should_fail=False, max_retries_fail=False, fail_delay=0.0):
+        super().__init__()
+        self.connected_count = 0
+        self.should_fail = should_fail
+        self.max_retries_fail = max_retries_fail
+        self.fail_delay = fail_delay
+        self.received_frames = []
+
+    async def connect_and_stream(self):
+        self.connected_count += 1
+        if self.should_fail:
+            self.should_fail = False
+            if self.fail_delay:
+                await asyncio.sleep(self.fail_delay)
+            raise Exception("Simulated disconnect")
+        if self.max_retries_fail:
+            raise Exception("Simulated permanent failure")
+
+        while True:
+            frame = await self.queue.get()
+            if frame is None:
+                break
+            self.received_frames.append(frame)
+
+class DummyChunkedProvider(ChunkedProvider):
+    def __init__(self, processing_delay=0.0):
+        super().__init__()
+        self.processed_blocks = []
+        self.processing_delay = processing_delay
+
+    async def process_block(self, audio_bytes: bytes, start_timestamp: float, language_code: str, model_variant: str, config: ProviderConfig) -> str:
+        if self.processing_delay > 0:
+            await asyncio.sleep(self.processing_delay)
+        self.processed_blocks.append((audio_bytes, start_timestamp))
+        return f"transcribed {len(audio_bytes)} bytes"
+
+@pytest.mark.anyio
+async def test_chunked_provider_exact_block_size_and_flush():
+    provider = DummyChunkedProvider()
+    aggregator = MockAggregator()
+
+    gaps = []
+    async def notify_gap(start, end):
+        gaps.append((start, end))
+
+    frames = []
+    for i in range(25):
+        frames.append(AudioFrame(data=b"a"*4096, start_timestamp=i*0.128, duration=0.128, seq=i))
+
+    await provider.process_stream(
+        mock_audio_generator(frames),
+        aggregator,
+        notify_gap,
+        "en", "test", ProviderConfig(None), "booth1"
+    )
+
+    assert len(provider.processed_blocks) == 2
+    b1_bytes, b1_ts = provider.processed_blocks[0]
+    assert len(b1_bytes) == 24 * 4096
+    assert b1_ts == 0.0
+
+    b2_bytes, b2_ts = provider.processed_blocks[1]
+    assert len(b2_bytes) == 1 * 4096
+    assert b2_ts == 24 * 0.128
+    assert len(gaps) == 0
+
+@pytest.mark.anyio
+async def test_continuous_provider_reconnect_and_gap():
+    # should_fail triggers a failure on first connection attempt,
+    # causing it to back off and buffer frames
+    provider = DummyContinuousProvider(should_fail=True, fail_delay=0.1)
+    aggregator = MockAggregator()
+
+    gaps = []
+    async def notify_gap(start, end):
+        gaps.append((start, end))
+
+    async def infinite_mock_generator():
+        # Produce exactly 15 seconds of audio overall
+        # 15s / 0.128s = 118 frames
+        for i in range(118):
+            yield AudioFrame(data=b"a"*4096, start_timestamp=i*0.128, duration=0.128, seq=i)
+            await asyncio.sleep(0.001)
+
+        # Wait until it connects a second time before sending EOF
+        while provider.connected_count < 2:
+            await asyncio.sleep(0.01)
+
+    await provider.process_stream(
+        infinite_mock_generator(),
+        aggregator,
+        notify_gap,
+        "en", "test", ProviderConfig(None), "booth1"
+    )
+
+    assert provider.connected_count == 2
+    assert len(gaps) == 1
+
+    gap_start, gap_end = gaps[0]
+    assert gap_start == 0.0
+    # We pushed ~15s of audio, max queue is 10s. So roughly 5s should be dropped.
+    assert 4.5 < gap_end < 5.5
+
+@pytest.mark.anyio
+async def test_continuous_provider_terminal_error():
+    provider = DummyContinuousProvider(max_retries_fail=True)
+    aggregator = MockAggregator()
+
+    gaps = []
+    async def notify_gap(start, end):
+        gaps.append((start, end))
+
+    async def infinite_mock_generator():
+        seq = 0
+        while True:
+            yield AudioFrame(data=b"a"*4096, start_timestamp=seq*0.128, duration=0.128, seq=seq)
+            seq += 1
+            await asyncio.sleep(0.001)
+
+    # Speed up sleep for test
+    original_sleep = asyncio.sleep
+    async def fast_sleep(t):
+        await original_sleep(0.001)
+    asyncio.sleep = fast_sleep
+
+    try:
+        await provider.process_stream(
+            infinite_mock_generator(),
+            aggregator,
+            notify_gap,
+            "en", "test", ProviderConfig(None), "booth1"
+        )
+    finally:
+        asyncio.sleep = original_sleep
+
+    assert provider.connected_count == 6 # initial + 5 retries
+    assert len(aggregator.system_messages) == 1
+    assert "transcription failed" in aggregator.system_messages[0]
+
+@pytest.mark.anyio
+async def test_chunked_provider_overload_drops_oldest():
+    # Make processing extremely slow so it backs up
+    provider = DummyChunkedProvider(processing_delay=0.2)
+    aggregator = MockAggregator()
+
+    gaps = []
+    async def notify_gap(start, end):
+        gaps.append((start, end))
+
+    # Push 15 seconds of audio extremely fast
+    # 15 / 0.128 = 118 frames
+    # That's 5 blocks. Max pending blocks is 3. So it should drop at least 1-2 blocks.
+    frames = []
+    for i in range(118):
+        frames.append(AudioFrame(data=b"a"*4096, start_timestamp=i*0.128, duration=0.128, seq=i))
+
+    await provider.process_stream(
+        mock_audio_generator(frames),
+        aggregator,
+        notify_gap,
+        "en", "test", ProviderConfig(None), "booth1"
+    )
+
+    assert len(gaps) > 0
+    # Block 1 (0.0) is instantly popped and begins processing.
+    # Block 2 (3.072), Block 3 (6.144), and Block 4 (9.216) fill the queue.
+    # When Block 5 is assembled, Block 2 is dropped.
+    assert gaps[0][0] == 3.072

--- a/tests/test_transcription_providers_contract.py
+++ b/tests/test_transcription_providers_contract.py
@@ -1,5 +1,6 @@
-import asyncio
+from __future__ import annotations
 
+import asyncio
 import pytest
 
 from portal.transcription.providers.base import AudioFrame, ChunkedProvider, ContinuousProvider, ProviderConfig


### PR DESCRIPTION
## The Problem
Previously, VoxBento forced all audio through a rigid 3-second (96KB) block-based chunking pipeline (`TranscriptionProvider.run_stream`). While this architecture was acceptable for older models (like Whisper), it created a severe architectural bottleneck for modern streaming AI (like Deepgram or OpenAI Realtime) that natively accept continuous WebSockets. Providers were forced into leaky abstractions, having to override the entire base stream logic and duplicate massive amounts of boilerplate just to read from the `ffmpeg` subprocess.

- fixes : #351 
- stacked : #368 

## The Solution
This PR decouples **Audio Ingestion** from **Transcription Inference** and introduces two specialized pipelines to fully support both legacy block-based models and modern continuous streaming models.

### Key Architectural Changes
1. **`AudioFrame` & `AudioIngester`:** 
   - Moved all `ffmpeg` subprocess reading into a dedicated `AudioIngester` class.
   - Introduced a frozen `AudioFrame` dataclass with strictly deterministic, audio-relative timestamps and sequence numbers for accurate gap tracking.
2. **`StreamingProvider` Base Class:**
   - Introduced the shared `StreamingProvider` interface, providing strict contracts for backpressure, connection lifecycles, and gap signaling to the `CaptionAggregator`.
3. **`ContinuousProvider` (For Deepgram & OpenAI Realtime):**
   - Implements a duration-bounded queue (max 10 seconds of audio buffer).
   - Features robust self-healing: capped exponential backoff (up to 25s) with a strictly enforced `DROP_OLDEST` policy under backpressure to ensure live streams remain in real-time sync. 
   - Preempts reconnect backoffs instantly on Graceful EOF to prevent orphaned websocket attempts.
4. **`ChunkedProvider` (For Whisper, Local, NVIDIA):**
   - Assembles `AudioFrame`s into exact 3-second byte arrays for block inference.
   - Enforces a 9-second pending block queue, dropping the oldest blocks when CPU inference lags.
   - Ensures the trailing partial block is flushed accurately on Graceful EOF, but dropped instantly on Cancellation.
5. **Dynamic Worker Migration (`worker.py`):**
   - Implemented dynamic runtime introspection in the transcription worker. If a provider inherits from `StreamingProvider`, it uses the new architecture natively. Otherwise, it seamlessly falls back to the legacy `run_stream`. This enables safe, incremental parallel migration of providers one by one.
6. **Exhaustive Contract Testing:**
   - Added `tests/test_transcription_providers_contract.py` to exhaustively verify queue boundaries, drop-oldest behaviors, gap signaling, trailing flushes, and EOF preemptions.

## Testing Instructions
- [x] all unit tests have been run and verified successfully 

## Next Steps
With this architectural foundation merged, the immediate next step is to migrate `DeepgramProvider` and `OpenAIProvider` to inherit from `ContinuousProvider`, slashing transcription latency by eliminating the 3-second buffer.

## Summary by Sourcery

Decouple audio ingestion from transcription processing to support both continuous streaming and legacy chunked providers.

New Features:
- Add audio frame ingestion and streaming provider abstractions for continuous and block-based transcription workflows.

Bug Fixes:
- Improve transcription resilience by handling provider reconnects, backpressure, dropped audio, and end-of-stream behavior.

Enhancements:
- Enable transcription workers to select the new streaming architecture while retaining compatibility with legacy providers.

Tests:
- Add contract tests covering block assembly, trailing audio flushing, queue overflow, gap reporting, reconnection, and terminal failures.