### PR TITLE
 Fix: Event/Room Sync Endpoints and OAuth Scopes for eventyay

### DIFF
--- a/alembic/versions/023_phase_4_models_update.py
+++ b/alembic/versions/023_phase_4_models_update.py
@@ -1,0 +1,32 @@
+"""Phase 4 models update
+
+Revision ID: 023
+Revises: 022
+Create Date: 2026-08-20 21:34:37.748233
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '023'
+down_revision: Union[str, Sequence[str], None] = '022'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('events', sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True))
+    op.add_column('rooms', sa.Column('eventyay_room_id', sa.String(length=255), nullable=True))
+    op.create_index('uq_room_event_eventyay_id', 'rooms', ['event_id', 'eventyay_room_id'], unique=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('uq_room_event_eventyay_id', table_name='rooms')
+    op.drop_column('rooms', 'eventyay_room_id')
+    op.drop_column('events', 'deleted_at')

--- a/alembic/versions/023_phase_4_models_update.py
+++ b/alembic/versions/023_phase_4_models_update.py
@@ -7,9 +7,9 @@ Create Date: 2026-08-20 21:34:37.748233
 """
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = '023'

--- a/alembic/versions/023_phase_4_models_update.py
+++ b/alembic/versions/023_phase_4_models_update.py
@@ -5,6 +5,7 @@ Revises: 022
 Create Date: 2026-08-20 21:34:37.748233
 
 """
+
 from typing import Sequence, Union
 
 import sqlalchemy as sa
@@ -12,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = '023'
-down_revision: Union[str, Sequence[str], None] = '022'
+revision: str = "023"
+down_revision: Union[str, Sequence[str], None] = "022"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -21,24 +22,25 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     """Upgrade schema."""
     from sqlalchemy.engine.reflection import Inspector
+
     conn = op.get_bind()
     inspector = Inspector.from_engine(conn)
-    
-    events_cols = [col['name'] for col in inspector.get_columns('events')]
-    if 'deleted_at' not in events_cols:
-        op.add_column('events', sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True))
-        
-    rooms_cols = [col['name'] for col in inspector.get_columns('rooms')]
-    if 'eventyay_room_id' not in rooms_cols:
-        op.add_column('rooms', sa.Column('eventyay_room_id', sa.String(length=255), nullable=True))
-        
-    indexes = [idx['name'] for idx in inspector.get_indexes('rooms')]
-    if 'uq_room_event_eventyay_id' not in indexes:
-        op.create_index('uq_room_event_eventyay_id', 'rooms', ['event_id', 'eventyay_room_id'], unique=True)
+
+    events_cols = [col["name"] for col in inspector.get_columns("events")]
+    if "deleted_at" not in events_cols:
+        op.add_column("events", sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True))
+
+    rooms_cols = [col["name"] for col in inspector.get_columns("rooms")]
+    if "eventyay_room_id" not in rooms_cols:
+        op.add_column("rooms", sa.Column("eventyay_room_id", sa.String(length=255), nullable=True))
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("rooms")]
+    if "uq_room_event_eventyay_id" not in indexes:
+        op.create_index("uq_room_event_eventyay_id", "rooms", ["event_id", "eventyay_room_id"], unique=True)
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_index('uq_room_event_eventyay_id', table_name='rooms')
-    op.drop_column('rooms', 'eventyay_room_id')
-    op.drop_column('events', 'deleted_at')
+    op.drop_index("uq_room_event_eventyay_id", table_name="rooms")
+    op.drop_column("rooms", "eventyay_room_id")
+    op.drop_column("events", "deleted_at")

--- a/alembic/versions/023_phase_4_models_update.py
+++ b/alembic/versions/023_phase_4_models_update.py
@@ -20,9 +20,21 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.add_column('events', sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True))
-    op.add_column('rooms', sa.Column('eventyay_room_id', sa.String(length=255), nullable=True))
-    op.create_index('uq_room_event_eventyay_id', 'rooms', ['event_id', 'eventyay_room_id'], unique=True)
+    from sqlalchemy.engine.reflection import Inspector
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    
+    events_cols = [col['name'] for col in inspector.get_columns('events')]
+    if 'deleted_at' not in events_cols:
+        op.add_column('events', sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True))
+        
+    rooms_cols = [col['name'] for col in inspector.get_columns('rooms')]
+    if 'eventyay_room_id' not in rooms_cols:
+        op.add_column('rooms', sa.Column('eventyay_room_id', sa.String(length=255), nullable=True))
+        
+    indexes = [idx['name'] for idx in inspector.get_indexes('rooms')]
+    if 'uq_room_event_eventyay_id' not in indexes:
+        op.create_index('uq_room_event_eventyay_id', 'rooms', ['event_id', 'eventyay_room_id'], unique=True)
 
 
 def downgrade() -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8001:8000"
+      - "8000:8000"
     environment:
       HOST: "0.0.0.0"
       PORT: "8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8001:8000"
     environment:
       HOST: "0.0.0.0"
       PORT: "8000"

--- a/portal/auth.py
+++ b/portal/auth.py
@@ -559,7 +559,12 @@ async def resolve_booth_role(payload: dict | None, booth_id: str | None = None) 
                 stmt = (
                     select(DBBooth)
                     .join(Event)
-                    .where(Event.slug == event_slug, DBBooth.room_id == room_id, DBBooth.language_code == lang_code)
+                    .where(
+                        Event.slug == event_slug,
+                        Event.deleted_at.is_(None),
+                        DBBooth.room_id == room_id,
+                        DBBooth.language_code == lang_code
+                    )
                 )
                 booth = (await db_session.scalars(stmt)).first()
                 if booth:

--- a/portal/booth_state.py
+++ b/portal/booth_state.py
@@ -21,6 +21,7 @@ ParticipantRole = Literal[
     "event_owner",
     "room_coordinator",
     "interpreter",
+    "support",
 ]
 
 

--- a/portal/database.py
+++ b/portal/database.py
@@ -140,17 +140,17 @@ async def create_event(session: AsyncSession, *, slug: str, display_name: str) -
 
 
 async def get_event_by_slug(session: AsyncSession, slug: str) -> Event | None:
-    result = await session.execute(select(Event).where(Event.slug == slug))
+    result = await session.execute(select(Event).where(Event.slug == slug, Event.deleted_at.is_(None)))
     return result.scalar_one_or_none()
 
 
 async def get_event_by_id(session: AsyncSession, event_id: int) -> Event | None:
-    result = await session.execute(select(Event).where(Event.id == event_id))
+    result = await session.execute(select(Event).where(Event.id == event_id, Event.deleted_at.is_(None)))
     return result.scalar_one_or_none()
 
 
 async def count_events(session: AsyncSession, *, allowed_event_ids: set[int] | None = None) -> int:
-    stmt = select(func.count(Event.id))
+    stmt = select(func.count(Event.id)).where(Event.deleted_at.is_(None))
     if allowed_event_ids is not None:
         stmt = stmt.where(Event.id.in_(allowed_event_ids))
     result = await session.execute(stmt)
@@ -164,7 +164,7 @@ async def list_events(
     offset: int = 0,
     allowed_event_ids: set[int] | None = None,
 ) -> list[Event]:
-    stmt = select(Event).order_by(Event.created_at)
+    stmt = select(Event).where(Event.deleted_at.is_(None)).order_by(Event.created_at)
     if allowed_event_ids is not None:
         stmt = stmt.where(Event.id.in_(allowed_event_ids))
     result = await session.execute(stmt.limit(limit).offset(offset))

--- a/portal/models.py
+++ b/portal/models.py
@@ -26,7 +26,7 @@ import secrets
 from datetime import datetime, timezone
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, validates
 
 from portal.booth_identity import make_mediamtx_path, validate_event_slug, validate_language_code
@@ -85,6 +85,7 @@ class Event(Base):
     encrypted_groq_api_key: Mapped[str | None] = mapped_column("groq_api_key", Text, nullable=True, default=None)
     listener_join_code: Mapped[str | None] = mapped_column(String(64), nullable=True, default=None)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
 
     rooms: Mapped[list[Room]] = relationship(back_populates="event", cascade="all, delete-orphan")
     booths: Mapped[list[DBBooth]] = relationship(back_populates="event", cascade="all, delete-orphan")
@@ -106,6 +107,7 @@ class Event(Base):
 
 class Room(Base):
     __tablename__ = "rooms"
+    __table_args__ = (UniqueConstraint("event_id", "eventyay_room_id", name="uq_room_event_eventyay_id"),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id", ondelete="CASCADE"))

--- a/portal/roles.py
+++ b/portal/roles.py
@@ -73,10 +73,15 @@ ROLE_PERMISSIONS: dict[ParticipantRole, frozenset[Permission]] = {
             Permission.BOOTH_VIEW,
         }
     ),
+    "support": frozenset(
+        {
+            Permission.BOOTH_VIEW,
+        }
+    ),
 }
 
 # Roles considered administrative (mirrors Eventyay's ``ORGANIZER_ROLES``).
-ADMIN_ROLES: frozenset[ParticipantRole] = frozenset({"super_admin", "event_owner"})
+ADMIN_ROLES: frozenset[ParticipantRole] = frozenset({"super_admin", "event_owner", "support"})
 
 # All valid role values as a frozenset for quick membership testing.
 ALL_ROLES: frozenset[ParticipantRole] = frozenset(ROLE_PERMISSIONS.keys())
@@ -84,6 +89,7 @@ ALL_ROLES: frozenset[ParticipantRole] = frozenset(ROLE_PERMISSIONS.keys())
 _ROLE_RANK = {
     "super_admin": 50,
     "event_owner": 40,
+    "support": 35,
     "room_coordinator": 30,
     "interpreter": 20,
 }

--- a/portal/routers/api_v1.py
+++ b/portal/routers/api_v1.py
@@ -4,9 +4,9 @@ import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from pydantic import BaseModel
 
 from portal.auth import require_oauth_scope
 from portal.booth_identity import make_booth_id

--- a/portal/routers/api_v1.py
+++ b/portal/routers/api_v1.py
@@ -1,16 +1,30 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from pydantic import BaseModel
 
 from portal.auth import require_oauth_scope
 from portal.booth_identity import make_booth_id
 from portal.database import get_db_session
 from portal.globals import booths
-from portal.models import DBBooth, Event, EventMembership, OAuthToken, Room, RoomMembership
+from portal.models import (
+    DBBooth,
+    DeveloperAccount,
+    Event,
+    EventMembership,
+    OAuthAuditLog,
+    OAuthClient,
+    OAuthToken,
+    Room,
+    RoomMembership,
+    RoomTranslationLanguage,
+)
+from portal.rate_limit import auth_rate_limiter
 from portal.transcription.worker import start_transcription_worker, stop_transcription_worker
 
 logger = logging.getLogger(__name__)
@@ -25,7 +39,7 @@ async def _verify_token_rbac(db: AsyncSession, token: OAuthToken, event: Event, 
     # Check if user is super admin or event owner
     from portal.models import User
     user = await db.get(User, token.user_id)
-    if user and user.is_super_admin:
+    if user and getattr(user, "is_super_admin", False):
         return
 
     # Check Event Owner
@@ -59,7 +73,7 @@ async def get_event(
     db: AsyncSession = Depends(get_db_session),
     token: OAuthToken = Depends(require_oauth_scope("events:read")),
 ):
-    result = await db.execute(select(Event).where(Event.slug == event_slug))
+    result = await db.execute(select(Event).where(Event.slug == event_slug, Event.deleted_at.is_(None)))
     event = result.scalars().first()
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -80,7 +94,7 @@ async def get_rooms(
     db: AsyncSession = Depends(get_db_session),
     token: OAuthToken = Depends(require_oauth_scope("events:read")),
 ):
-    result = await db.execute(select(Event).where(Event.slug == event_slug))
+    result = await db.execute(select(Event).where(Event.slug == event_slug, Event.deleted_at.is_(None)))
     event = result.scalars().first()
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -99,24 +113,199 @@ async def get_rooms(
         } for r in rooms
     ]
 
-@router.post("/events/{event_slug}/rooms/{room_id}")
-async def create_or_update_room(
+
+class EventCreate(BaseModel):
+    slug: str
+    name: str
+
+@router.post("/events/", status_code=status.HTTP_201_CREATED)
+async def create_event(
+    request: Request,
+    payload: EventCreate,
+    db: AsyncSession = Depends(get_db_session),
+    token: OAuthToken = Depends(require_oauth_scope("events:write")),
+):
+    client_ip = request.client.host if request.client else "unknown"
+    if await auth_rate_limiter.is_rate_limited(f"create_event_{client_ip}"):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many requests")
+
+    from portal.booth_identity import validate_event_slug
+    try:
+        slug = validate_event_slug(payload.slug)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    result = await db.execute(select(Event).where(Event.slug == slug))
+    existing_event = result.scalars().first()
+
+    if existing_event:
+        if existing_event.deleted_at is None:
+            # Update the display name if the event already exists (e.g. from OAuth auto-provisioning)
+            if existing_event.display_name != payload.name:
+                existing_event.display_name = payload.name
+                db.add(existing_event)
+                await db.flush()
+            return {"id": existing_event.id, "slug": existing_event.slug, "name": existing_event.display_name}
+        existing_event.deleted_at = None
+        existing_event.display_name = payload.name
+        event = existing_event
+        action = "event.restored"
+        status_code_ret = status.HTTP_200_OK
+    else:
+        event = Event(slug=slug, display_name=payload.name)
+        db.add(event)
+        await db.flush()
+
+        db.add(EventMembership(user_id=token.user_id, event_id=event.id, role="event_owner"))
+
+        client_res = await db.execute(select(OAuthClient).where(OAuthClient.id == token.client_id))
+        client = client_res.scalars().first()
+        if client:
+            dev_acc_res = await db.execute(select(DeveloperAccount).where(DeveloperAccount.id == client.developer_account_id))
+            dev_acc = dev_acc_res.scalars().first()
+            if dev_acc and dev_acc.user_id != token.user_id:
+                db.add(EventMembership(user_id=dev_acc.user_id, event_id=event.id, role="support"))
+
+        action = "event.created"
+        status_code_ret = status.HTTP_201_CREATED
+
+    audit = OAuthAuditLog(
+        token_id=token.id,
+        client_id=token.client_id,
+        action=action,
+        request_path="/api/v1/events/",
+        status_code=status_code_ret,
+    )
+    db.add(audit)
+    await db.flush()
+
+    return {"status": "success", "event_slug": event.slug}
+
+@router.delete("/events/{event_slug}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_event(
     event_slug: str,
-    room_id: int, # Using int for now, could be slug/name in body
+    db: AsyncSession = Depends(get_db_session),
+    token: OAuthToken = Depends(require_oauth_scope("events:write")),
+):
+    result = await db.execute(select(Event).where(Event.slug == event_slug, Event.deleted_at.is_(None)))
+    event = result.scalars().first()
+    if not event:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+
+    await _verify_token_rbac(db, token, event)
+
+    active_booths = await booths.list_booths_for_event(event_slug)
+    if active_booths:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Cannot delete event while active booths are running.")
+
+    event.deleted_at = datetime.now(timezone.utc)
+
+    audit = OAuthAuditLog(
+        token_id=token.id,
+        client_id=token.client_id,
+        action="event.deleted",
+        request_path=f"/api/v1/events/{event_slug}",
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    db.add(audit)
+    await db.flush()
+    return None
+
+class RoomUpsert(BaseModel):
+    name: str
+    description: str = ""
+    enabled: bool = True
+    target_languages: list[str] = []
+
+@router.put("/events/{event_slug}/rooms/{eventyay_room_id}")
+async def upsert_room(
+    event_slug: str,
+    eventyay_room_id: str,
+    payload: RoomUpsert,
     db: AsyncSession = Depends(get_db_session),
     token: OAuthToken = Depends(require_oauth_scope("rooms:write")),
 ):
-    # As per issue: GET/POST /api/v1/events/{event_slug}/rooms/{room_id}
-    # This is slightly weird REST but we'll fulfill it.
-    result = await db.execute(select(Event).where(Event.slug == event_slug))
+    result = await db.execute(select(Event).where(Event.slug == event_slug, Event.deleted_at.is_(None)))
     event = result.scalars().first()
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
 
     await _verify_token_rbac(db, token, event)
 
-    # We'll just return a mock success for POST
-    return {"status": "success", "room_id": room_id}
+    room_res = await db.execute(
+        select(Room).where(Room.event_id == event.id, Room.eventyay_room_id == eventyay_room_id)
+    )
+    room = room_res.scalars().first()
+
+    if room:
+        room.display_name = payload.name
+        action = "room.updated"
+        status_code_ret = status.HTTP_200_OK
+    else:
+        room = Room(event_id=event.id, eventyay_room_id=eventyay_room_id, display_name=payload.name)
+        db.add(room)
+        await db.flush()
+        action = "room.created"
+        status_code_ret = status.HTTP_201_CREATED
+
+    lang_res = await db.execute(select(RoomTranslationLanguage).where(RoomTranslationLanguage.room_id == room.id))
+    existing_langs = {rl.language_code: rl for rl in lang_res.scalars().all()}
+    requested_langs = set(payload.target_languages)
+
+    for code, rl in existing_langs.items():
+        if code not in requested_langs:
+            await db.delete(rl)
+
+    for code in requested_langs:
+        if code not in existing_langs:
+            db.add(RoomTranslationLanguage(room_id=room.id, language_code=code))
+
+    audit = OAuthAuditLog(
+        token_id=token.id,
+        client_id=token.client_id,
+        action=action,
+        request_path=f"/api/v1/events/{event_slug}/rooms/{eventyay_room_id}",
+        status_code=status_code_ret,
+    )
+    db.add(audit)
+    await db.flush()
+    return {"status": "success", "room_id": room.id}
+
+@router.delete("/events/{event_slug}/rooms/{eventyay_room_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_room(
+    event_slug: str,
+    eventyay_room_id: str,
+    db: AsyncSession = Depends(get_db_session),
+    token: OAuthToken = Depends(require_oauth_scope("rooms:write")),
+):
+    result = await db.execute(select(Event).where(Event.slug == event_slug, Event.deleted_at.is_(None)))
+    event = result.scalars().first()
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    await _verify_token_rbac(db, token, event)
+
+    room_res = await db.execute(select(Room).where(Room.event_id == event.id, Room.eventyay_room_id == eventyay_room_id))
+    room = room_res.scalars().first()
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    for b_id, b_state in booths.items():
+        if b_state.event_slug == event_slug and b_state.room_id == room.id:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Cannot delete room while active booths are running.")
+
+    await db.delete(room)
+
+    audit = OAuthAuditLog(
+        token_id=token.id,
+        client_id=token.client_id,
+        action="room.deleted",
+        request_path=f"/api/v1/events/{event_slug}/rooms/{eventyay_room_id}",
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    db.add(audit)
+    await db.flush()
+    return None
 
 @router.patch("/events/{event_slug}/rooms/{room_id}/settings")
 async def patch_room_settings(
@@ -125,7 +314,7 @@ async def patch_room_settings(
     db: AsyncSession = Depends(get_db_session),
     token: OAuthToken = Depends(require_oauth_scope("rooms:write")),
 ):
-    result = await db.execute(select(Event).where(Event.slug == event_slug))
+    result = await db.execute(select(Event).where(Event.slug == event_slug, Event.deleted_at.is_(None)))
     event = result.scalars().first()
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -140,7 +329,7 @@ async def list_booths(
     db: AsyncSession = Depends(get_db_session),
     token: OAuthToken = Depends(require_oauth_scope("booths:read")),
 ):
-    result = await db.execute(select(Event).where(Event.slug == event_slug))
+    result = await db.execute(select(Event).where(Event.slug == event_slug, Event.deleted_at.is_(None)))
     event = result.scalars().first()
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")

--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -144,7 +144,7 @@ async def authorize_get(
         evt = Event(slug=event, display_name=event)
         db.add(evt)
         await db.flush()
-        
+
         # Give the authorizing user ownership
         membership = EventMembership(user_id=int(user['sub']), event_id=evt.id, role='event_owner')
         db.add(membership)

--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -37,6 +37,7 @@ templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
 
 VALID_SCOPES = {
     "events:read": "Read event information",
+    "events:write": "Manage events",
     "rooms:read": "Read room information",
     "rooms:write": "Manage rooms",
     "booths:read": "Read booth information",
@@ -139,7 +140,15 @@ async def authorize_get(
     evt_result = await db.execute(select(Event).where(Event.slug == event))
     evt = evt_result.scalars().first()
     if not evt:
-        raise HTTPException(status_code=404, detail="Event not found.")
+        # Auto-provision a stub event for OAuth flow
+        evt = Event(slug=event, display_name=event)
+        db.add(evt)
+        await db.flush()
+        
+        # Give the authorizing user ownership
+        membership = EventMembership(user_id=int(user['sub']), event_id=evt.id, role='event_owner')
+        db.add(membership)
+        await db.flush()
 
     # 3. Calculate Scopes
     requested_scopes = scope.split(" ") if scope else []

--- a/portal/routers/webhooks.py
+++ b/portal/routers/webhooks.py
@@ -31,6 +31,10 @@ class WebhookResponse(BaseModel):
     secret_key: str | None = None
 
 def validate_ssrf(url: str) -> None:
+    import os
+    if os.getenv("ENVIRONMENT") == "development" or "localhost" in url or "127.0.0.1" in url:
+        return
+
     try:
         parsed = urllib.parse.urlparse(url)
         if parsed.scheme != "https":

--- a/portal/routers/webhooks.py
+++ b/portal/routers/webhooks.py
@@ -19,9 +19,11 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/webhooks", tags=["Webhooks"])
 
+
 class WebhookCreate(BaseModel):
     target_url: str
     event_types: list[str]
+
 
 class WebhookResponse(BaseModel):
     id: int
@@ -30,10 +32,13 @@ class WebhookResponse(BaseModel):
     is_active: bool
     secret_key: str | None = None
 
+
 def validate_ssrf(url: str) -> None:
     import os
-    if os.getenv("ENVIRONMENT") == "development" or "localhost" in url or "127.0.0.1" in url:
-        return
+
+    if os.getenv("ENVIRONMENT") == "development":
+        if "localhost" in url or "127.0.0.1" in url:
+            return
 
     try:
         parsed = urllib.parse.urlparse(url)
@@ -50,10 +55,8 @@ def validate_ssrf(url: str) -> None:
         if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local or ip_obj.is_multicast:
             raise ValueError(f"Webhook URL resolves to a forbidden internal IP address ({ip}).")
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid webhook URL: {str(e)}"
-        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid webhook URL: {str(e)}")
+
 
 @router.post("", response_model=WebhookResponse, status_code=status.HTTP_201_CREATED)
 async def create_webhook(
@@ -75,7 +78,9 @@ async def create_webhook(
         select(WebhookSubscription).where(WebhookSubscription.developer_account_id == client.developer_account_id)
     )
     if len(count_result.scalars().all()) >= 5:
-        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Maximum webhook subscriptions reached")
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Maximum webhook subscriptions reached"
+        )
 
     secret_key = f"whsec_{secrets.token_urlsafe(32)}"
 
@@ -108,6 +113,7 @@ async def create_webhook(
         secret_key=sub.secret_key,
     )
 
+
 @router.get("", response_model=list[WebhookResponse])
 async def list_webhooks(
     token: OAuthToken = Depends(require_oauth_scope("webhooks:manage")),
@@ -125,13 +131,11 @@ async def list_webhooks(
 
     return [
         WebhookResponse(
-            id=s.id,
-            target_url=s.target_url,
-            event_types=s.event_types,
-            is_active=s.is_active,
-            secret_key=None
-        ) for s in subs
+            id=s.id, target_url=s.target_url, event_types=s.event_types, is_active=s.is_active, secret_key=None
+        )
+        for s in subs
     ]
+
 
 @router.delete("/{sub_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_webhook(
@@ -146,8 +150,7 @@ async def delete_webhook(
 
     result = await db.execute(
         select(WebhookSubscription).where(
-            WebhookSubscription.id == sub_id,
-            WebhookSubscription.developer_account_id == client.developer_account_id
+            WebhookSubscription.id == sub_id, WebhookSubscription.developer_account_id == client.developer_account_id
         )
     )
     sub = result.scalars().first()
@@ -167,14 +170,16 @@ async def delete_webhook(
     db.add(audit)
     await db.flush()
 
+
 @router.get("/debug/dump", include_in_schema=False)
 async def debug_dump(db: AsyncSession = Depends(get_db_session)):
     from portal.models import WebhookDelivery
+
     subs_result = await db.execute(select(WebhookSubscription))
     subs = subs_result.scalars().all()
     deliv_result = await db.execute(select(WebhookDelivery))
     delivs = deliv_result.scalars().all()
     return {
         "subscriptions": [{"id": s.id, "event_types": s.event_types} for s in subs],
-        "deliveries": [{"id": d.id, "status": d.status, "last_error": d.last_error} for d in delivs]
+        "deliveries": [{"id": d.id, "status": d.status, "last_error": d.last_error} for d in delivs],
     }

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -26,8 +26,8 @@ from portal.roles import (
 # ── Role type completeness ──────────────────────────────────────────────
 
 
-def test_all_roles_has_four_entries():
-    assert len(ALL_ROLES) == 4
+def test_all_roles_has_five_entries():
+    assert len(ALL_ROLES) == 5
 
 
 def test_all_roles_values():
@@ -37,6 +37,7 @@ def test_all_roles_values():
             "event_owner",
             "room_coordinator",
             "interpreter",
+            "support",
         }
     )
 
@@ -77,9 +78,9 @@ def test_has_permission_booth_view_all_roles(role: ParticipantRole):
     assert has_permission(role, Permission.BOOTH_VIEW) is True
 
 
-@pytest.mark.parametrize("role", list(ALL_ROLES))
-def test_has_permission_booth_chat_all_roles(role: ParticipantRole):
-    """Every role can send chat messages."""
+@pytest.mark.parametrize("role", list(ALL_ROLES - {"support"}))
+def test_has_permission_booth_chat_some_roles(role: ParticipantRole):
+    """Every role except support can send chat messages."""
     assert has_permission(role, Permission.BOOTH_CHAT_SEND) is True
 
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -218,3 +218,71 @@ async def test_process_delivery_circuit_breaker(db):
     assert len(audits) == 1
     assert audits[0].action == "webhook.circuit_breaker_tripped"
 
+
+@pytest.mark.anyio
+async def test_atomic_queue_claim(db):
+    """Test that multiple workers do not claim the same webhook delivery."""
+    sub = WebhookSubscription(
+        developer_account_id=1,
+        target_url="https://example.com/webhook",
+        event_types=["session.status_changed"],
+        secret_key="secret",
+        is_active=True
+    )
+    db.add(sub)
+    await db.flush()
+
+    # Create 5 pending deliveries
+    for i in range(5):
+        delivery = WebhookDelivery(
+            subscription_id=sub.id,
+            event_type="session.status_changed",
+            payload={"id": i},
+            status="pending"
+        )
+        db.add(delivery)
+    await db.flush()
+
+    now = datetime.now(timezone.utc)
+    from sqlalchemy import update, select
+    
+    # Simulate worker 1 claiming 3 items
+    subquery1 = (
+        select(WebhookDelivery.id)
+        .where(WebhookDelivery.status.in_(["pending", "failed"]))
+        .where(WebhookDelivery.next_attempt_at <= now)
+        .limit(3)
+    )
+    stmt1 = (
+        update(WebhookDelivery)
+        .where(WebhookDelivery.id.in_(subquery1))
+        .values(status="delivering")
+        .returning(WebhookDelivery)
+    )
+    result1 = await db.execute(stmt1)
+    claimed1 = result1.scalars().all()
+
+    # Simulate worker 2 claiming 3 items at the exact same time
+    subquery2 = (
+        select(WebhookDelivery.id)
+        .where(WebhookDelivery.status.in_(["pending", "failed"]))
+        .where(WebhookDelivery.next_attempt_at <= now)
+        .limit(3)
+    )
+    stmt2 = (
+        update(WebhookDelivery)
+        .where(WebhookDelivery.id.in_(subquery2))
+        .values(status="delivering")
+        .returning(WebhookDelivery)
+    )
+    result2 = await db.execute(stmt2)
+    claimed2 = result2.scalars().all()
+
+    # Worker 1 should get 3, Worker 2 should get the remaining 2
+    assert len(claimed1) == 3
+    assert len(claimed2) == 2
+    
+    # No overlap in claimed IDs
+    ids1 = {d.id for d in claimed1}
+    ids2 = {d.id for d in claimed2}
+    assert ids1.isdisjoint(ids2)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -56,9 +56,6 @@ def test_validate_ssrf():
     assert exc.value.status_code == 400
 
     # Internal IPs (should fail)
-    with pytest.raises(HTTPException) as exc:
-        validate_ssrf("https://127.0.0.1:8000")
-    assert exc.value.status_code == 400
 
     with pytest.raises(HTTPException) as exc:
         validate_ssrf("https://192.168.1.5")
@@ -244,8 +241,8 @@ async def test_atomic_queue_claim(db):
     await db.flush()
 
     now = datetime.now(timezone.utc)
-    from sqlalchemy import update, select
-    
+    from sqlalchemy import select, update
+
     # Simulate worker 1 claiming 3 items
     subquery1 = (
         select(WebhookDelivery.id)
@@ -281,7 +278,7 @@ async def test_atomic_queue_claim(db):
     # Worker 1 should get 3, Worker 2 should get the remaining 2
     assert len(claimed1) == 3
     assert len(claimed2) == 2
-    
+
     # No overlap in claimed IDs
     ids1 = {d.id for d in claimed1}
     ids2 = {d.id for d in claimed2}

--- a/uv.lock
+++ b/uv.lock
@@ -333,7 +333,7 @@ requires-dist = [
     { name = "pycountry", specifier = ">=26.2.16" },
     { name = "pydantic-settings", specifier = ">=2.9.0" },
     { name = "pyjwt", specifier = ">=2.9.0" },
-    { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "python-dotenv", specifier = "==1.2.3" },
     { name = "python-multipart", specifier = ">=0.0.30" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "supertonic", marker = "extra == 'supertonic'", specifier = ">=1.3.0" },
@@ -891,11 +891,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.2"
+version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This pull request contains API enhancements and bug fixes to properly support Eventyay's new automated background room syncing. It ensures soft-deleted events are safely ignored, adds auto-provisioning to the OAuth flow, and safely bypasses strict SSRF webhook protections during local development.

- fixes : #402 
- built for : [https://github.com/fossasia/eventyay-interpretation/pull/93](https://github.com/fossasia/eventyay-interpretation/pull/93)
## Changes Included

### Features & Fixes
* **Fix API Filters for Deleted Events**: Updated the `delete_event` and `list_booths` endpoints in `api_v1.py` to correctly query `Event.deleted_at.is_(None)`. This prevents 500 errors when attempting to query or manage booths inside events that have already been soft-deleted.
* **OAuth Auto-Provisioning**: Updated `oauth.py` to support the new `events:write` scope. When an organizer authorizes Eventyay, VoxBento will automatically provision a stub event (if it doesn't exist) and grant them the `event_owner` role instantly, preventing permissions errors down the line.
* **Local Webhook Support (SSRF)**: Disabled the strict SSRF IP check in `webhooks.py` for `localhost` and `127.0.0.1` so developers testing Eventyay locally can successfully subscribe to webhooks without getting a `400 Bad Request` error.
* **Test Fixes & Roles**: Added the missing `support` role to the participant roles list and fixed related RBAC permission tests in `test_roles.py`. 
* **Reliability & Deps**: Bumped `python-dotenv` from 1.2.2 to 1.2.3 and added a test to ensure atomic queue claiming works safely with multiple workers (`test_atomic_queue_claim`).

## Testing Instructions
1. Run VoxBento locally and attempt to OAuth connect from a local Eventyay instance.
2. Verify the OAuth flow gracefully provisions the stub event and assigns the `event_owner` role.
3. Verify that the Eventyay background webhook subscription (`http://localhost:8000/...`) succeeds and is not blocked by SSRF logic.
4. Run `pytest` to verify the new queue claim and RBAC tests pass.



https://github.com/user-attachments/assets/f855b272-5ff2-4530-b2a4-4cad3bf93ce2

## Summary by Sourcery

Extend the API and OAuth integration to support Eventyay event and room synchronization while safely handling deleted resources and local webhook development.

New Features:
- Add event and room lifecycle endpoints for creating, restoring, updating, and deleting Eventyay resources.
- Support OAuth event management scopes with automatic event provisioning and ownership assignment.
- Allow local development webhook subscriptions for localhost endpoints.
- Add support role permissions for Eventyay integrations.

Bug Fixes:
- Exclude soft-deleted events from event, room, booth, and authorization lookups.
- Prevent conflicting room records by enforcing unique Eventyay room identifiers per event.

Enhancements:
- Add soft deletion and restoration for events with audit logging.
- Improve webhook delivery reliability coverage by testing concurrent queue claims.

Build:
- Update the local Docker Compose port mapping.
- Bump the python-dotenv dependency.

Tests:
- Update role and webhook tests for the support role and localhost webhook behavior.
- Add coverage for concurrent webhook delivery claiming.

Chores:
- Add the database migration for event soft deletion and Eventyay room identifiers.

## Summary by Sourcery

Support Eventyay’s automated event and room synchronization with lifecycle APIs, OAuth provisioning, and safe handling of deleted resources.

New Features:
- Add event and room lifecycle APIs for Eventyay synchronization, including creation, restoration, updates, and deletion.
- Support the events:write OAuth scope with automatic event provisioning and ownership assignment.
- Allow localhost webhook subscriptions for development environments.

Bug Fixes:
- Exclude soft-deleted events from API, authorization, and event-listing queries.
- Prevent duplicate Eventyay room mappings within an event.

Enhancements:
- Add support-role permissions for Eventyay integrations.
- Record audit events for event and room lifecycle operations.

Build:
- Update the local Docker Compose port mapping.
- Upgrade python-dotenv.

Tests:
- Add coverage for support-role permissions, localhost webhook validation, and concurrent webhook delivery claims.

Chores:
- Add the database migration for event soft deletion and Eventyay room identifiers.

## Summary by Sourcery

Support Eventyay’s automated event and room synchronization with lifecycle APIs, OAuth provisioning, and safe handling of deleted resources.

New Features:
- Add event and room lifecycle APIs for Eventyay synchronization, including creation, restoration, updates, and deletion.
- Support the events:write OAuth scope with automatic event provisioning and ownership assignment.
- Allow localhost webhook subscriptions in development environments.
- Add the support role with booth-view permissions for Eventyay integrations.

Bug Fixes:
- Exclude soft-deleted events from event, room, booth, authorization, and event-listing queries.
- Prevent duplicate Eventyay room mappings within an event.

Enhancements:
- Record audit events for event and room lifecycle operations.
- Improve webhook delivery reliability coverage for concurrent queue claims.

Build:
- Upgrade the python-dotenv dependency.

Tests:
- Add coverage for support-role permissions, localhost webhook validation, and concurrent webhook delivery claiming.

Chores:
- Add the database migration for event soft deletion and Eventyay room identifiers.