### PR TITLE
fix(translations): align client timeout with 60s inference limit

### DIFF
--- a/portal/translations/worker.py
+++ b/portal/translations/worker.py
@@ -185,8 +185,8 @@ class TranslationWorker:
             queue_decremented = False
             async with sem:
                 try:
-                    # Enforce a strict 12-second timeout on LLM inference. If the local CPU is pegged,
-                    # NLLB can take 30+ seconds or deadlock, which permanently fills the queue.
+                    # Enforce a strict timeout on LLM inference (12s for cloud, 60s for local).
+                    # If the local CPU is pegged, NLLB can take 30+ seconds.
                     timeout_val = 12.0
                     if provider == "local":
                         timeout_val = 60.0
@@ -212,7 +212,7 @@ class TranslationWorker:
                         )
                         return
 
-                    logger.error(f"[{booth_id_str}] Translation LLM timed out after 12s for {lang_code}.")
+                    logger.error(f"[{booth_id_str}] Translation LLM timed out after {timeout_val}s for {lang_code}.")
                     translated_text = None
 
                 if not translated_text:

--- a/static/js/listener-event.js
+++ b/static/js/listener-event.js
@@ -394,7 +394,7 @@ function pumpSegmentQueue() {
 
   var nextSeg = segmentStore[expectedSeq];
   if (!nextSeg) {
-    // It hasn't arrived yet. Set the 10s last-resort timeout if not already set.
+    // It hasn't arrived yet. Set the 65s last-resort timeout if not already set (to accommodate slow local translation).
     if (!seqWaitTimer) {
       seqWaitTimer = setTimeout(function () {
         console.warn(
@@ -405,7 +405,7 @@ function pumpSegmentQueue() {
         expectedSeq++;
         seqWaitTimer = null;
         pumpSegmentQueue();
-      }, 10000);
+      }, 65000);
     }
     return;
   }


### PR DESCRIPTION
Addresses PR feedback:
1. Fixes the hardcoded 12s log message and comment in `worker.py` to accurately reflect the 60s local timeout.
2. Increases the client-side missing sequence timeout in `listener-event.js` from 10s to 65s so the UI doesn't skip slow local translations before they arrive.

## Summary by Sourcery

Bug Fixes:
- Align translation timeout messaging and client sequence handling with the 60-second local inference limit to prevent slow local translations from being skipped.