### PR TITLE
 fix(auth): fix for OAuth Authorization flow for third party integrations

### DIFF
--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -75,7 +75,8 @@ async def get_effective_scopes(db: AsyncSession, user: dict, event_id: int, requ
     # Check if user has RoomMembership in this event (for room_coordinators)
     # simplified for now: if they have any role in the event, we grant scopes they requested
     # that map to their role.
-    is_event_admin = event_membership and event_membership.role in ("event_owner", "super_admin")
+    # Accept "owner" as a synonym for "event_owner" (e.g. roles synced from Eventyay)
+    is_event_admin = event_membership and event_membership.role in ("event_owner", "super_admin", "owner")
     is_room_coordinator = event_membership and event_membership.role == "room_coordinator"
 
     # In a full implementation, we would narrow this down per-room.
@@ -197,11 +198,24 @@ async def authorize_post(
     if not effective_scopes:
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    # Save consent
-    consent = OAuthConsentGrant(
-        client_id=client.id, user_id=int(user["sub"]), event_id=event_id, scopes=effective_scopes
-    )
-    db.add(consent)
+    # Save consent — handle race conditions with a savepoint
+    from sqlalchemy.exc import IntegrityError
+    try:
+        async with db.begin_nested():
+            consent = OAuthConsentGrant(
+                client_id=client.id, user_id=int(user["sub"]), event_id=event_id, scopes=effective_scopes
+            )
+            db.add(consent)
+            await db.flush()
+    except IntegrityError:
+        # Another request inserted it concurrently. Just update the scopes.
+        await db.execute(
+            update(OAuthConsentGrant).where(
+                OAuthConsentGrant.client_id == client.id,
+                OAuthConsentGrant.user_id == int(user["sub"]),
+                OAuthConsentGrant.event_id == event_id,
+            ).values(scopes=effective_scopes)
+        )
 
     # Generate authorization code
     code = generate_token()
@@ -263,7 +277,7 @@ async def token_exchange(
         )
         auth_code = code_result.scalars().first()
 
-        if not auth_code or auth_code.used or auth_code.expires_at < datetime.now(timezone.utc):
+        if not auth_code or auth_code.used or auth_code.expires_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
             return JSONResponse(status_code=400, content={"error": "invalid_grant"})
 
         if auth_code.client_id != client.id or auth_code.redirect_uri != redirect_uri:


### PR DESCRIPTION
## Description
This PR addresses several critical bugs discovered during the integration of VoxBento with the Eventyay plugin via OAuth 2.0. These bugs were causing `500 Internal Server Error` crashes and `403 Forbidden` errors during the developer app creation and OAuth authorization flows.

- fixes : #397 

## Bug Fixes

1. **Fixed `Closed Transaction` crash during App Creation**
   - **Issue:** Creating a new Developer App in the dashboard resulted in an `InvalidRequestError: Can't operate on closed transaction inside context manager`.
   - **Root Cause:** The endpoint was manually calling `await db.commit()` mid-request, which prematurely closed the single transaction managed by the FastAPI `get_db_session` dependency context manager.
   - **Fix:** Replaced `await db.commit()` with `await db.flush()` in `portal/routers/developer.py` to generate the Client ID while keeping the transaction open for subsequent queries.

2. **Fixed Duplicate Consent Grant Crash (Race Condition)**
   - **Issue:** Users authorizing an app occasionally hit a `500 Internal Server Error` due to an `IntegrityError` (UNIQUE constraint failed on `oauth_consent_grants`). This happened if the user double-clicked "Authorize" or the client aggressively retried the request.
   - **Root Cause:** Concurrent requests checked for existing consent simultaneously, found none, and both attempted to `db.add(consent)`, causing the second request to crash on flush.
   - **Fix:** Wrapped the consent insertion in a nested transaction savepoint (`async with db.begin_nested():`) in `portal/routers/oauth.py`. If an `IntegrityError` is thrown, it is now safely caught and falls back to an `UPDATE` on the scopes.

3. **Fixed `403 Forbidden` for Eventyay Owners**
   - **Issue:** Users with the `owner` role from Eventyay were being rejected during the OAuth flow because the scopes check didn't recognize their role.
   - **Root Cause:** `get_effective_scopes()` strictly looked for `event_owner` or `super_admin`.
   - **Fix:** Added `owner` as a recognized synonym for `event_owner` to accommodate roles synced from external systems like Eventyay.

## How to Test
1. **App Creation:** Go to the Developer Dashboard, apply for access (if needed), and create a new App. Ensure it succeeds without a 500 error.
2. **Role Authorization:** Attempt an OAuth flow as a user whose EventMembership role is exactly `owner`. Ensure you are allowed to proceed instead of receiving a 403 Forbidden.
3. **Race Condition / Idempotency:** During the OAuth flow, double-click the "Authorize" button, or try authorizing the exact same client on the exact same event twice. Ensure it succeeds and redirects back to the client application properly instead of throwing a 500 constraint error.

## Summary by Sourcery

Harden the OAuth authorization flow against transaction, concurrency, role-mapping, and timestamp-handling errors.

Bug Fixes:
- Prevent duplicate OAuth consent grants from causing authorization failures during concurrent or repeated authorization requests.
- Recognize the external `owner` membership role during OAuth scope validation.
- Handle authorization-code expiration checks consistently for timezone-aware timestamps.

Enhancements:
- Keep developer app creation transactions usable while generating client identifiers.