### PR TITLE
Removed a Redundant Line in Aggregator

### DIFF
--- a/portal/transcription/aggregator.py
+++ b/portal/transcription/aggregator.py
@@ -63,8 +63,6 @@ class CaptionAggregator:
         else:
             state.current_utterance = text.strip()
 
-        state.current_word_count = len(state.current_utterance.split())
-
         import re
 
         has_finalized = False


### PR DESCRIPTION
## Description

This PR removes a single line of redundant code. The line is completely unnecessary and is simply a repetition of the same line of code so it ends up serving no purpose

## Changes Made

- removes line 66 in portal/transcription/aggregator.py which happens later in line 92

## Testing

Ran all the tests as described in CONTRIBUTING.md. The linter and test suite pass successfully

- [x] Tested locally
- [x] Existing tests pass
- [ ] Added/updated tests (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] My changes do not introduce new warnings or errors

## Summary by Sourcery

Enhancements:
- Remove the redundant current word count assignment from transcription aggregation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription word-count accuracy by calculating counts after sentence-boundary processing.
  * Ensured word counts reset to zero when no remainder utterance remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->