### PR TITLE
chore(deps): update dependabot to use uv package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 
 updates:
   # Python dependencies (uv / pyproject.toml)
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Updates dependabot to properly support the `uv.lock` file by switching the package-ecosystem from `pip` to `uv`. This ensures Dependabot can provide daily patch updates correctly for our transitive dependencies.

## Summary by Sourcery

Enhancements:
- Configure Dependabot to use the uv package ecosystem for Python dependency updates.