### PR TITLE
chore: remove debug console logs from listener-event.js

### DIFF
--- a/static/js/listener-event.js
+++ b/static/js/listener-event.js
@@ -155,7 +155,6 @@ function startTtsWs(roomId, langCode, boothId, audioDelayMs) {
     langCode +
     "/" +
     boothId;
-  console.log("Connecting TTS WS to:", wsUrl);
   ttsWs = new WebSocket(wsUrl);
   ttsWs.binaryType = "arraybuffer";
 
@@ -221,7 +220,7 @@ function startTtsWs(roomId, langCode, boothId, audioDelayMs) {
   };
 
   ttsWs.onclose = function () {
-    console.log("TTS WS closed");
+    // closed
   };
 }
 


### PR DESCRIPTION
Removed some remaining debug console.log statements from static/js/listener-event.js to clean up dead code.

## Summary by Sourcery

Enhancements:
- Remove obsolete WebSocket debug logging from the TTS listener.