### PR TITLE
feat(ui): add navigation links to developer dashboard and account settings

### DIFF
--- a/templates/account.html
+++ b/templates/account.html
@@ -11,6 +11,7 @@
   <a class="brand" href="/"><img src="{{ url_for('static', path='img/wordmark.png') }}" alt="Voxbento" class="brand-logo-sm" /></a>
   <nav class="header-nav">
     <a href="/account">My Account</a>
+    <a href="/developer">Developer API</a>
     <a href="/admin/">Admin Panel</a>
     <a href="/logout">Logout</a>
   </nav>

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -25,6 +25,8 @@
         <a href="/admin/users/" class="{{ 'is-active' if _path.startswith('/admin/users') else '' }}">Users</a>
         <a href="/admin/developer-accounts" class="{{ 'is-active' if _path.startswith('/admin/developer-accounts') else '' }}">Dev Accounts</a>
         {% endif %}
+        <a href="/developer">Developer API</a>
+        <a href="/account">Account</a>
         <a href="/" target="_blank">Portal Home</a>
         <a href="/admin/setup" class="btn btn-sm btn-primary">+ New event</a>
         <a href="/admin/logout" class="nav-logout">Logout</a>

--- a/templates/developer/dashboard.html
+++ b/templates/developer/dashboard.html
@@ -147,6 +147,8 @@
         <span class="header-badge">Developers</span>
       </div>
       <nav class="header-nav">
+        <a href="/account">My Account</a>
+        <a href="/admin/">Admin Panel</a>
         <a href="/">Portal Home</a>
       </nav>
     </header>

--- a/templates/home.html
+++ b/templates/home.html
@@ -57,8 +57,10 @@
             </nav>
             <div class="flex items-center gap-3 md:gap-4 text-[10px] sm:text-xs md:text-sm font-bold flex-shrink-0">
                 {% if current_user %}
+                <a href="/developer" class="brutal-btn brutal-btn-outline brutal-btn-nav max-md:hidden !px-2.5 !py-1.5 md:!px-5 md:!py-2">Developer</a>
+                <a href="/account" class="brutal-btn brutal-btn-outline brutal-btn-nav !px-2.5 !py-1.5 md:!px-5 md:!py-2">Account</a>
+                <a href="/admin/events/" class="brutal-btn brutal-btn-primary brutal-btn-nav !px-2.5 !py-1.5 md:!px-5 md:!py-2">Dashboard</a>
                 <a href="/logout" class="brutal-btn brutal-btn-outline brutal-btn-nav !px-2.5 !py-1.5 md:!px-5 md:!py-2">Logout</a>
-                <a href="/admin/events/" class="brutal-btn brutal-btn-outline brutal-btn-nav !px-2.5 !py-1.5 md:!px-5 md:!py-2">Dashboard</a>
                 {% else %}
                 <a href="/login" class="brutal-btn brutal-btn-primary brutal-btn-nav !px-2.5 !py-1.5 md:!px-5 md:!py-2">Sign In</a>
                 <a href="/register" class="brutal-btn brutal-btn-outline brutal-btn-nav !px-2.5 !py-1.5 md:!px-5 md:!py-2">Register</a>


### PR DESCRIPTION
Added navigation links to the Developer Dashboard (`/developer`) and Account Settings (`/account`) across the landing page, portal home, and developer portal to ensure users can access developer mode.

## Summary by Sourcery

Expand authenticated portal navigation so users can move easily between account settings, administration, and developer tools.

New Features:
- Add navigation links to the Developer API, Account, and Dashboard areas across the home, account, admin, and developer portal pages.

Enhancements:
- Improve cross-navigation between the main portal, account settings, administration, and developer portal.