### PR TITLE
fix: resolve 500 error on developer dashboard caused by dict attribute access

### DIFF
--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -1685,10 +1685,10 @@ async def api_supertonic_download_progress():
 # Developer Accounts
 # ---------------------------------------------------------------------------
 
-@router.get("/admin/developer-accounts", include_in_schema=False)
+@router.get("/admin/developer-accounts", include_in_schema=False, dependencies=[Depends(require_super_admin)])
 async def admin_developer_accounts(
     request: Request,
-    user: User = Depends(require_super_admin),
+    user: dict = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ):
     from sqlalchemy.orm import selectinload
@@ -1711,10 +1711,10 @@ async def admin_developer_accounts(
         },
     )
 
-@router.post("/api/admin/developer-accounts/{account_id}/approve", include_in_schema=False)
+@router.post("/api/admin/developer-accounts/{account_id}/approve", include_in_schema=False, dependencies=[Depends(require_super_admin)])
 async def admin_developer_approve(
     account_id: int,
-    user: User = Depends(require_super_admin),
+    user: dict = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ):
     from datetime import datetime, timezone
@@ -1726,16 +1726,16 @@ async def admin_developer_approve(
         raise HTTPException(status_code=404, detail="Account not found")
 
     account.status = "approved"
-    account.reviewed_by = user.id
+    account.reviewed_by = int(user["sub"])
     account.reviewed_at = datetime.now(timezone.utc)
     await db.commit()
 
     return RedirectResponse(url="/admin/developer-accounts", status_code=status.HTTP_303_SEE_OTHER)
 
-@router.post("/api/admin/developer-accounts/{account_id}/reject", include_in_schema=False)
+@router.post("/api/admin/developer-accounts/{account_id}/reject", include_in_schema=False, dependencies=[Depends(require_super_admin)])
 async def admin_developer_reject(
     account_id: int,
-    user: User = Depends(require_super_admin),
+    user: dict = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ):
     from datetime import datetime, timezone
@@ -1747,7 +1747,7 @@ async def admin_developer_reject(
         raise HTTPException(status_code=404, detail="Account not found")
 
     account.status = "rejected"
-    account.reviewed_by = user.id
+    account.reviewed_by = int(user["sub"])
     account.reviewed_at = datetime.now(timezone.utc)
     await db.commit()
 

--- a/portal/routers/developer.py
+++ b/portal/routers/developer.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from portal.auth import require_user
 from portal.database import get_session
-from portal.models import DeveloperAccount, OAuthClient, User
+from portal.models import DeveloperAccount, OAuthClient
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +23,10 @@ templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
 @router.get("/developer", include_in_schema=False)
 async def developer_dashboard(
     request: Request,
-    user: User = Depends(require_user),
+    user: dict = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ):
-    result = await db.execute(select(DeveloperAccount).where(DeveloperAccount.user_id == user.id))
+    result = await db.execute(select(DeveloperAccount).where(DeveloperAccount.user_id == int(user["sub"])))
     account = result.scalars().first()
 
     clients = []
@@ -47,17 +47,17 @@ async def developer_dashboard(
 @router.post("/api/developer/apply")
 async def apply_for_developer(
     organization_name: str = Form(...),
-    user: User = Depends(require_user),
+    user: dict = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ):
-    result = await db.execute(select(DeveloperAccount).where(DeveloperAccount.user_id == user.id))
+    result = await db.execute(select(DeveloperAccount).where(DeveloperAccount.user_id == int(user["sub"])))
     existing = result.scalars().first()
 
     if existing:
         return RedirectResponse(url="/developer", status_code=status.HTTP_303_SEE_OTHER)
 
     account = DeveloperAccount(
-        user_id=user.id,
+        user_id=int(user["sub"]),
         status="pending",
         organization_name=organization_name,
     )

--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -26,7 +26,6 @@ from portal.models import (
     OAuthClient,
     OAuthConsentGrant,
     OAuthToken,
-    User,
 )
 from portal.rate_limit import auth_rate_limiter, token_rate_limiter
 
@@ -62,11 +61,11 @@ def verify_pkce(code_verifier: str, code_challenge: str, method: str) -> bool:
         return encoded == code_challenge
     return False
 
-async def get_effective_scopes(db: AsyncSession, user: User, event_id: int, requested_scopes: list[str]) -> list[str]:
+async def get_effective_scopes(db: AsyncSession, user: dict, event_id: int, requested_scopes: list[str]) -> list[str]:
     # Check if user has EventMembership
     result = await db.execute(
         select(EventMembership).where(
-            EventMembership.user_id == user.id,
+            EventMembership.user_id == int(user["sub"]),
             EventMembership.event_id == event_id
         )
     )
@@ -104,7 +103,7 @@ async def authorize_get(
     code_challenge: str = "",
     code_challenge_method: str = "",
     event: str = "",
-    user: User = Depends(require_user),
+    user: dict = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ):
     if response_type != "code":
@@ -169,7 +168,7 @@ async def authorize_post(
     event_id: Annotated[int, Form()],
     scope: Annotated[str, Form()],
     action: Annotated[str, Form()],
-    user: User = Depends(require_user),
+    user: dict = Depends(require_user),
     db: AsyncSession = Depends(get_session),
 ):
     if action == "deny":
@@ -190,7 +189,7 @@ async def authorize_post(
     # Save consent
     consent = OAuthConsentGrant(
         client_id=client.id,
-        user_id=user.id,
+        user_id=int(user["sub"]),
         event_id=event_id,
         scopes=effective_scopes
     )
@@ -200,7 +199,7 @@ async def authorize_post(
     code = generate_token()
     auth_code = OAuthAuthorizationCode(
         client_id=client.id,
-        user_id=user.id,
+        user_id=int(user["sub"]),
         event_id=event_id,
         scopes=effective_scopes,
         code_hash=hash_token(code),


### PR DESCRIPTION
FastAPI's dependencies resolve `user_token`s to a dictionary payload in VoxBento's architecture, not a SQLAlchemy `User` object. 

Accessing `user.id` directly resulted in `AttributeError: 'dict' object has no attribute 'id'`, causing HTTP 500 errors on the `/developer` dashboard and several OAuth/Admin routes. This PR correctly accesses the subject claim via `int(user['sub'])` and ensures `Depends(require_user)` provides the correct typing.

## Summary by Sourcery

Use authenticated token subject claims consistently across developer, OAuth, and administrator routes to prevent attribute-access errors and restore affected workflows.

Bug Fixes:
- Fix developer dashboard and OAuth flows that failed when authenticated user payloads were treated as model objects.
- Correct administrator developer-account review actions to record the authenticated user from the token payload.

Enhancements:
- Align authenticated-user dependency typing and authorization checks across developer, OAuth, and administrator routes.