### PR TITLE
fix(listener): don't count join-page views as failed code attempts

### DIFF
--- a/portal/routers/listener.py
+++ b/portal/routers/listener.py
@@ -83,7 +83,7 @@ async def listen_event_page(request: Request, event_slug: str, code: str | None 
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
 
         if not has_listener_access(request, event_slug, ev.listener_join_code, code):
-            if _register_failed_attempt(_client_ip(request)):
+            if code and _register_failed_attempt(_client_ip(request)):
                 raise HTTPException(
                     status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                     detail="Too many join attempts. Please try again later.",
@@ -181,7 +181,7 @@ async def listener_room_audio_delay(
         if not ev:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
         if not has_listener_access(request, event_slug, ev.listener_join_code, code):
-            if _register_failed_attempt(_client_ip(request)):
+            if code and _register_failed_attempt(_client_ip(request)):
                 raise HTTPException(
                     status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                     detail="Too many join attempts. Please try again later.",

--- a/portal/routers/listener.py
+++ b/portal/routers/listener.py
@@ -61,13 +61,17 @@ def _client_ip(request: Request) -> str:
     return request.client.host if request.client else "unknown"
 
 
+def _submitted_code(request: Request, event_slug: str, code: str | None) -> str | None:
+    """The join code this request submits, from the query parameter or the stored cookie."""
+    return code or request.cookies.get(f"listener_code_{event_slug}")
+
+
 def has_listener_access(request: Request, event_slug: str, listener_join_code: str | None, code: str | None) -> bool:
     payload = get_booth_session(request)
     if payload and payload.get("user"):
         return True
 
-    cookie_code = request.cookies.get(f"listener_code_{event_slug}")
-    active_code = code or cookie_code
+    active_code = _submitted_code(request, event_slug, code)
     if bool(listener_join_code and active_code == listener_join_code):
         _reset_attempts(_client_ip(request))
         return True
@@ -83,7 +87,7 @@ async def listen_event_page(request: Request, event_slug: str, code: str | None 
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
 
         if not has_listener_access(request, event_slug, ev.listener_join_code, code):
-            if code and _register_failed_attempt(_client_ip(request)):
+            if _submitted_code(request, event_slug, code) and _register_failed_attempt(_client_ip(request)):
                 raise HTTPException(
                     status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                     detail="Too many join attempts. Please try again later.",
@@ -181,7 +185,7 @@ async def listener_room_audio_delay(
         if not ev:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
         if not has_listener_access(request, event_slug, ev.listener_join_code, code):
-            if code and _register_failed_attempt(_client_ip(request)):
+            if _submitted_code(request, event_slug, code) and _register_failed_attempt(_client_ip(request)):
                 raise HTTPException(
                     status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                     detail="Too many join attempts. Please try again later.",

--- a/tests/test_listener_rate_limit.py
+++ b/tests/test_listener_rate_limit.py
@@ -158,3 +158,16 @@ class TestListenerRateLimit:
             for _ in range(15):
                 resp = await c.get(f"/listener/{event.slug}/rooms/{room.id}/audio-delay")
                 assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_cookie_supplied_wrong_codes_are_throttled(self, seed_event):
+        """A guess sent through the listener_code_ cookie is a submission too."""
+        event, _ = seed_event
+        async with _client() as c:
+            c.cookies.set(f"listener_code_{event.slug}", "WRONGCODE")
+            for _ in range(10):
+                resp = await c.get(f"/listener/{event.slug}")
+                assert resp.status_code == 200
+
+            resp = await c.get(f"/listener/{event.slug}")
+            assert resp.status_code == 429

--- a/tests/test_listener_rate_limit.py
+++ b/tests/test_listener_rate_limit.py
@@ -3,7 +3,9 @@
 Covers:
 - Repeated bad join codes from one client get throttled with 429
 - A valid join code succeeds and is not throttled
-- A client holding a valid session cookie is never throttled
+- A client holding a valid session cookie reaches the listener page and is never throttled
+- Viewing the join page, and polling for the room audio delay, are not join-code attempts
+- A wrong code submitted through the listener_code_ cookie is still throttled
 """
 
 from __future__ import annotations
@@ -119,6 +121,10 @@ class TestListenerRateLimit:
                 resp = await c.get(f"/listener/{event.slug}")
                 assert resp.status_code == 200
                 assert b"Invalid join code." not in resp.content
+                # A cookie-less visitor also gets 200 now, so assert the cookie
+                # actually grants access instead of just dodging the throttle.
+                assert b"Enter the join code" not in resp.content
+                assert b"-- Select Source Audio --" in resp.content
 
     @pytest.mark.anyio
     async def test_different_clients_are_throttled_independently(self, seed_event):
@@ -171,3 +177,14 @@ class TestListenerRateLimit:
 
             resp = await c.get(f"/listener/{event.slug}")
             assert resp.status_code == 429
+
+    @pytest.mark.anyio
+    async def test_cookie_holder_can_poll_audio_delay(self, seed_event):
+        """listener-event.js polls this every 3s for the whole session, with no ?code=."""
+        event, room = seed_event
+        async with _client() as c:
+            await c.get(f"/listener/{event.slug}?code=ROOM42")
+            for _ in range(15):
+                resp = await c.get(f"/listener/{event.slug}/rooms/{room.id}/audio-delay")
+                assert resp.status_code == 200
+                assert resp.json() == {"audio_delay_ms": 0}

--- a/tests/test_listener_rate_limit.py
+++ b/tests/test_listener_rate_limit.py
@@ -140,3 +140,21 @@ class TestListenerRateLimit:
 
             resp = await c.get(f"/listener/{event.slug}/rooms/{room.id}/audio-delay?code=WRONGCODE")
             assert resp.status_code == 429
+
+    @pytest.mark.anyio
+    async def test_viewing_the_join_page_is_not_a_failed_attempt(self, seed_event):
+        """Attendees sharing one venue IP open the bare link before typing a code."""
+        event, _ = seed_event
+        async with _client() as c:
+            for attendee in range(1, 16):
+                resp = await c.get(f"/listener/{event.slug}")
+                assert resp.status_code == 200, f"attendee {attendee} was locked out"
+                assert b"Invalid join code." not in resp.content
+
+    @pytest.mark.anyio
+    async def test_audio_delay_poll_without_code_is_not_a_failed_attempt(self, seed_event):
+        event, room = seed_event
+        async with _client() as c:
+            for _ in range(15):
+                resp = await c.get(f"/listener/{event.slug}/rooms/{room.id}/audio-delay")
+                assert resp.status_code == 403


### PR DESCRIPTION
## Description

Opening the listener join page counted as a failed join-code attempt, so attendees
sharing one public IP locked each other out of the form before anyone typed a code. On
venue wifi, the 11th person to scan the QR code within a minute got `429 Too Many
Attempts` instead of the join form.

## Related Issue

Closes #454

## Changes Made
- Both listener gates now count an attempt only when a code was actually submitted.
  A request that submits none, which is what rendering the join form and polling the
  room audio delay look like, is not an attempt.
- `_submitted_code()` holds the single rule for which code a request submits, the
  `?code=` parameter or the `listener_code_{slug}` cookie. `has_listener_access` already
  accepted either, so both it and the limiter now read the same helper and cannot
  disagree about what counts as a submission.
- Tests: bare page views and uncoded `audio-delay` polls stay 200 and 403, and a wrong
  code sent through the cookie is still throttled. `test_cookie_holder_is_never_throttled`
  proved the cookie granted access only because a bare view used to hit the throttle, so
  it now asserts the listener page renders; added the successful `audio-delay` poll that
  `listener-event.js` makes every 3 seconds on the cookie alone.

Brute-force protection is unchanged. A wrong code is still counted and still throttled
whether it arrives in the query parameter or in the cookie.

<img width="1105" height="409" alt="image" src="https://github.com/user-attachments/assets/a409341c-e5d4-45ba-9328-87f679bbdb1f" />


## Testing

Running stack, event with a join code, one client IP:

```
25 bare page views (no code, no cookie)  -> 200 x25          (was 429 from the 11th)
20 wrong codes via the cookie only       -> 200 x10, then 429
12 wrong codes via ?code=                -> 200 x10, then 429
correct code, by query and by cookie     -> 200, 200
15 uncoded audio-delay polls             -> 403 x15          (was 429 from the 11th)
```

Mutation-checked rather than assumed: ignoring the cookie fails 3 tests, never setting it
on a successful join fails 2, and disabling the limiter fails 4. The first two were silent
before this PR. Also walked through in Chromium: the 15th attendee on the shared IP gets
the form, enters the real code and reaches the listener page.

```
uv run pytest tests/ -q     556 passed
uv run ruff check .         All checks passed!
```

- [x] Tested locally
- [x] Existing tests pass
- [x] Added/updated tests (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] My changes do not introduce new warnings or errors

## Additional Notes

Out of scope on purpose: the counter is keyed on the client IP alone, so a throttled
client is throttled across every event on the deployment. Happy to file that separately.

## Summary by Sourcery

Count only submitted join codes toward listener rate limits while preserving protection against incorrect-code attempts.

Bug Fixes:
- Stop counting listener join-page views and uncoded audio-delay polls as failed join-code attempts, preventing shared-IP attendees from being throttled before submitting a code.

Enhancements:
- Use a shared submission rule for query-parameter and cookie-based join codes so access checks and rate limiting remain consistent.
- Preserve brute-force protection for incorrect codes submitted through either the query parameter or listener cookie.

Tests:
- Add coverage for uncoded page views and audio-delay polls, cookie-based incorrect codes, and successful cookie-based audio-delay polling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Listener rate limiting now consistently applies to submitted join codes from supported request sources.
  * Requests without a submitted join code remain unthrottled.
  * Repeated invalid join-code submissions can now receive an HTTP 429 response.
  * Authorized cookie holders can access the source-audio selector and repeatedly check audio delay without being throttled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->