### PR TITLE
fix: resolve FastAPI Dependency ContextManager crash

### DIFF
--- a/portal/database.py
+++ b/portal/database.py
@@ -105,6 +105,13 @@ async def get_session() -> AsyncGenerator[AsyncSession]:
         async with session.begin():
             yield session
 
+async def get_db_session() -> AsyncGenerator[AsyncSession]:
+    """FastAPI dependency for database sessions."""
+    async with get_session() as session:
+        yield session
+
+
+
 
 async def init_db() -> None:
     """Create all tables (for testing / development without Alembic)."""

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -46,6 +46,7 @@ from portal.database import (
     delete_user,
     get_api_keys_for_event,
     get_booth_by_id,
+    get_db_session,
     get_event_by_id,
     get_event_by_slug,
     get_room_by_id,
@@ -1689,7 +1690,7 @@ async def api_supertonic_download_progress():
 async def admin_developer_accounts(
     request: Request,
     user: dict = Depends(require_user),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_db_session),
 ):
     from sqlalchemy.orm import selectinload
 
@@ -1715,7 +1716,7 @@ async def admin_developer_accounts(
 async def admin_developer_approve(
     account_id: int,
     user: dict = Depends(require_user),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_db_session),
 ):
     from datetime import datetime, timezone
 
@@ -1736,7 +1737,7 @@ async def admin_developer_approve(
 async def admin_developer_reject(
     account_id: int,
     user: dict = Depends(require_user),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_db_session),
 ):
     from datetime import datetime, timezone
 

--- a/portal/routers/developer.py
+++ b/portal/routers/developer.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from portal.auth import require_user
-from portal.database import get_session
+from portal.database import get_db_session
 from portal.models import DeveloperAccount, OAuthClient
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
 async def developer_dashboard(
     request: Request,
     user: dict = Depends(require_user),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_db_session),
 ):
     result = await db.execute(select(DeveloperAccount).where(DeveloperAccount.user_id == int(user["sub"])))
     account = result.scalars().first()
@@ -48,7 +48,7 @@ async def developer_dashboard(
 async def apply_for_developer(
     organization_name: str = Form(...),
     user: dict = Depends(require_user),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_db_session),
 ):
     result = await db.execute(select(DeveloperAccount).where(DeveloperAccount.user_id == int(user["sub"])))
     existing = result.scalars().first()

--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from portal.auth import require_user
-from portal.database import get_session
+from portal.database import get_db_session
 from portal.models import (
     Event,
     EventMembership,
@@ -104,7 +104,7 @@ async def authorize_get(
     code_challenge_method: str = "",
     event: str = "",
     user: dict = Depends(require_user),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_db_session),
 ):
     if response_type != "code":
         raise HTTPException(status_code=400, detail="Unsupported response_type. Only 'code' is supported.")
@@ -169,7 +169,7 @@ async def authorize_post(
     scope: Annotated[str, Form()],
     action: Annotated[str, Form()],
     user: dict = Depends(require_user),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_db_session),
 ):
     if action == "deny":
         error_url = f"{redirect_uri}?error=access_denied&state={urllib.parse.quote(state)}"
@@ -226,7 +226,7 @@ async def token_exchange(
     redirect_uri: Annotated[str | None, Form()] = None,
     code_verifier: Annotated[str | None, Form()] = None,
     refresh_token: Annotated[str | None, Form()] = None,
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_db_session),
 ):
     # Basic client validation
     result = await db.execute(select(OAuthClient).where(OAuthClient.client_id == client_id))
@@ -353,7 +353,7 @@ async def revoke_token(
     token: Annotated[str, Form()],
     client_id: Annotated[str, Form()],
     client_secret: Annotated[str | None, Form()] = None,
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_db_session),
 ):
     result = await db.execute(select(OAuthClient).where(OAuthClient.client_id == client_id))
     client = result.scalars().first()


### PR DESCRIPTION
My previous PR fixed the auth dictionaries but missed the root cause of the initial FastAPI crash. FastAPI dependencies cannot directly inject a `@asynccontextmanager` generator. This PR introduces `get_db_session` as a clean FastAPI dependency to fix the 500 errors across all developer and admin routes.

## Summary by Sourcery

Make database sessions compatible with FastAPI dependency injection across affected routes.

Bug Fixes:
- Fix FastAPI 500 errors on developer, admin, and OAuth routes by providing database sessions through a compatible dependency.

Enhancements:
- Centralize FastAPI database-session injection behind a dedicated dependency while preserving the existing session lifecycle.