### PR TITLE
feat(admin): add sorting to registered users list

### DIFF
--- a/portal/database.py
+++ b/portal/database.py
@@ -105,12 +105,11 @@ async def get_session() -> AsyncGenerator[AsyncSession]:
         async with session.begin():
             yield session
 
+
 async def get_db_session() -> AsyncGenerator[AsyncSession]:
     """FastAPI dependency for database sessions."""
     async with get_session() as session:
         yield session
-
-
 
 
 async def init_db() -> None:
@@ -494,10 +493,22 @@ async def list_users(
     limit: int = 100,
     offset: int = 0,
     search: str | None = None,
+    sort_by: str = "created_at",
+    sort_order: str = "asc",
 ) -> list[User]:
-    stmt = select(User).order_by(User.created_at).limit(limit).offset(offset)
+    stmt = select(User)
+
     if search:
         stmt = stmt.where(or_(User.email.ilike(f"%{search}%"), User.display_name.ilike(f"%{search}%")))
+
+    sort_column = getattr(User, sort_by, User.created_at)
+    if sort_order == "desc":
+        sort_column = sort_column.desc()
+    else:
+        sort_column = sort_column.asc()
+
+    stmt = stmt.order_by(sort_column).limit(limit).offset(offset)
+
     result = await session.execute(stmt)
     return list(result.scalars().all())
 

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -1427,12 +1427,21 @@ async def admin_transcription_settings(
 
 
 @router.get("/admin/users/", dependencies=[Depends(require_super_admin)])
-async def admin_user_list(request: Request, page: int = 1, search: str | None = None):
-    limit = 20
+async def admin_users(
+    request: Request,
+    page: int = 1,
+    limit: int = 50,
+    search: str | None = None,
+    sort_by: str = "created_at",
+    sort_order: str = "asc",
+):
+    """List all registered users (super admin only)."""
     offset = (page - 1) * limit
     async with get_session() as session:
         total_users = await count_users(session, search=search)
-        users = await list_users(session, limit=limit, offset=offset, search=search)
+        users = await list_users(
+            session, limit=limit, offset=offset, search=search, sort_by=sort_by, sort_order=sort_order
+        )
     total_pages = max(1, math.ceil(total_users / limit))
     return templates.TemplateResponse(
         request=request,
@@ -1441,10 +1450,12 @@ async def admin_user_list(request: Request, page: int = 1, search: str | None = 
             "users": users,
             "page": page,
             "total_pages": total_pages,
+            "search": search,
+            "sort_by": sort_by,
+            "sort_order": sort_order,
             "is_super_admin": True,
             "is_event_owner": True,
             "is_room_coordinator": True,
-            "search": search,
         },
     )
 
@@ -1729,6 +1740,7 @@ async def admin_developer_accounts(
     accounts = result.scalars().all()
 
     from portal.auth import get_admin_flags
+
     admin_flags = await get_admin_flags(request)
 
     return templates.TemplateResponse(

--- a/templates/admin/pagination.html
+++ b/templates/admin/pagination.html
@@ -1,8 +1,16 @@
 {% if total_pages > 1 %}
 {% set search_qs = '&search=' ~ search if search else '' %}
+{% set sort_qs = '' %}
+{% if sort_by %}
+  {% set sort_qs = sort_qs ~ '&sort_by=' ~ sort_by %}
+{% endif %}
+{% if sort_order %}
+  {% set sort_qs = sort_qs ~ '&sort_order=' ~ sort_order %}
+{% endif %}
+{% set qs = search_qs ~ sort_qs %}
 <div class="pagination">
   {% if page > 1 %}
-    <a href="?page={{ page - 1 }}{{ search_qs }}" class="btn btn-sm">Previous</a>
+    <a href="?page={{ page - 1 }}{{ qs }}" class="btn btn-sm">Previous</a>
   {% else %}
     <span class="btn btn-sm btn-disabled">Previous</span>
   {% endif %}
@@ -10,7 +18,7 @@
   <span>Page {{ page }} of {{ total_pages }}</span>
 
   {% if page < total_pages %}
-    <a href="?page={{ page + 1 }}{{ search_qs }}" class="btn btn-sm">Next</a>
+    <a href="?page={{ page + 1 }}{{ qs }}" class="btn btn-sm">Next</a>
   {% else %}
     <span class="btn btn-sm btn-disabled">Next</span>
   {% endif %}

--- a/templates/admin/user_list.html
+++ b/templates/admin/user_list.html
@@ -14,8 +14,24 @@
   <span class="badge">{{ users|length }} displayed</span>
 </div>
 
+{% macro sortable_header(column, label) %}
+  {% set new_sort_order = 'desc' if sort_by == column and sort_order == 'asc' else 'asc' %}
+  <th>
+    <a href="?sort_by={{ column }}&sort_order={{ new_sort_order }}{% if search %}&search={{ search }}{% endif %}" style="text-decoration: none; color: inherit; display: flex; align-items: center; gap: 4px;">
+      {{ label }}
+      {% if sort_by == column %}
+        <span style="font-size: 0.8em;">{% if sort_order == 'asc' %}▲{% else %}▼{% endif %}</span>
+      {% else %}
+        <span style="font-size: 0.8em; color: transparent;">▲</span>
+      {% endif %}
+    </a>
+  </th>
+{% endmacro %}
+
 <div class="search-bar" style="margin-bottom: 24px;">
   <form method="get" action="/admin/users/" style="display: flex; gap: 10px; max-width: 500px;">
+    {% if sort_by %}<input type="hidden" name="sort_by" value="{{ sort_by }}">{% endif %}
+    {% if sort_order %}<input type="hidden" name="sort_order" value="{{ sort_order }}">{% endif %}
     <input type="text" name="search" value="{{ search or '' }}" placeholder="Search by email or name..." style="min-height: 42px; padding: 10px 12px; font-size: 0.95rem; border: 1px solid var(--color-border-strong); border-radius: 10px; background: var(--color-surface); width: 100%; box-sizing: border-box; font-family: inherit; color: var(--color-text); outline: none;">
     <button type="submit" class="btn btn-primary">Search</button>
     {% if search %}
@@ -28,13 +44,13 @@
 <table class="data-table">
   <thead>
     <tr>
-      <th>ID</th>
-      <th>Email</th>
-      <th>Display Name</th>
-      <th>Admin</th>
-      <th>2FA Status</th>
-      <th>Status</th>
-      <th>Joined</th>
+      {{ sortable_header('id', 'ID') }}
+      {{ sortable_header('email', 'Email') }}
+      {{ sortable_header('display_name', 'Display Name') }}
+      {{ sortable_header('is_admin', 'Admin') }}
+      {{ sortable_header('email_verified', '2FA Status') }}
+      {{ sortable_header('is_active', 'Status') }}
+      {{ sortable_header('created_at', 'Joined') }}
       <th>Actions</th>
     </tr>
   </thead>


### PR DESCRIPTION
Adds backend and frontend sorting to the registered users table based on user request. Includes sorting by ID, Email, Display Name, Admin, 2FA Status, Status, and Joined.

## Summary by Sourcery

Enable searching, pagination, and configurable sorting for the super-admin registered users list.

New Features:
- Add sortable columns to the registered users admin table for ID, email, display name, admin status, 2FA status, account status, and joined date.
- Preserve search and sorting parameters across user-list pagination and searches.

Enhancements:
- Extend user-list pagination and database queries to support configurable page sizes and ascending or descending sort order.