### PR TITLE
feat: automated onboarding email after 2FA verification

### DIFF
--- a/portal/email_sender.py
+++ b/portal/email_sender.py
@@ -1,6 +1,9 @@
+import asyncio
 import logging
+from pathlib import Path
 from typing import Any, Dict
 
+from fastapi.templating import Jinja2Templates
 from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
 
 from portal.config import settings
@@ -51,3 +54,41 @@ async def send_demo_request_email(form_data: Dict[str, Any]) -> None:
         logger.info(f"Demo request email sent for {form_data.get('email')}")
     except Exception as e:
         logger.error(f"Failed to send demo request email: {e}")
+
+
+_BASE_DIR = Path(__file__).resolve().parent
+templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
+
+
+async def send_delayed_onboarding_email(email_address: str, display_name: str) -> None:
+    # 15 minute delay
+    await asyncio.sleep(900)
+
+    if not settings.smtp_host:
+        logger.warning("SMTP host is not configured. Onboarding email not sent.")
+        return
+
+    subject = "Welcome to VoxBento! How can we help?"
+
+    # Render HTML template
+    # Since we need to render it without a request object, we can use Template.render directly
+    template = templates.get_template("email/onboarding.html")
+    html_body = template.render({"display_name": display_name, "email_address": email_address})
+
+    message = MessageSchema(
+        subject=subject,
+        recipients=[email_address],
+        body=html_body,
+        subtype=MessageType.html,
+        headers={"Reply-To": "voxbento.dev@gmail.com"},
+    )
+
+    # Send from Arnav Angarkar, Team Voxbento
+    conf.MAIL_FROM_NAME = "Arnav Angarkar, Team Voxbento"
+
+    fm = FastMail(conf)
+    try:
+        await fm.send_message(message)
+        logger.info(f"Onboarding email sent to {email_address}")
+    except Exception as e:
+        logger.error(f"Failed to send onboarding email to {email_address}: {e}")

--- a/portal/routers/auth.py
+++ b/portal/routers/auth.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import APIRouter, Body, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Body, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 
@@ -32,6 +32,7 @@ from portal.database import (
     update_user,
 )
 from portal.email import send_magic_login_email, send_password_reset_email, send_verification_email
+from portal.email_sender import send_delayed_onboarding_email
 from portal.rate_limit import check_rate_limit
 from portal.schemas.auth import TokenRequest, TokenResponse
 from portal.utils import safe_redirect
@@ -162,11 +163,12 @@ async def register_submit(request: Request):
 
 
 @router.get("/auth/verify/{token}")
-async def verify_email_route(request: Request, token: str):
+async def verify_email_route(request: Request, token: str, background_tasks: BackgroundTasks):
     async with get_session() as session:
         try:
             auth_token = await redeem_auth_token(session, token, "verification")
             user = await update_user(session, auth_token.user_id, email_verified=True)
+            background_tasks.add_task(send_delayed_onboarding_email, user.email, user.display_name)
 
             jwt_token = create_user_token(
                 user_id=user.id, email=user.email, display_name=user.display_name, is_admin=user.is_admin
@@ -278,7 +280,7 @@ async def request_magic_link(request: Request):
 
 
 @router.get("/auth/magic/{token}")
-async def redeem_magic_link(request: Request, token: str, next: str | None = None):
+async def redeem_magic_link(request: Request, token: str, background_tasks: BackgroundTasks, next: str | None = None):
     async with get_session() as session:
         try:
             auth_token = await redeem_auth_token(session, token, "magic_link")
@@ -289,6 +291,7 @@ async def redeem_magic_link(request: Request, token: str, next: str | None = Non
             # If they log in via magic link, we can implicitly consider their email verified
             if not user.email_verified:
                 await update_user(session, user.id, email_verified=True)
+                background_tasks.add_task(send_delayed_onboarding_email, user.email, user.display_name)
 
             jwt_token = create_user_token(
                 user_id=user.id, email=user.email, display_name=user.display_name, is_admin=user.is_admin

--- a/portal/templates/email/onboarding.html
+++ b/portal/templates/email/onboarding.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Welcome to VoxBento</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { margin-bottom: 20px; }
+        .content { font-size: 16px; }
+        .footer { margin-top: 30px; font-size: 14px; color: #777; border-top: 1px solid #eaeaea; padding-top: 20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="content">
+            <p>Hi {{ display_name }},</p>
+            <p>I just saw you recently signed up on voxbento.com, and I wanted to personally welcome you!</p>
+            <p>What are your requirements for the platform? Do you have any upcoming conference events, webinars, or internal meetings where you need real-time interpretation and captions?</p>
+            <p>If you need any help setting up your first event or integrating your setup, just reply directly to this email and let me know.</p>
+            <p>Best regards,<br>
+            Arnav Angarkar<br>
+            Team VoxBento</p>
+        </div>
+        <div class="footer">
+            <p>&copy; 2026 VoxBento. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Sends a delayed HTML onboarding email 15 minutes after a user successfully verifies their email/completes 2FA.

## Summary by Sourcery

Add delayed onboarding outreach after successful user verification.

New Features:
- Send a personalized HTML onboarding email 15 minutes after a user’s email is verified through either the verification-token or magic-link flow.

Enhancements:
- Use a dedicated onboarding email template with configurable SMTP handling and reply-to metadata.