### PR TITLE
ui: restyle navbar logout button to match Brutalist outline style

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -57,7 +57,7 @@
             </nav>
             <div class="flex items-center gap-3 md:gap-4 text-[10px] sm:text-xs md:text-sm font-bold flex-shrink-0">
                 {% if current_user %}
-                <a href="/logout" class="text-[#0d0f10] hover:text-brand-600 transition-colors uppercase tracking-wider">Logout</a>
+                <a href="/logout" class="brutal-btn brutal-btn-outline brutal-btn-nav !px-2.5 !py-1.5 md:!px-5 md:!py-2">Logout</a>
                 <a href="/admin/events/" class="brutal-btn brutal-btn-outline brutal-btn-nav !px-2.5 !py-1.5 md:!px-5 md:!py-2">Dashboard</a>
                 {% else %}
                 <a href="/login" class="brutal-btn brutal-btn-primary brutal-btn-nav !px-2.5 !py-1.5 md:!px-5 md:!py-2">Sign In</a>


### PR DESCRIPTION
## Description

This PR restyles the `Logout` action in the homepage header navbar.

Previously, `Logout` was rendered as a plain text link, creating a visual inconsistency with the adjacent `Dashboard` button. It is now styled as a Neo-Brutalist outline button to match the existing navbar design.

## Related Issue

Closes #394 

## Changes Made

* **Restyled Logout Button:** Updated the `Logout` anchor in `templates/home.html` to use the existing `.brutal-btn`, `.brutal-btn-outline`, and `.brutal-btn-nav` classes.
* Added responsive padding to match the sizing of the adjacent navbar controls.

## Testing

* [x] Tested locally
* [x] Existing tests pass
* [ ] Added/updated tests (not applicable)

### Verification

* **Visual:** Verified the button's alignment, borders, shadows, spacing, and hover state on `localhost:8000`.
* **Functional:** Verified that clicking the styled `Logout` button still logs the user out correctly.

## Screenshots

**Before**

<img width="330" height="120" alt="image" src="https://github.com/user-attachments/assets/152d6497-bdb4-4274-84fb-02644ec05c43" />


**After**

https://github.com/user-attachments/assets/59a58ccd-1fe0-4805-a295-692c487b35ad








## Checklist

* [x] My code follows the project's coding standards
* [x] I have tested my changes
* [x] My changes do not introduce new warnings or errors

## Additional Notes

This is a lightweight, scoped UI change with only one line modified in `templates/home.html`. No application logic or logout functionality was changed.

## Summary by Sourcery

Enhancements:
- Style the authenticated homepage navbar’s Logout link as a responsive Brutalist outline button consistent with the Dashboard control.