### PR TITLE
fix(floor-bot): revert startWithAudioMuted to allow shared video audio

### DIFF
--- a/floor-bot/bot.py
+++ b/floor-bot/bot.py
@@ -137,7 +137,7 @@ async def run_capture():
 
         join_url = (
             f"{jitsi_url}"
-            f"#config.startWithAudioMuted=true"
+            f"#config.startWithAudioMuted=false"
             f"&config.startWithVideoMuted=true"
             f"&config.prejoinPageEnabled=false"
             f"&config.disableDeepLinking=true"


### PR DESCRIPTION
Reverts #config.startWithAudioMuted to false so Jitsi doesn't immediately mute the bot, allowing it to hear the shared video stream.

## Summary by Sourcery

Bug Fixes:
- Keep the floor bot’s audio unmuted when joining Jitsi so it can hear shared video audio.