### PR TITLE
fix: resolve remaining rbac syncing issues and add ui indication for event owners

### DIFF
--- a/portal/auth.py
+++ b/portal/auth.py
@@ -219,9 +219,12 @@ async def require_event_owner(request: Request) -> None:
                 if payload.get("is_admin"):
                     return
                 if payload.get("sub"):
-                    from portal.database import get_session, list_memberships_for_user
+                    from portal.database import get_session, get_user_by_id, list_memberships_for_user
 
                     async with get_session() as db_session:
+                        user = await get_user_by_id(db_session, int(payload["sub"]))
+                        if user and user.is_admin:
+                            return
                         memberships = await list_memberships_for_user(db_session, int(payload["sub"]))
                         if event_id is not None:
                             if any((m.event_id == event_id and m.role == "event_owner" for m in memberships)):
@@ -266,11 +269,18 @@ async def get_admin_flags(request: Request, event_id: int | None = None, room_id
                 if payload.get("sub"):
                     from portal.database import (
                         get_session,
+                        get_user_by_id,
                         list_memberships_for_user,
                         list_room_memberships_for_user,
                     )
 
                     async with get_session() as db_session:
+                        user = await get_user_by_id(db_session, int(payload["sub"]))
+                        if user and user.is_admin:
+                            flags["is_super_admin"] = True
+                            flags["is_event_owner"] = True
+                            flags["is_room_coordinator"] = True
+                            return flags
                         memberships = await list_memberships_for_user(db_session, int(payload["sub"]))
                         rms = await list_room_memberships_for_user(db_session, int(payload["sub"]))
                         if event_id is not None:
@@ -364,7 +374,13 @@ async def get_accessible_event_ids(request: Request, *, user_id: int | None) -> 
             pass
     if is_super_admin or user_id is None:
         return (is_super_admin, None)
+
+    from portal.database import get_user_by_id
+
     async with get_session() as session:
+        user = await get_user_by_id(session, user_id)
+        if user and user.is_admin:
+            return (True, None)
         memberships = await list_memberships_for_user(session, user_id)
         room_memberships = await list_room_memberships_for_user(session, user_id)
     allowed_event_ids: set[int] = {m.event_id for m in memberships if m.role == "event_owner"}

--- a/templates/admin/user_detail.html
+++ b/templates/admin/user_detail.html
@@ -76,7 +76,7 @@
   </thead>
   <tbody>
     {% for event in events %}
-    {% set is_event_admin = event.id in event_admin_map %}
+    {% set is_event_admin = event.id in event_owner_map %}
     <tr class="{{ 'row-assigned' if is_event_admin else '' }}">
       <td><strong>{{ event.display_name }}</strong> ({{ event.slug }})</td>
       <td>


### PR DESCRIPTION
This PR introduces two follow-up fixes for the admin panel:
1. **Super Admin Events List (RBAC):** Fixed remaining places (like `get_accessible_event_ids` and `get_admin_flags`) that relied solely on the stale JWT cache instead of falling back to the database. This ensures newly promoted Super Admins can instantly see the global events list.
2. **Event Admin UI Indication:** The user detail page now correctly uses `event_owner_map` instead of the undefined `event_admin_map` to display the 'Event Admin' badge and 'Remove Admin' state for events the user owns.

Verified with local tests.

## Summary by Sourcery

Resolve RBAC synchronization gaps and correctly indicate event ownership in the admin UI.

New Features:
- Show event-owner status correctly in the admin user detail view, including the associated admin controls.

Bug Fixes:
- Ensure newly promoted super admins receive global event access and admin permissions without relying on stale JWT claims.