### PR TITLE
fix(client): eliminate UI lag when translations fail

### DIFF
--- a/portal/translations/constants.py
+++ b/portal/translations/constants.py
@@ -23,7 +23,7 @@ TRANSLATION_MODELS: Dict[str, List[str]] = {
     ],
     TranslationProviderEnum.GEMINI.value: ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-1.5-flash"],
     TranslationProviderEnum.ANTHROPIC.value: ["claude-3-5-sonnet-20241022", "claude-3-5-haiku-20241022"],
-    TranslationProviderEnum.GROQ.value: ["llama-3.3-70b-versatile", "mixtral-8x7b-32768", "gemma2-9b-it"],
+    TranslationProviderEnum.GROQ.value: ["llama-3.3-70b-versatile", "mixtral-8x7b-32768", "llama-3.1-8b-instant"],
     TranslationProviderEnum.LOCAL.value: ["nllb-200-distilled-600M"],
 }
 

--- a/static/js/listener-event.js
+++ b/static/js/listener-event.js
@@ -523,6 +523,7 @@ function finishSegmentWithDelay(seg, seqId) {
   var text = seg.translation || seg.caption || "";
   var wordCount = text.trim().split(/\s+/).filter(Boolean).length;
   var readingDelayMs = Math.max(2500, wordCount * 350);
+  if (seg.error && !seg.translation) { readingDelayMs = 2500; }
   fallbackQueueTimer = setTimeout(function () {
     isSegmentPlaying = false;
     delete segmentStore[seqId];


### PR DESCRIPTION
When a translation instantly fails (e.g. 400 Bad Request from Groq), the UI would still simulate a reading delay based on the length of the English original (which can be 20+ seconds). Because the UI processes sequences in order, this caused the German captions to freeze on the screen for 20 seconds at a time while the English captions kept scrolling by, making it appear as though the translation was severely lagging.

This PR sets the reading delay to a fixed 2.5s if the segment contains a translation error, allowing the queue to instantly catch up.

## Summary by Sourcery

Reduce caption lag after translation failures and update the Groq model fallback.

Bug Fixes:
- Prevent translation-error segments from imposing long, text-length-based UI delays, allowing failed translation queues to catch up promptly.
- Replace the unavailable Groq Gemma model with the supported Llama 3.1 8B Instant model.