### PR TITLE
fix: resolve TemplateResponse signature crash

### DIFF
--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -146,9 +146,9 @@ async def mission_control_list(request: Request, user=Depends(require_user), pag
         accessible_events = await list_events(session, limit=limit, offset=offset, allowed_event_ids=allowed_event_ids)
     total_pages = max(1, math.ceil(total_events / limit))
     return templates.TemplateResponse(
-        request,
-        "mission_control/event_list.html",
-        {
+        request=request,
+        name="mission_control/event_list.html",
+        context={
             "events": accessible_events,
             "is_super_admin": is_super_admin,
             "is_event_owner": True,
@@ -214,9 +214,9 @@ async def mission_control_grid(request: Request, event_slug: str, user=Depends(r
             state["room_name"] = db_b.room.display_name if db_b.room else "Unknown Room"
             event_booths.append(state)
     return templates.TemplateResponse(
-        request,
-        "mission_control/grid.html",
-        {
+        request=request,
+        name="mission_control/grid.html",
+        context={
             "event": event,
             "booths": event_booths,
             "whip_base": settings.mediamtx_whip_base,
@@ -234,7 +234,7 @@ async def admin_login_page(request: Request):
     user = await get_current_user(request)
     if user and user.get("is_admin"):
         return safe_redirect(url="/admin/", status_code=status.HTTP_303_SEE_OTHER)
-    return templates.TemplateResponse(request, "admin/login.html", {})
+    return templates.TemplateResponse(request=request, name="admin/login.html", context={})
 
 
 @router.post("/admin/login")
@@ -243,7 +243,10 @@ async def admin_login_submit(request: Request):
     password = form.get("password", "")
     if not settings.admin_password or password != settings.admin_password:
         return templates.TemplateResponse(
-            request, "admin/login.html", {"error": "Invalid password."}, status_code=status.HTTP_403_FORBIDDEN
+            request=request,
+            name="admin/login.html",
+            context={"error": "Invalid password."},
+            status_code=status.HTTP_403_FORBIDDEN,
         )
     token = create_admin_token()
     response = safe_redirect(url="/admin/", status_code=status.HTTP_303_SEE_OTHER)
@@ -298,9 +301,15 @@ async def admin_dashboard(request: Request, page: int = 1):
     mediamtx_ok = await _check_mediamtx()
     total_pages = max(1, math.ceil(total_events / limit))
     return templates.TemplateResponse(
-        request,
-        "admin/dashboard.html",
-        {"event_data": event_data, "mediamtx_ok": mediamtx_ok, "page": page, "total_pages": total_pages, **admin_flags},
+        request=request,
+        name="admin/dashboard.html",
+        context={
+            "event_data": event_data,
+            "mediamtx_ok": mediamtx_ok,
+            "page": page,
+            "total_pages": total_pages,
+            **admin_flags,
+        },
     )
 
 
@@ -317,7 +326,9 @@ async def admin_event_list(request: Request, page: int = 1):
         events = await list_events(session, limit=limit, offset=offset, allowed_event_ids=allowed_event_ids)
     total_pages = max(1, math.ceil(total_events / limit))
     return templates.TemplateResponse(
-        request, "admin/event_list.html", {"events": events, "page": page, "total_pages": total_pages, **admin_flags}
+        request=request,
+        name="admin/event_list.html",
+        context={"events": events, "page": page, "total_pages": total_pages, **admin_flags},
     )
 
 
@@ -344,7 +355,7 @@ async def admin_create_event(request: Request):
 @router.get("/admin/setup", dependencies=[Depends(require_admin)])
 async def admin_setup_start(request: Request):
     admin_flags = await get_admin_flags(request)
-    return templates.TemplateResponse(request, "admin/wizard_event.html", {**admin_flags})
+    return templates.TemplateResponse(request=request, name="admin/wizard_event.html", context={**admin_flags})
 
 
 @router.post("/admin/setup", dependencies=[Depends(require_admin)])
@@ -354,9 +365,9 @@ async def admin_setup_create_event(request: Request):
     raw_slug = form.get("slug", "").strip()
     if not display_name:
         return templates.TemplateResponse(
-            request,
-            "admin/wizard_event.html",
-            {"error": "Please enter an event name.", "slug": raw_slug},
+            request=request,
+            name="admin/wizard_event.html",
+            context={"error": "Please enter an event name.", "slug": raw_slug},
             status_code=status.HTTP_400_BAD_REQUEST,
         )
     candidate = raw_slug or _slugify(display_name)
@@ -364,9 +375,9 @@ async def admin_setup_create_event(request: Request):
         slug = validate_event_slug(candidate)
     except ValueError:
         return templates.TemplateResponse(
-            request,
-            "admin/wizard_event.html",
-            {
+            request=request,
+            name="admin/wizard_event.html",
+            context={
                 "error": "That URL slug isn't valid. Use lowercase letters, numbers and hyphens.",
                 "display_name": display_name,
                 "slug": candidate,
@@ -376,9 +387,9 @@ async def admin_setup_create_event(request: Request):
     async with get_session() as session:
         if await get_event_by_slug(session, slug) is not None:
             return templates.TemplateResponse(
-                request,
-                "admin/wizard_event.html",
-                {
+                request=request,
+                name="admin/wizard_event.html",
+                context={
                     "error": f"An event with the slug '{slug}' already exists. Choose another.",
                     "display_name": display_name,
                     "slug": slug,
@@ -399,7 +410,7 @@ async def admin_setup_rooms(request: Request, event_id: int):
             raise HTTPException(status_code=404, detail="Event not found.")
         rooms = await list_rooms_for_event(session, event_id)
     return templates.TemplateResponse(
-        request, "admin/wizard_rooms.html", {"event": event, "rooms": rooms, **admin_flags}
+        request=request, name="admin/wizard_rooms.html", context={"event": event, "rooms": rooms, **admin_flags}
     )
 
 
@@ -429,9 +440,9 @@ async def admin_setup_booths(request: Request, event_id: int):
         rooms = await list_rooms_for_event(session, event_id)
         booths_by_room = {room.id: await list_booths_for_room(session, room.id) for room in rooms}
     return templates.TemplateResponse(
-        request,
-        "admin/wizard_booths.html",
-        {
+        request=request,
+        name="admin/wizard_booths.html",
+        context={
             "event": event,
             "rooms": rooms,
             "booths_by_room": booths_by_room,
@@ -482,9 +493,9 @@ async def admin_setup_invite(request: Request, event_id: int, success: str | Non
             await session.flush()
         memberships = await list_memberships_for_event(session, event_id)
     return templates.TemplateResponse(
-        request,
-        "admin/wizard_invite.html",
-        {
+        request=request,
+        name="admin/wizard_invite.html",
+        context={
             "event": event,
             "memberships": memberships,
             "success": success,
@@ -550,9 +561,9 @@ async def admin_event_detail(request: Request, event_id: int):
         is_live = mem_booth is not None and mem_booth.ingest_status == "connected"
         booth_statuses.append({"db": b, "booth_id": bid, "is_live": is_live})
     return templates.TemplateResponse(
-        request,
-        "admin/event_detail.html",
-        {
+        request=request,
+        name="admin/event_detail.html",
+        context={
             "event": event,
             "rooms": rooms,
             "booths": booth_statuses,
@@ -569,7 +580,9 @@ async def admin_event_api_settings_get(request: Request, event_id: int):
         if event is None:
             raise HTTPException(status_code=404, detail="Event not found.")
     admin_flags = await get_admin_flags(request, event_id=event_id)
-    return templates.TemplateResponse(request, "admin/api_settings.html", {"event": event, **admin_flags})
+    return templates.TemplateResponse(
+        request=request, name="admin/api_settings.html", context={"event": event, **admin_flags}
+    )
 
 
 @router.post("/admin/events/{event_id}/api-settings", dependencies=[Depends(require_admin)])
@@ -662,7 +675,9 @@ async def admin_room_list(request: Request, event_id: int):
         for room in rooms:
             room_booths = await list_booths_for_room(session, room.id)
             room_data.append({"room": room, "booth_count": len(room_booths)})
-    return templates.TemplateResponse(request, "admin/room_list.html", {"event": event, "room_data": room_data})
+    return templates.TemplateResponse(
+        request=request, name="admin/room_list.html", context={"event": event, "room_data": room_data}
+    )
 
 
 @router.post("/admin/events/{event_id}/rooms/", dependencies=[Depends(require_admin)])
@@ -710,9 +725,9 @@ async def admin_room_detail(request: Request, event_id: int, room_id: int):
     async with get_session() as session:
         memberships = await list_memberships_for_room(session, room_id)
     return templates.TemplateResponse(
-        request,
-        "admin/room_detail.html",
-        {
+        request=request,
+        name="admin/room_detail.html",
+        context={
             "event": event,
             "room": room,
             "booths": booth_statuses,
@@ -737,7 +752,9 @@ async def admin_room_transcripts(request: Request, event_id: int, room_id: int):
         booths = await list_booths_for_room(session, room_id)
     admin_flags = await get_admin_flags(request, event_id=event_id, room_id=room_id)
     return templates.TemplateResponse(
-        request, "admin/room_transcripts.html", {"event": event, "room": room, "booths": booths, **admin_flags}
+        request=request,
+        name="admin/room_transcripts.html",
+        context={"event": event, "room": room, "booths": booths, **admin_flags},
     )
 
 
@@ -1030,7 +1047,9 @@ async def admin_booth_list(request: Request, event_id: int, room_id: int):
         booth_statuses.append({"db": b, "booth_id": bid, "is_live": is_live})
     admin_flags = await get_admin_flags(request, event_id=event_id, room_id=room_id)
     return templates.TemplateResponse(
-        request, "admin/booth_list.html", {"event": event, "room": room, "booths": booth_statuses, **admin_flags}
+        request=request,
+        name="admin/booth_list.html",
+        context={"event": event, "room": room, "booths": booth_statuses, **admin_flags},
     )
 
 
@@ -1085,9 +1104,9 @@ async def admin_booth_detail(request: Request, event_id: int, room_id: int, boot
     translation_languages_dataset.sort(key=lambda x: x["name"])
     enabled_translation_language_codes = [lang.language_code for lang in db_booth.translation_languages if lang.enabled]
     return templates.TemplateResponse(
-        request,
-        "admin/booth_detail.html",
-        {
+        request=request,
+        name="admin/booth_detail.html",
+        context={
             "event": event,
             "room": room,
             "booth": db_booth,
@@ -1416,9 +1435,9 @@ async def admin_user_list(request: Request, page: int = 1, search: str | None = 
         users = await list_users(session, limit=limit, offset=offset, search=search)
     total_pages = max(1, math.ceil(total_users / limit))
     return templates.TemplateResponse(
-        request,
-        "admin/user_list.html",
-        {
+        request=request,
+        name="admin/user_list.html",
+        context={
             "users": users,
             "page": page,
             "total_pages": total_pages,
@@ -1456,9 +1475,9 @@ async def admin_user_detail(request: Request, user_id: int):
         memberships = await list_memberships_for_user(session, user_id)
         event_owner_map = {m.event_id: m for m in memberships if m.role == "event_owner"}
     return templates.TemplateResponse(
-        request,
-        "admin/user_detail.html",
-        {
+        request=request,
+        name="admin/user_detail.html",
+        context={
             "user_detail": user,
             "events": events,
             "event_owner_map": event_owner_map,
@@ -1506,9 +1525,9 @@ async def admin_event_members(request: Request, event_id: int):
         users = await list_users(session)
     membership_map = {m.user_id: m for m in memberships}
     return templates.TemplateResponse(
-        request,
-        "admin/event_members.html",
-        {"event": event, "memberships": memberships, "membership_map": membership_map, "users": users},
+        request=request,
+        name="admin/event_members.html",
+        context={"event": event, "memberships": memberships, "membership_map": membership_map, "users": users},
     )
 
 
@@ -1670,21 +1689,27 @@ async def api_download_progress(model: str = Query("nllb-200-distilled-600M")):
     progress = get_download_progress(model)
     return progress
 
+
 @router.post("/admin/models/supertonic/trigger_download", dependencies=[Depends(require_admin)])
 async def api_supertonic_trigger_download():
     from portal.tts.providers.supertonic import trigger_supertonic_download
+
     trigger_supertonic_download()
     return {"status": "started"}
+
 
 @router.get("/admin/models/supertonic/download_progress", dependencies=[Depends(require_admin)])
 async def api_supertonic_download_progress():
     from portal.tts.providers.supertonic import get_supertonic_download_progress
+
     progress = get_supertonic_download_progress()
     return progress
+
 
 # ---------------------------------------------------------------------------
 # Developer Accounts
 # ---------------------------------------------------------------------------
+
 
 @router.get("/admin/developer-accounts", include_in_schema=False, dependencies=[Depends(require_super_admin)])
 async def admin_developer_accounts(
@@ -1704,15 +1729,20 @@ async def admin_developer_accounts(
     accounts = result.scalars().all()
 
     return templates.TemplateResponse(
-        request,
-        "admin/developer_accounts.html",
-        {
+        request=request,
+        name="admin/developer_accounts.html",
+        context={
             "user": user,
             "accounts": accounts,
         },
     )
 
-@router.post("/api/admin/developer-accounts/{account_id}/approve", include_in_schema=False, dependencies=[Depends(require_super_admin)])
+
+@router.post(
+    "/api/admin/developer-accounts/{account_id}/approve",
+    include_in_schema=False,
+    dependencies=[Depends(require_super_admin)],
+)
 async def admin_developer_approve(
     account_id: int,
     user: dict = Depends(require_user),
@@ -1733,7 +1763,12 @@ async def admin_developer_approve(
 
     return RedirectResponse(url="/admin/developer-accounts", status_code=status.HTTP_303_SEE_OTHER)
 
-@router.post("/api/admin/developer-accounts/{account_id}/reject", include_in_schema=False, dependencies=[Depends(require_super_admin)])
+
+@router.post(
+    "/api/admin/developer-accounts/{account_id}/reject",
+    include_in_schema=False,
+    dependencies=[Depends(require_super_admin)],
+)
 async def admin_developer_reject(
     account_id: int,
     user: dict = Depends(require_user),
@@ -1753,4 +1788,3 @@ async def admin_developer_reject(
     await db.commit()
 
     return RedirectResponse(url="/admin/developer-accounts", status_code=status.HTTP_303_SEE_OTHER)
-

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -1704,9 +1704,9 @@ async def admin_developer_accounts(
     accounts = result.scalars().all()
 
     return templates.TemplateResponse(
+        request,
         "admin/developer_accounts.html",
         {
-            "request": request,
             "user": user,
             "accounts": accounts,
         },

--- a/portal/routers/auth.py
+++ b/portal/routers/auth.py
@@ -104,7 +104,7 @@ async def register_page(request: Request):
     current_user = await get_current_user(request)
     if current_user:
         return safe_redirect(url="/account", status_code=status.HTTP_303_SEE_OTHER)
-    return templates.TemplateResponse(request, "register.html", {})
+    return templates.TemplateResponse(request=request, name="register.html", context={})
 
 
 @router.post("/register")
@@ -148,15 +148,15 @@ async def register_submit(request: Request):
                 await send_verification_email(email, token_val)
 
                 return templates.TemplateResponse(
-                    request,
-                    "register_success.html",
-                    {"email": email},
+                    request=request,
+                    name="register_success.html",
+                    context={"email": email},
                 )
 
     return templates.TemplateResponse(
-        request,
-        "register.html",
-        {"errors": errors, "email": email, "display_name": display_name},
+        request=request,
+        name="register.html",
+        context={"errors": errors, "email": email, "display_name": display_name},
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
     )
 
@@ -190,7 +190,7 @@ async def user_login_page(request: Request, next: str = ""):
     if current_user:
         redirect_to = next if next and next.startswith("/") and not next.startswith("//") else "/account"
         return safe_redirect(url=redirect_to, status_code=status.HTTP_303_SEE_OTHER)
-    return templates.TemplateResponse(request, "login.html", {"next_url": next})
+    return templates.TemplateResponse(request=request, name="login.html", context={"next_url": next})
 
 
 @router.post("/login")
@@ -202,9 +202,9 @@ async def user_login_submit(request: Request):
 
     if not check_rate_limit("login", email, max_requests=10, window_seconds=3600):
         return templates.TemplateResponse(
-            request,
-            "login.html",
-            {"error": "Too many attempts. Try again later.", "email": email, "next_url": next_url},
+            request=request,
+            name="login.html",
+            context={"error": "Too many attempts. Try again later.", "email": email, "next_url": next_url},
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
         )
 
@@ -213,23 +213,27 @@ async def user_login_submit(request: Request):
 
     if user is None or not user.password_hash or not verify_password(password, user.password_hash):
         return templates.TemplateResponse(
-            request,
-            "login.html",
-            {"error": "Invalid email or password.", "email": email, "next_url": next_url},
+            request=request,
+            name="login.html",
+            context={"error": "Invalid email or password.", "email": email, "next_url": next_url},
             status_code=status.HTTP_403_FORBIDDEN,
         )
     if not user.is_active:
         return templates.TemplateResponse(
-            request,
-            "login.html",
-            {"error": "Your account has been deactivated. Contact an admin.", "email": email, "next_url": next_url},
+            request=request,
+            name="login.html",
+            context={
+                "error": "Your account has been deactivated. Contact an admin.",
+                "email": email,
+                "next_url": next_url,
+            },
             status_code=status.HTTP_403_FORBIDDEN,
         )
     if not user.email_verified:
         return templates.TemplateResponse(
-            request,
-            "login.html",
-            {"error": "Please verify your email address first.", "email": email, "next_url": next_url},
+            request=request,
+            name="login.html",
+            context={"error": "Please verify your email address first.", "email": email, "next_url": next_url},
             status_code=status.HTTP_403_FORBIDDEN,
         )
 
@@ -330,7 +334,7 @@ async def forgot_password_request(request: Request):
 
 @router.get("/auth/reset/{token}")
 async def reset_password_page(request: Request, token: str):
-    return templates.TemplateResponse(request, "reset_password.html", {"token": token})
+    return templates.TemplateResponse(request=request, name="reset_password.html", context={"token": token})
 
 
 @router.post("/auth/reset/{token}")
@@ -340,7 +344,9 @@ async def reset_password_submit(request: Request, token: str):
 
     if len(password) < 8:
         return templates.TemplateResponse(
-            request, "reset_password.html", {"token": token, "error": "Password must be at least 8 characters"}
+            request=request,
+            name="reset_password.html",
+            context={"token": token, "error": "Password must be at least 8 characters"},
         )
 
     async with get_session() as session:
@@ -362,7 +368,9 @@ async def reset_password_submit(request: Request, token: str):
             )
             return response
         except ValueError as e:
-            return templates.TemplateResponse(request, "reset_password.html", {"token": token, "error": str(e)})
+            return templates.TemplateResponse(
+                request=request, name="reset_password.html", context={"token": token, "error": str(e)}
+            )
 
 
 @router.get("/logout")
@@ -424,7 +432,9 @@ async def account_page(request: Request):
 
     unified_memberships.sort(key=lambda x: x["created_at"] or datetime.min.replace(tzinfo=timezone.utc))
 
-    return templates.TemplateResponse(request, "account.html", {"user": user, "memberships": unified_memberships})
+    return templates.TemplateResponse(
+        request=request, name="account.html", context={"user": user, "memberships": unified_memberships}
+    )
 
 
 @router.post("/api/auth/set-password")

--- a/portal/routers/developer.py
+++ b/portal/routers/developer.py
@@ -20,6 +20,7 @@ router = APIRouter()
 _BASE_DIR = Path(__file__).resolve().parent.parent.parent
 templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
 
+
 @router.get("/developer", include_in_schema=False)
 async def developer_dashboard(
     request: Request,
@@ -35,14 +36,15 @@ async def developer_dashboard(
         clients = client_result.scalars().all()
 
     return templates.TemplateResponse(
-        request,
-        "developer/dashboard.html",
-        {
+        request=request,
+        name="developer/dashboard.html",
+        context={
             "user": user,
             "account": account,
             "clients": clients,
         },
     )
+
 
 @router.post("/api/developer/apply")
 async def apply_for_developer(

--- a/portal/routers/developer.py
+++ b/portal/routers/developer.py
@@ -35,9 +35,9 @@ async def developer_dashboard(
         clients = client_result.scalars().all()
 
     return templates.TemplateResponse(
+        request,
         "developer/dashboard.html",
         {
-            "request": request,
             "user": user,
             "account": account,
             "clients": clients,

--- a/portal/routers/interpreter.py
+++ b/portal/routers/interpreter.py
@@ -88,7 +88,7 @@ async def interpreter_landing_page(request: Request) -> Any:
         except ValueError:
             pass
     return templates.TemplateResponse(
-        request, "interpreter_landing.html", {"my_booths": my_booths, "js_version": _JS_CACHE_BUST}
+        request=request, name="interpreter_landing.html", context={"my_booths": my_booths, "js_version": _JS_CACHE_BUST}
     )
 
 
@@ -147,9 +147,9 @@ async def interpreter_booth_by_identity(
     final_jitsi_url = room_jitsi_url or default_jitsi_url
     display_name = payload.get("display_name", "") or payload.get("email", "")
     return templates.TemplateResponse(
-        request,
-        "interpreter_booth.html",
-        {
+        request=request,
+        name="interpreter_booth.html",
+        context={
             "booth_id": booth_id,
             "booth_token": token,
             "booth_language": display_language,

--- a/portal/routers/listener.py
+++ b/portal/routers/listener.py
@@ -89,7 +89,9 @@ async def listen_event_page(request: Request, event_slug: str, code: str | None 
                     detail="Too many join attempts. Please try again later.",
                 )
             return templates.TemplateResponse(
-                request, "listener_join.html", {"event": ev, "error": "Invalid join code." if code else None}
+                request=request,
+                name="listener_join.html",
+                context={"event": ev, "error": "Invalid join code." if code else None},
             )
 
         rooms = await list_rooms_for_event(session, ev.id)
@@ -155,9 +157,9 @@ async def listen_event_page(request: Request, event_slug: str, code: str | None 
         await asyncio.gather(*ensure_tasks)
 
     response = templates.TemplateResponse(
-        request,
-        "listener-event.html",
-        {
+        request=request,
+        name="listener-event.html",
+        context={
             "event": ev,
             "rooms": rooms,
             "rooms_json": json.dumps(rooms_data),
@@ -325,7 +327,7 @@ async def _embed_listener_impl(
         "audio_delay_ms": audio_delay_ms,
     }
 
-    return templates.TemplateResponse(request, "embed.html", context, headers=response_headers)
+    return templates.TemplateResponse(request=request, name="embed.html", context=context, headers=response_headers)
 
 
 @router.get("/embed/{event_slug}/{language_code}")

--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -48,11 +48,14 @@ VALID_SCOPES = {
     "webhooks:manage": "Manage webhook subscriptions",
 }
 
+
 def generate_token() -> str:
     return secrets.token_urlsafe(32)
 
+
 def hash_token(token: str) -> str:
     return hashlib.sha256(token.encode()).hexdigest()
+
 
 def verify_pkce(code_verifier: str, code_challenge: str, method: str) -> bool:
     if method == "S256":
@@ -61,13 +64,11 @@ def verify_pkce(code_verifier: str, code_challenge: str, method: str) -> bool:
         return encoded == code_challenge
     return False
 
+
 async def get_effective_scopes(db: AsyncSession, user: dict, event_id: int, requested_scopes: list[str]) -> list[str]:
     # Check if user has EventMembership
     result = await db.execute(
-        select(EventMembership).where(
-            EventMembership.user_id == int(user["sub"]),
-            EventMembership.event_id == event_id
-        )
+        select(EventMembership).where(EventMembership.user_id == int(user["sub"]), EventMembership.event_id == event_id)
     )
     event_membership = result.scalars().first()
 
@@ -85,12 +86,19 @@ async def get_effective_scopes(db: AsyncSession, user: dict, event_id: int, requ
         allowed = set(VALID_SCOPES.keys())
     elif is_room_coordinator:
         allowed = {
-            "rooms:read", "rooms:write", "booths:read", "booths:write",
-            "sessions:manage", "sessions:read", "transcripts:read", "listeners:provision"
+            "rooms:read",
+            "rooms:write",
+            "booths:read",
+            "booths:write",
+            "sessions:manage",
+            "sessions:read",
+            "transcripts:read",
+            "listeners:provision",
         }
 
     # Intersection
     return list(set(requested_scopes) & allowed)
+
 
 @router.get("/oauth/authorize", include_in_schema=False)
 async def authorize_get(
@@ -137,16 +145,18 @@ async def authorize_get(
     effective_scopes = await get_effective_scopes(db, user, evt.id, requested_scopes)
 
     if not effective_scopes:
-        raise HTTPException(status_code=403, detail="You do not have permission to grant the requested scopes for this event.")
+        raise HTTPException(
+            status_code=403, detail="You do not have permission to grant the requested scopes for this event."
+        )
 
     # 4. For now, require explicit consent (can auto-approve if consent exists and covers scopes)
 
     # For now, require explicit consent (can auto-approve if consent exists and covers scopes)
 
     return templates.TemplateResponse(
-        request,
-        "oauth/consent.html",
-        {
+        request=request,
+        name="oauth/consent.html",
+        context={
             "client": client,
             "event": evt,
             "scopes": [(s, VALID_SCOPES.get(s, s)) for s in effective_scopes],
@@ -157,6 +167,7 @@ async def authorize_get(
             "scope_string": " ".join(effective_scopes),
         },
     )
+
 
 @router.post("/oauth/authorize", include_in_schema=False)
 async def authorize_post(
@@ -188,10 +199,7 @@ async def authorize_post(
 
     # Save consent
     consent = OAuthConsentGrant(
-        client_id=client.id,
-        user_id=int(user["sub"]),
-        event_id=event_id,
-        scopes=effective_scopes
+        client_id=client.id, user_id=int(user["sub"]), event_id=event_id, scopes=effective_scopes
     )
     db.add(consent)
 
@@ -206,10 +214,14 @@ async def authorize_post(
         code_challenge=code_challenge,
         code_challenge_method=code_challenge_method,
         redirect_uri=redirect_uri,
-        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5)
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
     )
     db.add(auth_code)
-    db.add(OAuthAuditLog(client_id=client.id, event_id=event_id, action='authorize', request_path='/oauth/authorize', status_code=303))
+    db.add(
+        OAuthAuditLog(
+            client_id=client.id, event_id=event_id, action="authorize", request_path="/oauth/authorize", status_code=303
+        )
+    )
     await db.commit()
 
     redirect_url = f"{redirect_uri}?code={code}&state={urllib.parse.quote(state)}"
@@ -258,7 +270,9 @@ async def token_exchange(
             return JSONResponse(status_code=400, content={"error": "invalid_grant"})
 
         if not verify_pkce(code_verifier, auth_code.code_challenge, auth_code.code_challenge_method):
-            return JSONResponse(status_code=400, content={"error": "invalid_grant", "error_description": "PKCE verification failed"})
+            return JSONResponse(
+                status_code=400, content={"error": "invalid_grant", "error_description": "PKCE verification failed"}
+            )
 
         # Mark code as used
         auth_code.used = True
@@ -274,10 +288,19 @@ async def token_exchange(
             scopes=auth_code.scopes,
             access_token_hash=hash_token(access_token_raw),
             refresh_token_hash=hash_token(refresh_token_raw),
-            expires_at=datetime.now(timezone.utc) + timedelta(hours=1)
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
         )
         db.add(token_record)
-        db.add(OAuthAuditLog(token_id=token_record.id, client_id=client.id, event_id=auth_code.event_id, action='token_exchange_code', request_path='/oauth/token', status_code=200))
+        db.add(
+            OAuthAuditLog(
+                token_id=token_record.id,
+                client_id=client.id,
+                event_id=auth_code.event_id,
+                action="token_exchange_code",
+                request_path="/oauth/token",
+                status_code=200,
+            )
+        )
         await db.commit()
 
         return {
@@ -285,7 +308,7 @@ async def token_exchange(
             "token_type": "Bearer",
             "expires_in": 3600,
             "refresh_token": refresh_token_raw,
-            "scope": " ".join(auth_code.scopes)
+            "scope": " ".join(auth_code.scopes),
         }
 
     elif grant_type == "refresh_token":
@@ -294,10 +317,9 @@ async def token_exchange(
 
         refresh_hash = hash_token(refresh_token)
         token_result = await db.execute(
-            select(OAuthToken).options(
-                selectinload(OAuthToken.client),
-                selectinload(OAuthToken.event)
-            ).where(OAuthToken.refresh_token_hash == refresh_hash)
+            select(OAuthToken)
+            .options(selectinload(OAuthToken.client), selectinload(OAuthToken.event))
+            .where(OAuthToken.refresh_token_hash == refresh_hash)
         )
         token_record = token_result.scalars().first()
 
@@ -313,9 +335,19 @@ async def token_exchange(
                 .where(OAuthToken.event_id == token_record.event_id)
                 .values(revoked=True)
             )
-            db.add(OAuthAuditLog(client_id=client.id, event_id=token_record.event_id, action='token_reuse_detected', request_path='/oauth/token', status_code=400))
+            db.add(
+                OAuthAuditLog(
+                    client_id=client.id,
+                    event_id=token_record.event_id,
+                    action="token_reuse_detected",
+                    request_path="/oauth/token",
+                    status_code=400,
+                )
+            )
             await db.commit()
-            return JSONResponse(status_code=400, content={"error": "invalid_grant", "error_description": "Token reuse detected"})
+            return JSONResponse(
+                status_code=400, content={"error": "invalid_grant", "error_description": "Token reuse detected"}
+            )
 
         # Revoke the old token
         token_record.revoked = True
@@ -328,14 +360,23 @@ async def token_exchange(
             client_id=client.id,
             user_id=token_record.user_id,
             event_id=token_record.event_id,
-            scopes=token_record.scopes, # Can be narrowed down, but keep same for now
+            scopes=token_record.scopes,  # Can be narrowed down, but keep same for now
             access_token_hash=hash_token(new_access_token_raw),
             refresh_token_hash=hash_token(new_refresh_token_raw),
             parent_token_id=token_record.id,
-            expires_at=datetime.now(timezone.utc) + timedelta(hours=1)
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
         )
         db.add(new_token_record)
-        db.add(OAuthAuditLog(token_id=new_token_record.id, client_id=client.id, event_id=token_record.event_id, action='token_exchange_refresh', request_path='/oauth/token', status_code=200))
+        db.add(
+            OAuthAuditLog(
+                token_id=new_token_record.id,
+                client_id=client.id,
+                event_id=token_record.event_id,
+                action="token_exchange_refresh",
+                request_path="/oauth/token",
+                status_code=200,
+            )
+        )
         await db.commit()
 
         return {
@@ -343,10 +384,11 @@ async def token_exchange(
             "token_type": "Bearer",
             "expires_in": 3600,
             "refresh_token": new_refresh_token_raw,
-            "scope": " ".join(token_record.scopes)
+            "scope": " ".join(token_record.scopes),
         }
 
     return JSONResponse(status_code=400, content={"error": "unsupported_grant_type"})
+
 
 @router.post("/oauth/revoke")
 async def revoke_token(
@@ -377,8 +419,16 @@ async def revoke_token(
 
     if token_record and token_record.client_id == client.id:
         token_record.revoked = True
-        db.add(OAuthAuditLog(token_id=token_record.id, client_id=client.id, event_id=token_record.event_id, action='token_revoke', request_path='/oauth/revoke', status_code=200))
+        db.add(
+            OAuthAuditLog(
+                token_id=token_record.id,
+                client_id=client.id,
+                event_id=token_record.event_id,
+                action="token_revoke",
+                request_path="/oauth/revoke",
+                status_code=200,
+            )
+        )
         await db.commit()
 
     return JSONResponse(status_code=200, content={})
-

--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -144,9 +144,9 @@ async def authorize_get(
     # For now, require explicit consent (can auto-approve if consent exists and covers scopes)
 
     return templates.TemplateResponse(
+        request,
         "oauth/consent.html",
         {
-            "request": request,
             "client": client,
             "event": evt,
             "scopes": [(s, VALID_SCOPES.get(s, s)) for s in effective_scopes],

--- a/portal/routers/public.py
+++ b/portal/routers/public.py
@@ -98,9 +98,9 @@ async def home(request: Request):
         event_data = []
 
     return templates.TemplateResponse(
-        request,
-        "home.html",
-        {
+        request=request,
+        name="home.html",
+        context={
             "events": event_data,
             "current_user": current_user,
             "my_booths": my_booths,
@@ -112,42 +112,42 @@ async def home(request: Request):
 @router.get("/research")
 @router.get("/research/")
 async def research_index(request: Request):
-    return templates.TemplateResponse(request, "research/index.html", {})
+    return templates.TemplateResponse(request=request, name="research/index.html", context={})
 
 
 @router.get("/research/speech-ai-statistics")
 async def research_speech_ai_statistics(request: Request):
-    return templates.TemplateResponse(request, "research/speech_ai_statistics.html", {})
+    return templates.TemplateResponse(request=request, name="research/speech_ai_statistics.html", context={})
 
 
 @router.get("/research/whisper-benchmark")
 async def research_whisper_benchmark(request: Request):
-    return templates.TemplateResponse(request, "research/whisper_benchmark.html", {})
+    return templates.TemplateResponse(request=request, name="research/whisper_benchmark.html", context={})
 
 
 @router.get("/research/stt-comparison")
 async def research_stt_comparison(request: Request):
-    return templates.TemplateResponse(request, "research/stt_comparison.html", {})
+    return templates.TemplateResponse(request=request, name="research/stt_comparison.html", context={})
 
 
 @router.get("/research/real-time-audio-latency")
 async def research_real_time_audio_latency(request: Request):
-    return templates.TemplateResponse(request, "research/real_time_audio_latency.html", {})
+    return templates.TemplateResponse(request=request, name="research/real_time_audio_latency.html", context={})
 
 
 @router.get("/research/webrtc-vs-rtmp-vs-hls")
 async def research_webrtc_vs_rtmp_vs_hls(request: Request):
-    return templates.TemplateResponse(request, "research/webrtc_vs_rtmp_vs_hls.html", {})
+    return templates.TemplateResponse(request=request, name="research/webrtc_vs_rtmp_vs_hls.html", context={})
 
 
 @router.get("/research/speech-ai-glossary")
 async def research_speech_ai_glossary(request: Request):
-    return templates.TemplateResponse(request, "research/speech_ai_glossary.html", {})
+    return templates.TemplateResponse(request=request, name="research/speech_ai_glossary.html", context={})
 
 
 @router.get("/research/streaming-stt-architecture")
 async def research_streaming_stt_architecture(request: Request):
-    return templates.TemplateResponse(request, "research/streaming_stt_architecture.html", {})
+    return templates.TemplateResponse(request=request, name="research/streaming_stt_architecture.html", context={})
 
 
 @router.get("/llms.txt")


### PR DESCRIPTION
The previous Phase 1 PRs incorrectly passed the template path as the first argument to `TemplateResponse`, causing the `request` object to be treated as a context dictionary. In this version of Starlette, `request` MUST be the first positional argument. This resulted in a `TypeError: unhashable type: 'dict'` when Jinja2 tried to use the context dictionary as a cache key.

This PR correctly formats all `TemplateResponse` calls in the Developer, OAuth, and Admin routes.

## Summary by Sourcery

Correct all affected TemplateResponse calls so requests and template contexts are handled properly.

Bug Fixes:
- Fix template rendering crashes across application routes by passing TemplateResponse arguments in the correct order and format.

Enhancements:
- Standardize template response calls across administrative, authentication, OAuth, public, listener, developer, and interpreter routes.