### PR TITLE
fix(translations): increase local translation timeout to 60s

### DIFF
--- a/portal/translations/worker.py
+++ b/portal/translations/worker.py
@@ -189,6 +189,7 @@ class TranslationWorker:
                     # NLLB can take 30+ seconds or deadlock, which permanently fills the queue.
                     timeout_val = 12.0
                     if provider == "local":
+                        timeout_val = 60.0
                         try:
                             from portal.translations.providers.local import get_download_progress
 


### PR DESCRIPTION
Increases the timeout for local translation models from 12 seconds to 60 seconds. On machines with few CPUs or high load (e.g. load average > 10 on a 2 CPU machine), local inference with NLLB takes longer than 12 seconds, causing valid translations to be repeatedly dropped with a 'Translation failed' message.

## Summary by Sourcery

Bug Fixes:
- Increase the local translation timeout to 60 seconds so valid translations are not dropped during slow or high-load inference.