### PR TITLE
Bug fix : speaker image blue overlay

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -489,9 +489,9 @@
                     <!-- Left: Floating Image / Graphic (Spans 2 cols) -->
                     <div class="lg:col-span-2 sticky top-32 max-md:hidden">
                         <div
-                            class="relative rounded-lg overflow-hidden bg-[#2563eb] aspect-[4/5] brutal-border brutal-shadow">
+                            class="relative rounded-lg overflow-hidden aspect-[4/5] brutal-border brutal-shadow">
                             <img src="https://images.unsplash.com/photo-1505373877841-8d25f7d46678?q=80&w=1000&auto=format&fit=crop"
-                                class="w-full h-full object-cover mix-blend-overlay opacity-80" alt="Speaker">
+                                class="w-full h-full object-cover" alt="Speaker">
                             <div class="absolute top-8 right-8 text-white/50">
                                 <svg class="w-16 h-16" fill="currentColor" viewBox="0 0 24 24">
                                     <path


### PR DESCRIPTION
## Description

This Pull Request fixes a visual bug on the landing page where the speaker image in the **"Enterprise-Ready for Every Event Format"** section was heavily obscured by a solid blue overlay.


## Related Issue

Closes #383 


## Changes Made

Modified `templates/home.html`:

* Removed `bg-[#2563eb]` from the outer image container.
* Removed `mix-blend-overlay` from the `<img>` element.
* Removed `opacity-80` from the `<img>` element.

## Why This Is Needed

The combination of `bg-[#2563eb]`, `mix-blend-overlay`, and `opacity-80` caused the image to appear heavily blue-tinted and reduced its visual clarity.

Removing these styles restores the intended full-color image and improves the overall visual polish of the section without affecting the surrounding layout.


## Before

<img width="1900" height="927" alt="image" src="https://github.com/user-attachments/assets/5365ef4d-9312-4a31-98f9-88a1da43418e" />


## After


<img width="1900" height="927" alt="image" src="https://github.com/user-attachments/assets/79f1433f-826e-4f17-8390-488201f762a2" />



## Testing Performed

* Checked out the branch and ran the project locally.
* Verified the landing page and the affected section.
* Confirmed that the speaker image renders correctly in full color.
* Verified that the text columns and surrounding layout remain properly aligned.
* Confirmed that no backend functionality or code was affected.

## Scope

**File changed:** `templates/home.html`

**Type:** UI / Visual Bug Fix

## Summary by Sourcery

Bug Fixes:
- Restore the speaker image’s intended full-color appearance on the landing page by removing the styling that caused the heavy blue overlay.